### PR TITLE
Phase 13: tokenomics endpoints + Prometheus gauges + demo fix

### DIFF
--- a/crates/tirami-ledger/src/metrics.rs
+++ b/crates/tirami-ledger/src/metrics.rs
@@ -33,6 +33,14 @@ pub struct TiramiMetrics {
     pub collusion_spike: GaugeVec,
     pub collusion_robin: GaugeVec,
     pub collusion_penalty: GaugeVec,
+    // Phase 13 tokenomics metrics
+    pub total_minted: IntGauge,
+    pub supply_factor: Gauge,
+    pub current_epoch: IntGauge,
+    pub yield_rate: Gauge,
+    pub total_staked: IntGauge,
+    pub total_burned: IntGauge,
+    pub referral_bonus_minted: IntGauge,
 }
 
 impl TiramiMetrics {
@@ -124,6 +132,49 @@ impl TiramiMetrics {
         )
         .expect("valid gauge vec opts");
 
+        // Phase 13 tokenomics gauges
+        let total_minted = IntGauge::with_opts(Opts::new(
+            "tirami_total_minted",
+            "Total TRM minted so far (counts toward 21B cap)",
+        ))
+        .expect("valid gauge opts");
+
+        let supply_factor = Gauge::with_opts(Opts::new(
+            "tirami_supply_factor",
+            "Supply factor: fraction of TRM cap remaining (1.0 at genesis, 0.0 at cap)",
+        ))
+        .expect("valid gauge opts");
+
+        let current_epoch = IntGauge::with_opts(Opts::new(
+            "tirami_current_epoch",
+            "Current halving epoch (0 = genesis, increases as supply is consumed)",
+        ))
+        .expect("valid gauge opts");
+
+        let yield_rate = Gauge::with_opts(Opts::new(
+            "tirami_yield_rate",
+            "Current availability yield rate per hour (halves each epoch)",
+        ))
+        .expect("valid gauge opts");
+
+        let total_staked = IntGauge::with_opts(Opts::new(
+            "tirami_total_staked",
+            "Total TRM currently locked in staking contracts",
+        ))
+        .expect("valid gauge opts");
+
+        let total_burned = IntGauge::with_opts(Opts::new(
+            "tirami_total_burned",
+            "Total TRM burned via slashing (permanently removed from circulation)",
+        ))
+        .expect("valid gauge opts");
+
+        let referral_bonus_minted = IntGauge::with_opts(Opts::new(
+            "tirami_referral_bonus_minted",
+            "Total TRM minted as referral bonuses",
+        ))
+        .expect("valid gauge opts");
+
         // Register all metrics with the isolated registry.
         registry
             .register(Box::new(cu_contributed.clone()))
@@ -158,6 +209,27 @@ impl TiramiMetrics {
         registry
             .register(Box::new(collusion_penalty.clone()))
             .expect("register collusion_penalty");
+        registry
+            .register(Box::new(total_minted.clone()))
+            .expect("register total_minted");
+        registry
+            .register(Box::new(supply_factor.clone()))
+            .expect("register supply_factor");
+        registry
+            .register(Box::new(current_epoch.clone()))
+            .expect("register current_epoch");
+        registry
+            .register(Box::new(yield_rate.clone()))
+            .expect("register yield_rate");
+        registry
+            .register(Box::new(total_staked.clone()))
+            .expect("register total_staked");
+        registry
+            .register(Box::new(total_burned.clone()))
+            .expect("register total_burned");
+        registry
+            .register(Box::new(referral_bonus_minted.clone()))
+            .expect("register referral_bonus_minted");
 
         Self {
             registry,
@@ -172,6 +244,13 @@ impl TiramiMetrics {
             collusion_spike,
             collusion_robin,
             collusion_penalty,
+            total_minted,
+            supply_factor,
+            current_epoch,
+            yield_rate,
+            total_staked,
+            total_burned,
+            referral_bonus_minted,
         }
     }
 
@@ -179,7 +258,25 @@ impl TiramiMetrics {
     ///
     /// This is idempotent and cheap to call — Prometheus gauges are set (not
     /// incremented), so calling `observe` twice in a row is safe.
-    pub fn observe(&self, ledger: &ComputeLedger, now_ms: u64) {
+    ///
+    /// `staking_pool` and `referral_tracker` are optional — if None the Phase 13
+    /// tokenomics gauges remain at their last set value (zero at startup).
+    pub fn observe(
+        &self,
+        ledger: &ComputeLedger,
+        now_ms: u64,
+    ) {
+        self.observe_with_tokenomics(ledger, now_ms, None, None);
+    }
+
+    /// Extended observe that also snapshots Phase 13 tokenomics state.
+    pub fn observe_with_tokenomics(
+        &self,
+        ledger: &ComputeLedger,
+        now_ms: u64,
+        staking_pool: Option<&crate::staking::StakingPool>,
+        referral_tracker: Option<&crate::referral::ReferralTracker>,
+    ) {
         // Per-node balance and reputation metrics.
         for balance in ledger.balances.values() {
             let hex = balance.node_id.to_hex();
@@ -247,6 +344,28 @@ impl TiramiMetrics {
                     .with_label_values(&label)
                     .set(report.trust_penalty);
             }
+        }
+
+        // Phase 13 tokenomics gauges — ledger-derived.
+        let minted = ledger.total_minted;
+        self.total_minted.set(minted as i64);
+        self.supply_factor
+            .set(crate::tokenomics::supply_factor(minted));
+        self.current_epoch
+            .set(crate::tokenomics::current_epoch(minted) as i64);
+        self.yield_rate
+            .set(crate::tokenomics::epoch_yield_rate(minted));
+
+        // Optional staking pool data.
+        if let Some(pool) = staking_pool {
+            self.total_staked.set(pool.total_staked() as i64);
+            self.total_burned.set(pool.total_burned as i64);
+        }
+
+        // Optional referral tracker data.
+        if let Some(tracker) = referral_tracker {
+            self.referral_bonus_minted
+                .set(tracker.total_bonus_minted as i64);
         }
     }
 
@@ -407,5 +526,61 @@ mod tests {
         metrics.observe(&ledger, now_ms);
         // trade_count should have been incremented to 5.
         assert_eq!(metrics.trade_count.get(), 5);
+    }
+
+    #[test]
+    fn test_tokenomics_gauges_populated_at_genesis() {
+        let ledger = ComputeLedger::new();
+        let metrics = TiramiMetrics::new();
+        metrics.observe(&ledger, 1_700_000_000_000);
+        // At genesis: total_minted=0, supply_factor=1.0, epoch=0, yield=0.001
+        assert_eq!(metrics.total_minted.get(), 0);
+        assert!((metrics.supply_factor.get() - 1.0).abs() < 1e-9);
+        assert_eq!(metrics.current_epoch.get(), 0);
+        assert!((metrics.yield_rate.get() - 0.001).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_tokenomics_staking_gauges_with_pool() {
+        let ledger = ComputeLedger::new();
+        let mut pool = crate::staking::StakingPool::new();
+        let node = NodeId([5u8; 32]);
+        let now_ms: u64 = 1_000_000_000;
+        pool.stake(node, 10_000, crate::staking::StakeDuration::Days90, now_ms).unwrap();
+        let metrics = TiramiMetrics::new();
+        metrics.observe_with_tokenomics(&ledger, now_ms, Some(&pool), None);
+        assert_eq!(metrics.total_staked.get(), 10_000);
+        assert_eq!(metrics.total_burned.get(), 0);
+    }
+
+    #[test]
+    fn test_tokenomics_referral_gauge_with_tracker() {
+        let ledger = ComputeLedger::new();
+        let mut tracker = crate::referral::ReferralTracker::new();
+        let sponsor = NodeId([1u8; 32]);
+        let referred = NodeId([2u8; 32]);
+        let now_ms: u64 = 1_000_000_000;
+        tracker.register(sponsor, referred.clone(), now_ms).unwrap();
+        tracker.mark_loan_repaid(&referred);
+        tracker.mark_earn_threshold(&referred);
+        // total_bonus_minted = REFERRAL_BONUS_TRM = 100
+        let metrics = TiramiMetrics::new();
+        metrics.observe_with_tokenomics(&ledger, now_ms, None, Some(&tracker));
+        assert_eq!(metrics.referral_bonus_minted.get(), crate::referral::REFERRAL_BONUS_TRM as i64);
+    }
+
+    #[test]
+    fn test_tokenomics_metrics_appear_in_encoded_output() {
+        let ledger = ComputeLedger::new();
+        let metrics = TiramiMetrics::new();
+        metrics.observe(&ledger, 1_700_000_000_000);
+        let output = metrics.encode().unwrap();
+        assert!(output.contains("tirami_total_minted"), "missing tirami_total_minted");
+        assert!(output.contains("tirami_supply_factor"), "missing tirami_supply_factor");
+        assert!(output.contains("tirami_current_epoch"), "missing tirami_current_epoch");
+        assert!(output.contains("tirami_yield_rate"), "missing tirami_yield_rate");
+        assert!(output.contains("tirami_total_staked"), "missing tirami_total_staked");
+        assert!(output.contains("tirami_total_burned"), "missing tirami_total_burned");
+        assert!(output.contains("tirami_referral_bonus_minted"), "missing tirami_referral_bonus_minted");
     }
 }

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -50,6 +50,10 @@ pub(crate) struct AppState {
     pub agora_last_seen: Arc<Mutex<usize>>,
     /// forge-mind L3 agent (optional — None until POST /v1/tirami/mind/init).
     pub mind_agent: Arc<Mutex<Option<tirami_mind::TiramiMindAgent>>>,
+    /// Phase 13 — staking pool for TRM lock-up.
+    pub staking_pool: Arc<Mutex<tirami_ledger::StakingPool>>,
+    /// Phase 13 — referral tracker for sponsor bonuses.
+    pub referral_tracker: Arc<Mutex<tirami_ledger::ReferralTracker>>,
 }
 
 /// Simple rate limiter for authentication failures.
@@ -142,6 +146,8 @@ pub fn create_router(
         Arc::new(Mutex::new(Marketplace::new())),
         Arc::new(Mutex::new(0usize)),
         Arc::new(Mutex::new(None::<tirami_mind::TiramiMindAgent>)),
+        Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
+        Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
     )
 }
 
@@ -159,6 +165,8 @@ pub fn create_router_with_services(
     marketplace: Arc<Mutex<Marketplace>>,
     agora_last_seen: Arc<Mutex<usize>>,
     mind_agent: Arc<Mutex<Option<tirami_mind::TiramiMindAgent>>>,
+    staking_pool: Arc<Mutex<tirami_ledger::StakingPool>>,
+    referral_tracker: Arc<Mutex<tirami_ledger::ReferralTracker>>,
 ) -> Router {
     // Derive local node ID from cluster or generate a deterministic one.
     let local_node_id = cluster
@@ -183,6 +191,8 @@ pub fn create_router_with_services(
         marketplace,
         agora_last_seen,
         mind_agent,
+        staking_pool,
+        referral_tracker,
     };
     let api_max_request_body_bytes = state.config.api_max_request_body_bytes;
 
@@ -244,6 +254,13 @@ pub fn create_router_with_services(
         .route("/v1/tirami/mind/improve", post(crate::handlers::mind::mind_improve))
         .route("/v1/tirami/mind/budget", post(crate::handlers::mind::mind_budget))
         .route("/v1/tirami/mind/stats", get(crate::handlers::mind::mind_stats))
+        // Phase 13 — tokenomics / staking / referral (su = "pull me up" namespace)
+        .route("/v1/tirami/su/supply", get(crate::handlers::tokenomics::su_supply))
+        .route("/v1/tirami/su/stake", get(crate::handlers::tokenomics::su_stake_info))
+        .route("/v1/tirami/su/stake", post(crate::handlers::tokenomics::su_stake))
+        .route("/v1/tirami/su/unstake", post(crate::handlers::tokenomics::su_unstake))
+        .route("/v1/tirami/su/refer", post(crate::handlers::tokenomics::su_refer))
+        .route("/v1/tirami/su/referrals", get(crate::handlers::tokenomics::su_referrals))
         // Phase 10 P6 — Bitcoin OP_RETURN anchoring
         .route("/v1/tirami/anchor", get(crate::handlers::anchor::anchor_handler))
         // Admin: manual state persistence trigger (Phase 9)
@@ -2505,6 +2522,8 @@ pub(crate) fn test_router_default(config: Config) -> Router {
         Arc::new(Mutex::new(Marketplace::new())),
         Arc::new(Mutex::new(0usize)),
         Arc::new(Mutex::new(None::<tirami_mind::TiramiMindAgent>)),
+        Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
+        Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
     )
 }
 

--- a/crates/tirami-node/src/handlers/metrics.rs
+++ b/crates/tirami-node/src/handlers/metrics.rs
@@ -24,8 +24,12 @@ pub(crate) async fn metrics_handler(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let now_ms = now_millis_pub();
     let ledger = state.ledger.lock().await;
+    let staking = state.staking_pool.lock().await;
+    let referrals = state.referral_tracker.lock().await;
     let metrics = metrics_instance();
-    metrics.observe(&ledger, now_ms);
+    metrics.observe_with_tokenomics(&ledger, now_ms, Some(&*staking), Some(&*referrals));
+    drop(referrals);
+    drop(staking);
     drop(ledger);
     let body = metrics
         .encode()

--- a/crates/tirami-node/src/handlers/mod.rs
+++ b/crates/tirami-node/src/handlers/mod.rs
@@ -3,3 +3,4 @@ pub mod anchor;
 pub mod bank;
 pub mod metrics;
 pub mod mind;
+pub mod tokenomics;

--- a/crates/tirami-node/src/handlers/tokenomics.rs
+++ b/crates/tirami-node/src/handlers/tokenomics.rs
@@ -1,0 +1,513 @@
+//! HTTP handlers for `/v1/tirami/su/*` tokenomics endpoints (Phase 13).
+//!
+//! "su" = "pull me up" — the tokenomics namespace for supply, staking, and referral.
+
+use axum::{Json, extract::State, http::StatusCode};
+use serde::{Deserialize, Serialize};
+use tirami_ledger::{
+    StakeDuration,
+    tokenomics::{
+        TOTAL_TRM_SUPPLY, current_epoch, epoch_yield_rate, supply_factor,
+        FEE_ACTIVATION_THRESHOLD,
+    },
+};
+
+use crate::api::{AppState, check_forge_rate_limit, now_millis_pub};
+
+// ---------------------------------------------------------------------------
+// Response / request types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct SupplyResponse {
+    pub total_supply: u64,
+    pub total_minted: u64,
+    pub supply_factor: f64,
+    pub current_epoch: u32,
+    pub yield_rate: f64,
+    pub transaction_fee_active: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StakeRequest {
+    pub amount: u64,
+    /// Duration string: "7d", "30d", "90d", or "365d"
+    pub duration: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StakeResponse {
+    pub ok: bool,
+    pub multiplier: f64,
+    pub unlocks_at_ms: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StakeInfoResponse {
+    pub staked: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multiplier: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unlocks_at_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UnstakeResponse {
+    pub ok: bool,
+    pub returned: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReferRequest {
+    pub referred_hex: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReferResponse {
+    pub ok: bool,
+    pub referral_count: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReferralsResponse {
+    pub count: u32,
+    pub total_bonus_earned: u64,
+    pub referrals: Vec<ReferralEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReferralEntry {
+    pub referred: String,
+    pub sponsored_at_ms: u64,
+    pub loan_repaid: bool,
+    pub earn_threshold_met: bool,
+    pub bonus_paid: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn parse_stake_duration(s: &str) -> Option<StakeDuration> {
+    match s {
+        "7d" => Some(StakeDuration::Days7),
+        "30d" => Some(StakeDuration::Days30),
+        "90d" => Some(StakeDuration::Days90),
+        "365d" => Some(StakeDuration::Days365),
+        _ => None,
+    }
+}
+
+fn stake_duration_str(d: &StakeDuration) -> &'static str {
+    match d {
+        StakeDuration::Days7 => "7d",
+        StakeDuration::Days30 => "30d",
+        StakeDuration::Days90 => "90d",
+        StakeDuration::Days365 => "365d",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// GET /v1/tirami/su/supply — supply cap status
+pub(crate) async fn su_supply(
+    State(state): State<AppState>,
+) -> Result<Json<SupplyResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+    let ledger = state.ledger.lock().await;
+    let total_minted = ledger.total_minted;
+    drop(ledger);
+
+    let sf = supply_factor(total_minted);
+    let epoch = current_epoch(total_minted);
+    let yield_rate = epoch_yield_rate(total_minted);
+    let fee_active = sf <= FEE_ACTIVATION_THRESHOLD;
+
+    Ok(Json(SupplyResponse {
+        total_supply: TOTAL_TRM_SUPPLY,
+        total_minted,
+        supply_factor: sf,
+        current_epoch: epoch,
+        yield_rate,
+        transaction_fee_active: fee_active,
+    }))
+}
+
+/// POST /v1/tirami/su/stake — create a stake
+pub(crate) async fn su_stake(
+    State(state): State<AppState>,
+    Json(req): Json<StakeRequest>,
+) -> Result<Json<StakeResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+
+    let duration = parse_stake_duration(&req.duration)
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                "duration must be one of: 7d, 30d, 90d, 365d".to_string(),
+            )
+        })?;
+
+    let now_ms = now_millis_pub();
+    let mut pool = state.staking_pool.lock().await;
+    let stake = pool
+        .stake(state.local_node_id.clone(), req.amount, duration, now_ms)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    Ok(Json(StakeResponse {
+        ok: true,
+        multiplier: stake.multiplier(),
+        unlocks_at_ms: stake.unlocks_at_ms,
+    }))
+}
+
+/// GET /v1/tirami/su/stake — get current stake info
+pub(crate) async fn su_stake_info(
+    State(state): State<AppState>,
+) -> Result<Json<StakeInfoResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+
+    let now_ms = now_millis_pub();
+    let pool = state.staking_pool.lock().await;
+
+    match pool.stakes.get(&state.local_node_id) {
+        None => Ok(Json(StakeInfoResponse {
+            staked: 0,
+            duration: None,
+            multiplier: None,
+            locked: None,
+            unlocks_at_ms: None,
+        })),
+        Some(s) => Ok(Json(StakeInfoResponse {
+            staked: s.amount,
+            duration: Some(stake_duration_str(&s.duration).to_string()),
+            multiplier: Some(s.multiplier()),
+            locked: Some(s.is_locked(now_ms)),
+            unlocks_at_ms: Some(s.unlocks_at_ms),
+        })),
+    }
+}
+
+/// POST /v1/tirami/su/unstake — withdraw after lock expires
+pub(crate) async fn su_unstake(
+    State(state): State<AppState>,
+) -> Result<Json<UnstakeResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+
+    let now_ms = now_millis_pub();
+    let mut pool = state.staking_pool.lock().await;
+    let returned = pool
+        .unstake(&state.local_node_id, now_ms)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    Ok(Json(UnstakeResponse { ok: true, returned }))
+}
+
+/// POST /v1/tirami/su/refer — register a referral
+pub(crate) async fn su_refer(
+    State(state): State<AppState>,
+    Json(req): Json<ReferRequest>,
+) -> Result<Json<ReferResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+
+    if req.referred_hex.len() != 64 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "referred_hex must be 64 hex chars".to_string(),
+        ));
+    }
+    let bytes: [u8; 32] = hex::decode(&req.referred_hex)
+        .map_err(|_| (StatusCode::BAD_REQUEST, "invalid referred_hex".to_string()))?
+        .try_into()
+        .map_err(|_: Vec<u8>| {
+            (StatusCode::BAD_REQUEST, "referred_hex must be 32 bytes".to_string())
+        })?;
+    let referred = tirami_core::NodeId(bytes);
+
+    let now_ms = now_millis_pub();
+    let mut tracker = state.referral_tracker.lock().await;
+    tracker
+        .register(state.local_node_id.clone(), referred, now_ms)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let count = tracker.referral_count(&state.local_node_id);
+
+    Ok(Json(ReferResponse {
+        ok: true,
+        referral_count: count,
+    }))
+}
+
+/// GET /v1/tirami/su/referrals — list your referrals
+pub(crate) async fn su_referrals(
+    State(state): State<AppState>,
+) -> Result<Json<ReferralsResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+
+    let tracker = state.referral_tracker.lock().await;
+    let count = tracker.referral_count(&state.local_node_id);
+    let total_bonus_earned = tracker
+        .records
+        .values()
+        .filter(|r| r.sponsor == state.local_node_id && r.bonus_paid)
+        .count() as u64
+        * tirami_ledger::referral::REFERRAL_BONUS_TRM;
+
+    let referrals: Vec<ReferralEntry> = tracker
+        .records
+        .values()
+        .filter(|r| r.sponsor == state.local_node_id)
+        .map(|r| ReferralEntry {
+            referred: hex::encode(r.referred.0),
+            sponsored_at_ms: r.sponsored_at_ms,
+            loan_repaid: r.loan_repaid,
+            earn_threshold_met: r.earn_threshold_met,
+            bonus_paid: r.bonus_paid,
+        })
+        .collect();
+
+    Ok(Json(ReferralsResponse {
+        count,
+        total_bonus_earned,
+        referrals,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::util::ServiceExt;
+
+    use crate::api::test_router_default;
+    use tirami_core::Config;
+
+    #[tokio::test]
+    async fn test_su_supply_returns_initial_state() {
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/su/supply")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["total_supply"].as_u64().unwrap(), 21_000_000_000);
+        assert_eq!(json["total_minted"].as_u64().unwrap(), 0);
+        assert!((json["supply_factor"].as_f64().unwrap() - 1.0).abs() < 1e-6);
+        assert_eq!(json["current_epoch"].as_u64().unwrap(), 0);
+        assert_eq!(json["transaction_fee_active"].as_bool().unwrap(), false);
+    }
+
+    #[tokio::test]
+    async fn test_su_stake_creates_stake() {
+        let app = test_router_default(Config::default());
+        let body = serde_json::json!({ "amount": 10000, "duration": "90d" }).to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/su/stake")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["ok"].as_bool().unwrap(), true);
+        assert!((json["multiplier"].as_f64().unwrap() - 2.0).abs() < 1e-9);
+        assert!(json["unlocks_at_ms"].as_u64().unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_su_stake_invalid_duration_returns_400() {
+        let app = test_router_default(Config::default());
+        let body = serde_json::json!({ "amount": 10000, "duration": "999d" }).to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/su/stake")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_su_stake_info_returns_no_stake_when_empty() {
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/su/stake")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["staked"].as_u64().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_su_unstake_fails_when_not_staked() {
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/su/unstake")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_su_refer_invalid_hex_returns_400() {
+        let app = test_router_default(Config::default());
+        let body = serde_json::json!({ "referred_hex": "not-a-hex" }).to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/su/refer")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_su_referrals_returns_empty_initially() {
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/su/referrals")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["count"].as_u64().unwrap(), 0);
+        assert_eq!(json["total_bonus_earned"].as_u64().unwrap(), 0);
+        assert!(json["referrals"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_su_supply_yield_rate_nonzero() {
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/su/supply")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // At genesis epoch 0, yield_rate = 0.001
+        assert!((json["yield_rate"].as_f64().unwrap() - 0.001).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn test_su_stake_below_minimum_returns_400() {
+        let app = test_router_default(Config::default());
+        // 90d minimum is 10_000 — stake 999 should fail
+        let body = serde_json::json!({ "amount": 999, "duration": "90d" }).to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/su/stake")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_su_refer_self_returns_400() {
+        // The local node ID in test_router_default is NodeId([0u8; 32])
+        let app = test_router_default(Config::default());
+        let zero_hex = "0".repeat(64);
+        let body = serde_json::json!({ "referred_hex": zero_hex }).to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/su/refer")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_su_stake_7d_multiplier() {
+        let app = test_router_default(Config::default());
+        let body = serde_json::json!({ "amount": 100, "duration": "7d" }).to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/su/stake")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!((json["multiplier"].as_f64().unwrap() - 1.2).abs() < 1e-9);
+    }
+}

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -30,6 +30,10 @@ pub struct TiramiNode {
     pub marketplace: Arc<Mutex<Marketplace>>,
     /// forge-mind L3 agent (persisted via mind_state_path; None until init).
     pub mind_agent: Arc<Mutex<Option<tirami_mind::TiramiMindAgent>>>,
+    /// Phase 13 — staking pool for TRM lock-up.
+    pub staking_pool: Arc<Mutex<tirami_ledger::StakingPool>>,
+    /// Phase 13 — referral tracker for sponsor bonuses.
+    pub referral_tracker: Arc<Mutex<tirami_ledger::ReferralTracker>>,
 }
 
 impl TiramiNode {
@@ -115,6 +119,8 @@ impl TiramiNode {
             bank: Arc::new(Mutex::new(bank)),
             marketplace: Arc::new(Mutex::new(marketplace)),
             mind_agent: Arc::new(Mutex::new(mind_agent)),
+            staking_pool: Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
+            referral_tracker: Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
         }
     }
 
@@ -162,6 +168,8 @@ impl TiramiNode {
             self.marketplace.clone(),
             Arc::new(Mutex::new(0usize)),
             self.mind_agent.clone(),
+            self.staking_pool.clone(),
+            self.referral_tracker.clone(),
         );
         let addr = self.config.api_socket_addr();
         tracing::info!("API server listening on {}", addr);
@@ -219,6 +227,8 @@ impl TiramiNode {
         let bank_api = self.bank.clone();
         let marketplace_api = self.marketplace.clone();
         let mind_agent_api = self.mind_agent.clone();
+        let staking_pool_api = self.staking_pool.clone();
+        let referral_tracker_api = self.referral_tracker.clone();
         let api_config = self.config.clone();
         tokio::spawn(async move {
             let app = crate::api::create_router_with_services(
@@ -233,6 +243,8 @@ impl TiramiNode {
                 marketplace_api,
                 Arc::new(Mutex::new(0usize)),
                 mind_agent_api,
+                staking_pool_api,
+                referral_tracker_api,
             );
             let addr = api_config.api_socket_addr();
             if let Ok(listener) = tokio::net::TcpListener::bind(&addr).await {

--- a/crates/tirami-node/src/security_tests.rs
+++ b/crates/tirami-node/src/security_tests.rs
@@ -703,6 +703,8 @@ mod security_tests {
             Arc::new(Mutex::new(Marketplace::new())),
             Arc::new(Mutex::new(0usize)),
             Arc::new(Mutex::new(None::<tirami_mind::TiramiMindAgent>)),
+            Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
+            Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
         );
         let _ = state; // suppress unused warning
 

--- a/scripts/demo-e2e.sh
+++ b/scripts/demo-e2e.sh
@@ -27,7 +27,7 @@ while [ $# -gt 0 ]; do
 done
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
-BIN="$REPO_ROOT/target/release/forge"
+BIN="$REPO_ROOT/target/release/tirami"
 BASE="http://127.0.0.1:$PORT"
 H="Authorization: Bearer $TOKEN"
 
@@ -49,7 +49,7 @@ trap cleanup EXIT
 
 step "build"
 if [ ! -x "$BIN" ]; then
-  cargo build --release -p forge-cli >/dev/null 2>&1 && ok "compiled forge"
+  cargo build --release -p tirami-cli >/dev/null 2>&1 && ok "compiled tirami"
 else
   ok "binary already built at $BIN"
 fi


### PR DESCRIPTION
Wires the tokenomics modules into the live API. 6 new `/v1/tirami/su/*` endpoints, 7 new Prometheus gauges, demo-e2e.sh binary fix. 748→763 tests.