### PR TITLE
Phase 13: full governance stack — API + Prometheus + SDK + MCP

### DIFF
--- a/crates/tirami-ledger/src/metrics.rs
+++ b/crates/tirami-ledger/src/metrics.rs
@@ -33,6 +33,9 @@ pub struct TiramiMetrics {
     pub collusion_spike: GaugeVec,
     pub collusion_robin: GaugeVec,
     pub collusion_penalty: GaugeVec,
+    // Phase 13 governance metrics
+    pub active_proposals: IntGauge,
+    pub total_votes: IntGauge,
     // Phase 13 tokenomics metrics
     pub total_minted: IntGauge,
     pub supply_factor: Gauge,
@@ -132,6 +135,19 @@ impl TiramiMetrics {
         )
         .expect("valid gauge vec opts");
 
+        // Phase 13 governance gauges
+        let active_proposals = IntGauge::with_opts(Opts::new(
+            "tirami_active_proposals",
+            "Number of currently active governance proposals",
+        ))
+        .expect("valid gauge opts");
+
+        let total_votes = IntGauge::with_opts(Opts::new(
+            "tirami_total_votes",
+            "Total votes cast across all governance proposals",
+        ))
+        .expect("valid gauge opts");
+
         // Phase 13 tokenomics gauges
         let total_minted = IntGauge::with_opts(Opts::new(
             "tirami_total_minted",
@@ -210,6 +226,12 @@ impl TiramiMetrics {
             .register(Box::new(collusion_penalty.clone()))
             .expect("register collusion_penalty");
         registry
+            .register(Box::new(active_proposals.clone()))
+            .expect("register active_proposals");
+        registry
+            .register(Box::new(total_votes.clone()))
+            .expect("register total_votes");
+        registry
             .register(Box::new(total_minted.clone()))
             .expect("register total_minted");
         registry
@@ -244,6 +266,8 @@ impl TiramiMetrics {
             collusion_spike,
             collusion_robin,
             collusion_penalty,
+            active_proposals,
+            total_votes,
             total_minted,
             supply_factor,
             current_epoch,
@@ -276,6 +300,18 @@ impl TiramiMetrics {
         now_ms: u64,
         staking_pool: Option<&crate::staking::StakingPool>,
         referral_tracker: Option<&crate::referral::ReferralTracker>,
+    ) {
+        self.observe_full(ledger, now_ms, staking_pool, referral_tracker, None);
+    }
+
+    /// Full observe including governance state.
+    pub fn observe_full(
+        &self,
+        ledger: &ComputeLedger,
+        now_ms: u64,
+        staking_pool: Option<&crate::staking::StakingPool>,
+        referral_tracker: Option<&crate::referral::ReferralTracker>,
+        governance: Option<&crate::governance::GovernanceState>,
     ) {
         // Per-node balance and reputation metrics.
         for balance in ledger.balances.values() {
@@ -366,6 +402,14 @@ impl TiramiMetrics {
         if let Some(tracker) = referral_tracker {
             self.referral_bonus_minted
                 .set(tracker.total_bonus_minted as i64);
+        }
+
+        // Optional governance state.
+        if let Some(gov) = governance {
+            self.active_proposals
+                .set(gov.active_proposals().len() as i64);
+            let total_v: usize = gov.votes.values().map(|v| v.len()).sum();
+            self.total_votes.set(total_v as i64);
         }
     }
 
@@ -567,6 +611,37 @@ mod tests {
         let metrics = TiramiMetrics::new();
         metrics.observe_with_tokenomics(&ledger, now_ms, None, Some(&tracker));
         assert_eq!(metrics.referral_bonus_minted.get(), crate::referral::REFERRAL_BONUS_TRM as i64);
+    }
+
+    #[test]
+    fn test_governance_gauges_with_state() {
+        let ledger = ComputeLedger::new();
+        let mut gov = crate::governance::GovernanceState::new(0);
+        let proposer = NodeId([1u8; 32]);
+        let now_ms = 1_000_000_000u64;
+        let deadline = now_ms + 86_400_000;
+        let pid = gov.create_proposal(
+            proposer,
+            crate::governance::ProposalKind::EmergencyPause,
+            now_ms,
+            deadline,
+        ).unwrap();
+        let voter = NodeId([2u8; 32]);
+        gov.cast_vote(voter, pid, true, 5000, 0.9, 2).unwrap();
+        let metrics = TiramiMetrics::new();
+        metrics.observe_full(&ledger, now_ms, None, None, Some(&gov));
+        assert_eq!(metrics.active_proposals.get(), 1);
+        assert_eq!(metrics.total_votes.get(), 1);
+    }
+
+    #[test]
+    fn test_governance_gauges_appear_in_encoded_output() {
+        let metrics = TiramiMetrics::new();
+        metrics.active_proposals.set(3);
+        metrics.total_votes.set(42);
+        let output = metrics.encode().unwrap();
+        assert!(output.contains("tirami_active_proposals"), "missing tirami_active_proposals");
+        assert!(output.contains("tirami_total_votes"), "missing tirami_total_votes");
     }
 
     #[test]

--- a/crates/tirami-mcp/src/main.rs
+++ b/crates/tirami-mcp/src/main.rs
@@ -1,6 +1,6 @@
 //! Forge MCP Server — Rust implementation
 //!
-//! Exposes all 36 Forge compute-economy endpoints as MCP tools for Claude Code,
+//! Exposes all 40 Forge compute-economy endpoints as MCP tools for Claude Code,
 //! Cursor, and other MCP-compatible AI clients.
 //!
 //! Usage:
@@ -320,6 +320,44 @@ impl ForgeMcpServer {
             "tirami_mind_budget" => self.client.post("/v1/tirami/mind/budget", args).await,
             "tirami_mind_stats" => self.client.get("/v1/tirami/mind/stats").await,
 
+            // ----------------------------------------------------------------
+            // Governance (4 tools)
+            // ----------------------------------------------------------------
+            "tirami_governance_propose" => {
+                let mut body = serde_json::json!({
+                    "proposer": obj.get("proposer").and_then(|v| v.as_str()).unwrap_or(""),
+                    "kind": obj.get("kind").and_then(|v| v.as_str()).unwrap_or(""),
+                    "deadline_ms": obj.get("deadline_ms").and_then(|v| v.as_u64()).unwrap_or(0),
+                });
+                if let Some(n) = obj.get("name") {
+                    body["name"] = n.clone();
+                }
+                if let Some(v) = obj.get("new_value") {
+                    body["new_value"] = v.clone();
+                }
+                if let Some(d) = obj.get("description") {
+                    body["description"] = d.clone();
+                }
+                self.client
+                    .post("/v1/tirami/governance/propose", body)
+                    .await
+            }
+            "tirami_governance_vote" => {
+                self.client.post("/v1/tirami/governance/vote", args).await
+            }
+            "tirami_governance_proposals" => {
+                self.client.get("/v1/tirami/governance/proposals").await
+            }
+            "tirami_governance_tally" => {
+                let id = obj
+                    .get("proposal_id")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                self.client
+                    .get(&format!("/v1/tirami/governance/tally/{id}"))
+                    .await
+            }
+
             other => {
                 return Self::error_result(format!("Unknown tool: {other}"));
             }
@@ -408,9 +446,9 @@ mod tests {
     use super::tools;
 
     #[test]
-    fn test_tool_list_has_36_tools() {
+    fn test_tool_list_has_40_tools() {
         let tools = tools::build_tool_list();
-        assert_eq!(tools.len(), 36, "expected 36 tools, got {}", tools.len());
+        assert_eq!(tools.len(), 40, "expected 40 tools, got {}", tools.len());
     }
 
     #[test]
@@ -524,6 +562,15 @@ mod tests {
             "tirami_mind_stats",
         ] {
             assert!(names.contains(*n), "missing mind tool: {n}");
+        }
+        // Governance
+        for n in &[
+            "tirami_governance_propose",
+            "tirami_governance_vote",
+            "tirami_governance_proposals",
+            "tirami_governance_tally",
+        ] {
+            assert!(names.contains(*n), "missing governance tool: {n}");
         }
     }
 }

--- a/crates/tirami-mcp/src/tools.rs
+++ b/crates/tirami-mcp/src/tools.rs
@@ -17,7 +17,7 @@ fn schema(value: serde_json::Value) -> Arc<rmcp::model::JsonObject> {
     )
 }
 
-/// Build the complete list of 36 Forge MCP tools.
+/// Build the complete list of 40 Forge MCP tools.
 pub fn build_tool_list() -> Vec<Tool> {
     vec![
         // ====================================================================
@@ -629,6 +629,107 @@ pub fn build_tool_list() -> Vec<Tool> {
             schema(json!({
                 "type": "object",
                 "properties": {}
+            })),
+        ),
+        // ====================================================================
+        // Governance (4 tools)
+        // ====================================================================
+        Tool::new(
+            "tirami_governance_propose",
+            "Create a governance proposal to change a protocol parameter or policy. Specify \
+             the proposer NodeId, proposal kind (e.g. 'parameter_change'), optional parameter \
+             name and new value, a human-readable description, and a deadline in Unix \
+             milliseconds.",
+            schema(json!({
+                "type": "object",
+                "properties": {
+                    "proposer": {
+                        "type": "string",
+                        "description": "64-char hex NodeId of the proposer"
+                    },
+                    "kind": {
+                        "type": "string",
+                        "description": "Proposal kind, e.g. 'parameter_change'"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Parameter name to change (optional)"
+                    },
+                    "new_value": {
+                        "type": "number",
+                        "description": "Proposed new value for the parameter (optional)"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable description of the proposal (optional)"
+                    },
+                    "deadline_ms": {
+                        "type": "integer",
+                        "description": "Voting deadline as Unix milliseconds"
+                    }
+                },
+                "required": ["proposer", "kind", "deadline_ms"]
+            })),
+        ),
+        Tool::new(
+            "tirami_governance_vote",
+            "Cast a vote on an active governance proposal. The vote weight is derived from \
+             stake, reputation, and participation history. Approve or reject the proposal.",
+            schema(json!({
+                "type": "object",
+                "properties": {
+                    "voter": {
+                        "type": "string",
+                        "description": "64-char hex NodeId of the voter"
+                    },
+                    "proposal_id": {
+                        "type": "integer",
+                        "description": "ID of the proposal to vote on"
+                    },
+                    "approve": {
+                        "type": "boolean",
+                        "description": "true to approve, false to reject"
+                    },
+                    "stake": {
+                        "type": "number",
+                        "description": "Voter's current CU stake"
+                    },
+                    "reputation": {
+                        "type": "number",
+                        "description": "Voter's reputation score [0.0, 1.0]"
+                    },
+                    "epochs_participated": {
+                        "type": "integer",
+                        "description": "Number of governance epochs the voter has participated in"
+                    }
+                },
+                "required": ["voter", "proposal_id", "approve", "stake", "reputation", "epochs_participated"]
+            })),
+        ),
+        Tool::new(
+            "tirami_governance_proposals",
+            "List all active governance proposals. Each proposal includes its ID, kind, \
+             proposer, description, deadline, and current vote counts. Use this to discover \
+             proposals before voting.",
+            schema(json!({
+                "type": "object",
+                "properties": {}
+            })),
+        ),
+        Tool::new(
+            "tirami_governance_tally",
+            "Get the tally result for a specific governance proposal by ID. Returns the \
+             weighted approve/reject totals, quorum status, and whether the proposal has \
+             passed or failed.",
+            schema(json!({
+                "type": "object",
+                "properties": {
+                    "proposal_id": {
+                        "type": "integer",
+                        "description": "ID of the proposal to tally"
+                    }
+                },
+                "required": ["proposal_id"]
             })),
         ),
     ]

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -54,6 +54,8 @@ pub(crate) struct AppState {
     pub staking_pool: Arc<Mutex<tirami_ledger::StakingPool>>,
     /// Phase 13 — referral tracker for sponsor bonuses.
     pub referral_tracker: Arc<Mutex<tirami_ledger::ReferralTracker>>,
+    /// Phase 13 — governance state for stake-weighted voting.
+    pub governance: Arc<Mutex<tirami_ledger::GovernanceState>>,
 }
 
 /// Simple rate limiter for authentication failures.
@@ -148,6 +150,7 @@ pub fn create_router(
         Arc::new(Mutex::new(None::<tirami_mind::TiramiMindAgent>)),
         Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
         Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
+        Arc::new(Mutex::new(tirami_ledger::GovernanceState::new(0))),
     )
 }
 
@@ -167,6 +170,7 @@ pub fn create_router_with_services(
     mind_agent: Arc<Mutex<Option<tirami_mind::TiramiMindAgent>>>,
     staking_pool: Arc<Mutex<tirami_ledger::StakingPool>>,
     referral_tracker: Arc<Mutex<tirami_ledger::ReferralTracker>>,
+    governance: Arc<Mutex<tirami_ledger::GovernanceState>>,
 ) -> Router {
     // Derive local node ID from cluster or generate a deterministic one.
     let local_node_id = cluster
@@ -193,6 +197,7 @@ pub fn create_router_with_services(
         mind_agent,
         staking_pool,
         referral_tracker,
+        governance,
     };
     let api_max_request_body_bytes = state.config.api_max_request_body_bytes;
 
@@ -261,6 +266,11 @@ pub fn create_router_with_services(
         .route("/v1/tirami/su/unstake", post(crate::handlers::tokenomics::su_unstake))
         .route("/v1/tirami/su/refer", post(crate::handlers::tokenomics::su_refer))
         .route("/v1/tirami/su/referrals", get(crate::handlers::tokenomics::su_referrals))
+        // Phase 13 — governance (stake-weighted voting)
+        .route("/v1/tirami/governance/propose", post(crate::handlers::governance::governance_propose))
+        .route("/v1/tirami/governance/vote", post(crate::handlers::governance::governance_vote))
+        .route("/v1/tirami/governance/proposals", get(crate::handlers::governance::governance_proposals))
+        .route("/v1/tirami/governance/tally/{id}", get(crate::handlers::governance::governance_tally))
         // Phase 10 P6 — Bitcoin OP_RETURN anchoring
         .route("/v1/tirami/anchor", get(crate::handlers::anchor::anchor_handler))
         // Admin: manual state persistence trigger (Phase 9)
@@ -2524,6 +2534,7 @@ pub(crate) fn test_router_default(config: Config) -> Router {
         Arc::new(Mutex::new(None::<tirami_mind::TiramiMindAgent>)),
         Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
         Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
+        Arc::new(Mutex::new(tirami_ledger::GovernanceState::new(0))),
     )
 }
 

--- a/crates/tirami-node/src/handlers/governance.rs
+++ b/crates/tirami-node/src/handlers/governance.rs
@@ -1,0 +1,713 @@
+//! HTTP handlers for `/v1/tirami/governance/*` endpoints (Phase 13).
+//!
+//! Stake-weighted governance: propose, vote, list proposals, tally results.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde_json::json;
+use tirami_ledger::ProposalKind;
+
+use crate::api::{AppState, check_forge_rate_limit, now_millis_pub};
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// POST /v1/tirami/governance/propose
+///
+/// Body: `{ "proposer": "hex64", "kind": "change_parameter"|"emergency_pause"|"protocol_upgrade",
+///          "name": "...", "new_value": 1.0, "description": "...", "deadline_ms": 123456 }`
+pub(crate) async fn governance_propose(
+    State(state): State<AppState>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    if let Err(e) = check_forge_rate_limit(&state).await {
+        return e.into_response();
+    }
+
+    let proposer_hex = match body["proposer"].as_str() {
+        Some(s) if s.len() == 64 => s,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "proposer must be 64 hex chars" })),
+            )
+                .into_response();
+        }
+    };
+    let mut proposer_bytes = [0u8; 32];
+    if hex::decode_to_slice(proposer_hex, &mut proposer_bytes).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid proposer hex" })),
+        )
+            .into_response();
+    }
+    let proposer = tirami_core::NodeId(proposer_bytes);
+
+    let kind_str = body["kind"].as_str().unwrap_or("");
+    let kind = match kind_str {
+        "change_parameter" => {
+            let name = match body["name"].as_str() {
+                Some(n) => n.to_string(),
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({ "error": "change_parameter requires 'name'" })),
+                    )
+                        .into_response();
+                }
+            };
+            let new_value = match body["new_value"].as_f64() {
+                Some(v) => v,
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({ "error": "change_parameter requires 'new_value'" })),
+                    )
+                        .into_response();
+                }
+            };
+            ProposalKind::ChangeParameter { name, new_value }
+        }
+        "emergency_pause" => ProposalKind::EmergencyPause,
+        "protocol_upgrade" => {
+            let description = body["description"]
+                .as_str()
+                .unwrap_or("")
+                .to_string();
+            ProposalKind::ProtocolUpgrade { description }
+        }
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "kind must be one of: change_parameter, emergency_pause, protocol_upgrade" })),
+            )
+                .into_response();
+        }
+    };
+
+    let deadline_ms = match body["deadline_ms"].as_u64() {
+        Some(d) => d,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "deadline_ms is required" })),
+            )
+                .into_response();
+        }
+    };
+
+    let now_ms = now_millis_pub();
+    let mut gov = state.governance.lock().await;
+    match gov.create_proposal(proposer, kind, now_ms, deadline_ms) {
+        Ok(id) => Json(json!({ "ok": true, "proposal_id": id })).into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /v1/tirami/governance/vote
+///
+/// Body: `{ "voter": "hex64", "proposal_id": 0, "approve": true,
+///          "stake": 5000.0, "reputation": 0.8, "epochs_participated": 2 }`
+pub(crate) async fn governance_vote(
+    State(state): State<AppState>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    if let Err(e) = check_forge_rate_limit(&state).await {
+        return e.into_response();
+    }
+
+    let voter_hex = match body["voter"].as_str() {
+        Some(s) if s.len() == 64 => s,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "voter must be 64 hex chars" })),
+            )
+                .into_response();
+        }
+    };
+    let mut voter_bytes = [0u8; 32];
+    if hex::decode_to_slice(voter_hex, &mut voter_bytes).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid voter hex" })),
+        )
+            .into_response();
+    }
+    let voter = tirami_core::NodeId(voter_bytes);
+
+    let proposal_id = match body["proposal_id"].as_u64() {
+        Some(id) => id,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "proposal_id is required" })),
+            )
+                .into_response();
+        }
+    };
+
+    let approve = match body["approve"].as_bool() {
+        Some(b) => b,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "approve (bool) is required" })),
+            )
+                .into_response();
+        }
+    };
+
+    let stake = match body["stake"].as_f64() {
+        Some(s) => s as u64,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "stake is required" })),
+            )
+                .into_response();
+        }
+    };
+
+    let reputation = match body["reputation"].as_f64() {
+        Some(r) => r,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "reputation is required" })),
+            )
+                .into_response();
+        }
+    };
+
+    let epochs_participated = body["epochs_participated"].as_u64().unwrap_or(0);
+
+    let mut gov = state.governance.lock().await;
+    match gov.cast_vote(voter, proposal_id, approve, stake, reputation, epochs_participated) {
+        Ok(()) => Json(json!({ "ok": true })).into_response(),
+        Err(e) => {
+            use tirami_ledger::GovernanceError;
+            let status = match &e {
+                GovernanceError::ProposalNotFound { .. } => StatusCode::NOT_FOUND,
+                _ => StatusCode::BAD_REQUEST,
+            };
+            (status, Json(json!({ "error": e.to_string() }))).into_response()
+        }
+    }
+}
+
+/// GET /v1/tirami/governance/proposals
+///
+/// Returns all active proposals.
+pub(crate) async fn governance_proposals(
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    if let Err(e) = check_forge_rate_limit(&state).await {
+        return e.into_response();
+    }
+
+    let gov = state.governance.lock().await;
+    let active: Vec<serde_json::Value> = gov
+        .active_proposals()
+        .iter()
+        .map(|p| {
+            json!({
+                "id": p.id,
+                "proposer": hex::encode(p.proposer.0),
+                "kind": format!("{:?}", p.kind),
+                "epoch": p.epoch,
+                "created_at_ms": p.created_at_ms,
+                "deadline_ms": p.deadline_ms,
+                "status": format!("{:?}", p.status),
+            })
+        })
+        .collect();
+
+    Json(json!({ "proposals": active })).into_response()
+}
+
+/// GET /v1/tirami/governance/tally/:id
+///
+/// Tallies votes for a proposal and returns the result.
+pub(crate) async fn governance_tally(
+    State(state): State<AppState>,
+    Path(id): Path<u64>,
+) -> impl IntoResponse {
+    if let Err(e) = check_forge_rate_limit(&state).await {
+        return e.into_response();
+    }
+
+    let mut gov = state.governance.lock().await;
+    match gov.tally(id) {
+        Ok(status) => Json(json!({
+            "proposal_id": id,
+            "status": format!("{:?}", status),
+        }))
+        .into_response(),
+        Err(e) => {
+            use tirami_ledger::GovernanceError;
+            let code = match &e {
+                GovernanceError::ProposalNotFound { .. } => StatusCode::NOT_FOUND,
+                _ => StatusCode::BAD_REQUEST,
+            };
+            (code, Json(json!({ "error": e.to_string() }))).into_response()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::util::ServiceExt;
+
+    use crate::api::test_router_default;
+    use tirami_core::Config;
+
+    fn proposer_hex() -> String {
+        "aa".repeat(32)
+    }
+
+    fn voter_hex() -> String {
+        "bb".repeat(32)
+    }
+
+    #[tokio::test]
+    async fn test_governance_propose_success() {
+        let app = test_router_default(Config::default());
+        let body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "emergency_pause",
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["ok"].as_bool().unwrap(), true);
+        assert!(json["proposal_id"].as_u64().unwrap() >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_governance_vote_success() {
+        let app = test_router_default(Config::default());
+
+        // First, create a proposal
+        let propose_body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "emergency_pause",
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(propose_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let pjson: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let proposal_id = pjson["proposal_id"].as_u64().unwrap();
+
+        // Now vote
+        let vote_body = serde_json::json!({
+            "voter": voter_hex(),
+            "proposal_id": proposal_id,
+            "approve": true,
+            "stake": 5000,
+            "reputation": 0.9,
+            "epochs_participated": 2,
+        })
+        .to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/vote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(vote_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["ok"].as_bool().unwrap(), true);
+    }
+
+    #[tokio::test]
+    async fn test_governance_proposals_empty() {
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/governance/proposals")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json["proposals"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_governance_proposals_with_data() {
+        let app = test_router_default(Config::default());
+
+        // Create a proposal
+        let body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "change_parameter",
+            "name": "yield_rate",
+            "new_value": 0.05,
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // List proposals
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/governance/proposals")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["proposals"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_governance_tally_returns_correct_status() {
+        let app = test_router_default(Config::default());
+
+        // Create proposal
+        let body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "emergency_pause",
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let pjson: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let proposal_id = pjson["proposal_id"].as_u64().unwrap();
+
+        // Vote approve
+        let vote_body = serde_json::json!({
+            "voter": voter_hex(),
+            "proposal_id": proposal_id,
+            "approve": true,
+            "stake": 5000,
+            "reputation": 0.9,
+            "epochs_participated": 0,
+        })
+        .to_string();
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/vote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(vote_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Tally
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&format!("/v1/tirami/governance/tally/{}", proposal_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["status"].as_str().unwrap(), "Passed");
+    }
+
+    #[tokio::test]
+    async fn test_governance_vote_insufficient_reputation_returns_400() {
+        let app = test_router_default(Config::default());
+
+        // Create proposal
+        let body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "emergency_pause",
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let pjson: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let proposal_id = pjson["proposal_id"].as_u64().unwrap();
+
+        // Vote with low reputation
+        let vote_body = serde_json::json!({
+            "voter": voter_hex(),
+            "proposal_id": proposal_id,
+            "approve": true,
+            "stake": 5000,
+            "reputation": 0.3,
+            "epochs_participated": 0,
+        })
+        .to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/vote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(vote_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_governance_vote_insufficient_stake_returns_400() {
+        let app = test_router_default(Config::default());
+
+        // Create proposal
+        let body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "emergency_pause",
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let pjson: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let proposal_id = pjson["proposal_id"].as_u64().unwrap();
+
+        // Vote with low stake
+        let vote_body = serde_json::json!({
+            "voter": voter_hex(),
+            "proposal_id": proposal_id,
+            "approve": true,
+            "stake": 100,
+            "reputation": 0.9,
+            "epochs_participated": 0,
+        })
+        .to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/vote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(vote_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_governance_tally_nonexistent_returns_404() {
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/governance/tally/999")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_governance_full_flow_propose_vote_tally() {
+        let app = test_router_default(Config::default());
+
+        // 1. Propose a parameter change
+        let body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "change_parameter",
+            "name": "fee_rate",
+            "new_value": 0.02,
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let pjson: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let proposal_id = pjson["proposal_id"].as_u64().unwrap();
+
+        // 2. Cast two votes: one approve (high stake), one reject (low stake)
+        let vote1 = serde_json::json!({
+            "voter": voter_hex(),
+            "proposal_id": proposal_id,
+            "approve": true,
+            "stake": 10000,
+            "reputation": 0.9,
+            "epochs_participated": 3,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/vote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(vote1))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let voter2_hex = "cc".repeat(32);
+        let vote2 = serde_json::json!({
+            "voter": voter2_hex,
+            "proposal_id": proposal_id,
+            "approve": false,
+            "stake": 2000,
+            "reputation": 0.8,
+            "epochs_participated": 0,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/vote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(vote2))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // 3. Tally — approve should win (10000*2.0=20000 vs 2000*1.0=2000)
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&format!("/v1/tirami/governance/tally/{}", proposal_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["status"].as_str().unwrap(), "Passed");
+        assert_eq!(json["proposal_id"].as_u64().unwrap(), proposal_id);
+    }
+}

--- a/crates/tirami-node/src/handlers/mod.rs
+++ b/crates/tirami-node/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod agora;
 pub mod anchor;
 pub mod bank;
+pub mod governance;
 pub mod metrics;
 pub mod mind;
 pub mod tokenomics;

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -34,6 +34,8 @@ pub struct TiramiNode {
     pub staking_pool: Arc<Mutex<tirami_ledger::StakingPool>>,
     /// Phase 13 — referral tracker for sponsor bonuses.
     pub referral_tracker: Arc<Mutex<tirami_ledger::ReferralTracker>>,
+    /// Phase 13 — governance state for stake-weighted voting.
+    pub governance: Arc<Mutex<tirami_ledger::GovernanceState>>,
 }
 
 impl TiramiNode {
@@ -121,6 +123,7 @@ impl TiramiNode {
             mind_agent: Arc::new(Mutex::new(mind_agent)),
             staking_pool: Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
             referral_tracker: Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
+            governance: Arc::new(Mutex::new(tirami_ledger::GovernanceState::new(0))),
         }
     }
 
@@ -170,6 +173,7 @@ impl TiramiNode {
             self.mind_agent.clone(),
             self.staking_pool.clone(),
             self.referral_tracker.clone(),
+            self.governance.clone(),
         );
         let addr = self.config.api_socket_addr();
         tracing::info!("API server listening on {}", addr);
@@ -229,6 +233,7 @@ impl TiramiNode {
         let mind_agent_api = self.mind_agent.clone();
         let staking_pool_api = self.staking_pool.clone();
         let referral_tracker_api = self.referral_tracker.clone();
+        let governance_api = self.governance.clone();
         let api_config = self.config.clone();
         tokio::spawn(async move {
             let app = crate::api::create_router_with_services(
@@ -245,6 +250,7 @@ impl TiramiNode {
                 mind_agent_api,
                 staking_pool_api,
                 referral_tracker_api,
+                governance_api,
             );
             let addr = api_config.api_socket_addr();
             if let Ok(listener) = tokio::net::TcpListener::bind(&addr).await {

--- a/crates/tirami-node/src/security_tests.rs
+++ b/crates/tirami-node/src/security_tests.rs
@@ -705,6 +705,7 @@ mod security_tests {
             Arc::new(Mutex::new(None::<tirami_mind::TiramiMindAgent>)),
             Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
             Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
+            Arc::new(Mutex::new(tirami_ledger::GovernanceState::new(0))),
         );
         let _ = state; // suppress unused warning
 

--- a/crates/tirami-sdk/src/client.rs
+++ b/crates/tirami-sdk/src/client.rs
@@ -560,6 +560,73 @@ impl TiramiClient {
     }
 
     // -----------------------------------------------------------------------
+    // Governance
+    // -----------------------------------------------------------------------
+
+    /// `POST /v1/tirami/governance/propose` — Create a governance proposal.
+    pub async fn governance_propose(
+        &self,
+        proposer: &str,
+        kind: &str,
+        name: Option<&str>,
+        new_value: Option<f64>,
+        description: Option<&str>,
+        deadline_ms: u64,
+    ) -> Result<serde_json::Value, SdkError> {
+        let mut body = serde_json::json!({
+            "proposer": proposer,
+            "kind": kind,
+            "deadline_ms": deadline_ms,
+        });
+        if let Some(n) = name {
+            body["name"] = serde_json::json!(n);
+        }
+        if let Some(v) = new_value {
+            body["new_value"] = serde_json::json!(v);
+        }
+        if let Some(d) = description {
+            body["description"] = serde_json::json!(d);
+        }
+        self.post("/v1/tirami/governance/propose", &body).await
+    }
+
+    /// `POST /v1/tirami/governance/vote` — Cast a vote on a governance proposal.
+    pub async fn governance_vote(
+        &self,
+        voter: &str,
+        proposal_id: u64,
+        approve: bool,
+        stake: f64,
+        reputation: f64,
+        epochs_participated: u64,
+    ) -> Result<serde_json::Value, SdkError> {
+        self.post(
+            "/v1/tirami/governance/vote",
+            &serde_json::json!({
+                "voter": voter,
+                "proposal_id": proposal_id,
+                "approve": approve,
+                "stake": stake,
+                "reputation": reputation,
+                "epochs_participated": epochs_participated,
+            }),
+        )
+        .await
+    }
+
+    /// `GET /v1/tirami/governance/proposals` — List active governance proposals.
+    pub async fn governance_proposals(&self) -> Result<serde_json::Value, SdkError> {
+        self.get("/v1/tirami/governance/proposals").await
+    }
+
+    /// `GET /v1/tirami/governance/tally/{id}` — Get tally result for a governance
+    /// proposal.
+    pub async fn governance_tally(&self, proposal_id: u64) -> Result<serde_json::Value, SdkError> {
+        self.get(&format!("/v1/tirami/governance/tally/{}", proposal_id))
+            .await
+    }
+
+    // -----------------------------------------------------------------------
     // Observability / Admin
     // -----------------------------------------------------------------------
 
@@ -833,6 +900,39 @@ mod tests {
         let inner: serde_json::Error = serde_json::from_str::<Balance>("bad").unwrap_err();
         let e = SdkError::Json(inner);
         assert!(e.to_string().contains("JSON"));
+    }
+
+    #[tokio::test]
+    async fn test_governance_propose_builds_request() {
+        let c = TiramiClient::new("http://localhost:3000", Some("tok"));
+        // Will fail to connect, but verifies the method compiles and accepts args
+        let res = c
+            .governance_propose("abc123", "parameter_change", Some("base_rate"), Some(0.05), Some("lower base rate"), 9999)
+            .await;
+        assert!(res.is_err()); // no server running
+    }
+
+    #[tokio::test]
+    async fn test_governance_vote_builds_request() {
+        let c = TiramiClient::new("http://localhost:3000", Some("tok"));
+        let res = c
+            .governance_vote("abc123", 1, true, 100.0, 0.8, 5)
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_governance_proposals_builds_request() {
+        let c = TiramiClient::new("http://localhost:3000", Some("tok"));
+        let res = c.governance_proposals().await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_governance_tally_builds_request() {
+        let c = TiramiClient::new("http://localhost:3000", Some("tok"));
+        let res = c.governance_tally(42).await;
+        assert!(res.is_err());
     }
 
     #[test]

--- a/scripts/verify-impl.sh
+++ b/scripts/verify-impl.sh
@@ -345,6 +345,9 @@ assert "#P13-gov-constants" "Governance constants match §19" \
 assert "#P13-gov-seniority" "Seniority bonuses 1.5 / 2.0" \
   "grep -q '1\\.5' crates/tirami-ledger/src/governance.rs && \
    grep -q '2\\.0' crates/tirami-ledger/src/governance.rs"
+assert "#P13-gov-prom"     "Governance Prometheus gauges (active_proposals, total_votes)" \
+  "grep -q 'tirami_active_proposals' crates/tirami-ledger/src/metrics.rs && \
+   grep -q 'tirami_total_votes' crates/tirami-ledger/src/metrics.rs"
 
 # === Phase 13: Tokenomics API endpoints ===
 assert "#P13-api-supply"    "/v1/tirami/su/supply endpoint registered" \


### PR DESCRIPTION
## Summary
- **4 governance HTTP endpoints**: POST propose, POST vote, GET proposals, GET tally/:id (8 handler tests)
- **2 Prometheus gauges**: tirami_active_proposals, tirami_total_votes with observe_full() (2 tests)
- **4 SDK methods**: governance_propose/vote/proposals/tally (4 tests)
- **4 MCP tools**: governance_propose/vote/proposals/tally for Claude/Cursor
- GovernanceState wired into AppState + ForgeNode

## Metrics
- 785 tests (was 770), 0 failing
- 123/123 verify-impl GREEN (was 122)

## Test plan
- [x] `cargo test --workspace --lib` — 785 pass
- [x] `bash scripts/verify-impl.sh` — 123/123 GREEN
- [x] `cargo check --workspace` — clean