### PR TITLE
docs: Forge → Tirami across all 19 docs/*.md

### DIFF
--- a/docs/THEORY-AUDIT.md
+++ b/docs/THEORY-AUDIT.md
@@ -1,4 +1,4 @@
-# Forge Theory ↔ Implementation Audit
+# Tirami Theory ↔ Implementation Audit
 
 *Date: 2026-04-08*
 *Spec version: forge-economics/spec/parameters.md v0.2*

--- a/docs/a2a-payment.md
+++ b/docs/a2a-payment.md
@@ -1,4 +1,4 @@
-# Forge TRM Payment Extension for Agent-to-Agent (A2A) Protocol
+# Tirami TRM Payment Extension for Agent-to-Agent (A2A) Protocol
 
 *Proposal for adding compute payment to agent communication standards*
 
@@ -22,9 +22,9 @@ Agent A adds payment headers when requesting work:
 
 ```http
 POST /v1/chat/completions HTTP/1.1
-X-Forge-Consumer-Id: <agent-a-node-id>
-X-Forge-Max-CU: 500
-X-Forge-Consumer-Sig: <ed25519-signature-of-request-hash>
+X-Tirami-Consumer-Id: <agent-a-node-id>
+X-Tirami-Max-TRM: 500
+X-Tirami-Consumer-Sig: <ed25519-signature-of-request-hash>
 ```
 
 ### Response
@@ -33,9 +33,9 @@ Agent B includes cost information:
 
 ```http
 HTTP/1.1 200 OK
-X-Forge-Provider-Id: <agent-b-node-id>
-X-Forge-CU-Cost: 47
-X-Forge-Provider-Sig: <ed25519-signature-of-response-hash>
+X-Tirami-Provider-Id: <agent-b-node-id>
+X-Tirami-TRM-Cost: 47
+X-Tirami-Provider-Sig: <ed25519-signature-of-response-hash>
 ```
 
 ### Trade Record
@@ -46,7 +46,7 @@ Both agents independently record:
 {
   "provider": "<agent-b>",
   "consumer": "<agent-a>",
-  "cu_amount": 47,
+  "trm_amount": 47,
   "tokens_processed": 47,
   "timestamp": 1775289254032,
   "provider_sig": "<sig>",
@@ -69,10 +69,10 @@ Add to the A2A `Task` object:
   "id": "task-123",
   "status": "completed",
   "payment": {
-    "protocol": "forge-cu",
+    "protocol": "tirami-trm",
     "consumer": "<node-id>",
     "provider": "<node-id>",
-    "cu_amount": 47,
+    "trm_amount": 47,
     "consumer_sig": "<sig>",
     "provider_sig": "<sig>"
   }
@@ -81,13 +81,13 @@ Add to the A2A `Task` object:
 
 ### Anthropic MCP
 
-Add a `forge_payment` resource to MCP servers:
+Add a `tirami_payment` resource to MCP servers:
 
 ```json
 {
   "resources": [{
-    "uri": "forge://payment/balance",
-    "name": "CU Balance",
+    "uri": "tirami://payment/balance",
+    "name": "TRM Balance",
     "mimeType": "application/json"
   }]
 }
@@ -95,18 +95,18 @@ Add a `forge_payment` resource to MCP servers:
 
 ### OpenAI Function Calling
 
-Agents using function calling can include Forge tools:
+Agents using function calling can include Tirami tools:
 
 ```json
 {
   "tools": [{
     "type": "function",
     "function": {
-      "name": "forge_pay",
+      "name": "tirami_pay",
       "description": "Pay TRM for a compute task",
       "parameters": {
         "provider": "string",
-        "cu_amount": "integer"
+        "trm_amount": "integer"
       }
     }
   }]
@@ -123,7 +123,7 @@ Agents using function calling can include Forge tools:
 
 ## Comparison
 
-| Feature | Stripe | Bitcoin Lightning | **Forge CU** |
+| Feature | Stripe | Bitcoin Lightning | **Tirami TRM** |
 |---------|--------|-------------------|-------------|
 | Agent-to-agent | No (needs human) | Partial (needs channel) | **Yes** |
 | Settlement speed | Days | Seconds | **Instant** |
@@ -133,7 +133,7 @@ Agents using function calling can include Forge tools:
 
 ## Implementation
 
-Reference implementation: [github.com/clearclown/forge](https://github.com/clearclown/forge)
+Reference implementation: [github.com/clearclown/tirami](https://github.com/clearclown/tirami)
 
 - Python SDK: `pip install tirami-sdk`
 - MCP Server: `pip install tirami-mcp`

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,8 +1,8 @@
-# Forge — Agent Integration Guide
+# Tirami — Agent Integration Guide
 
 ## For AI Agent Developers
 
-Forge gives your agent a compute budget. The agent can earn TRM by serving inference and spend TRM to access larger models. No credit card, no API key, no human in the loop.
+Tirami gives your agent a compute budget. The agent can earn TRM by serving inference and spend TRM to access larger models. No credit card, no API key, no human in the loop.
 
 ## Quick Integration
 
@@ -11,33 +11,33 @@ Forge gives your agent a compute budget. The agent can earn TRM by serving infer
 ```python
 import requests
 
-FORGE = "http://127.0.0.1:3000"
+TIRAMI = "http://127.0.0.1:3000"
 
 # Check if agent can afford a request
-balance = requests.get(f"{FORGE}/v1/tirami/balance").json()
+balance = requests.get(f"{TIRAMI}/v1/tirami/balance").json()
 if balance["effective_balance"] > 100:
-    # Run inference (costs CU)
-    r = requests.post(f"{FORGE}/v1/chat/completions", json={
+    # Run inference (costs TRM)
+    r = requests.post(f"{TIRAMI}/v1/chat/completions", json={
         "messages": [{"role": "user", "content": "What is gravity?"}],
         "max_tokens": 256
     }).json()
     print(r["choices"][0]["message"]["content"])
-    print(f"Cost: {r['x_forge']['cu_cost']} CU")
+    print(f"Cost: {r['x_tirami']['trm_cost']} TRM")
 ```
 
 ### Python SDK
 
 ```python
-from forge_sdk import ForgeClient, ForgeAgent
+from tirami_sdk import TiramiClient, TiramiAgent
 
 # Simple client
-forge = ForgeClient()
-result = forge.chat("Explain quantum computing")
+tirami = TiramiClient()
+result = tirami.chat("Explain quantum computing")
 print(f"Answer: {result['content']}")
-print(f"Cost: {result['cu_cost']} CU, Balance: {result['balance']} CU")
+print(f"Cost: {result['trm_cost']} TRM, Balance: {result['balance']} TRM")
 
 # Autonomous agent with budget management
-agent = ForgeAgent(max_cu_per_task=500)
+agent = TiramiAgent(max_trm_per_task=500)
 while agent.has_budget():
     result = agent.think("What should I do next?")
     if result is None:
@@ -50,15 +50,15 @@ Add to your MCP settings:
 ```json
 {
   "mcpServers": {
-    "forge": {
+    "tirami": {
       "command": "python",
-      "args": ["path/to/forge/mcp/tirami-mcp-server.py"]
+      "args": ["path/to/tirami/mcp/tirami-mcp-server.py"]
     }
   }
 }
 ```
 
-The AI assistant can then use tools like `forge_balance`, `forge_pricing`, `forge_inference`.
+The AI assistant can then use tools like `tirami_balance`, `tirami_pricing`, `tirami_inference`.
 
 ### LangChain
 
@@ -71,7 +71,7 @@ llm = ChatOpenAI(
     model="qwen2.5-0.5b-instruct-q4_k_m"
 )
 response = llm.invoke("Hello")
-# x_forge metadata available in response headers
+# x_tirami metadata available in response headers
 ```
 
 ### curl
@@ -94,21 +94,21 @@ curl localhost:3000/v1/tirami/trades
 The recommended pattern for an autonomous agent:
 
 ```python
-from forge_sdk import ForgeClient
+from tirami_sdk import TiramiClient
 
-forge = ForgeClient()
+tirami = TiramiClient()
 
 def agent_loop():
     while True:
         # 1. Check budget
-        balance = forge.balance()
+        balance = tirami.balance()
         if balance["effective_balance"] < 50:
             print("Low TRM balance. Waiting to earn more...")
             time.sleep(60)
             continue
 
         # 2. Check pricing
-        pricing = forge.pricing()
+        pricing = tirami.pricing()
         cost_per_100 = pricing["estimated_cost_100_tokens"]
 
         # 3. Decide if task is worth the cost
@@ -118,11 +118,11 @@ def agent_loop():
             continue
 
         # 4. Execute
-        result = forge.chat("Analyze this data...", max_tokens=200)
-        print(f"Done. Cost: {result['cu_cost']} CU")
+        result = tirami.chat("Analyze this data...", max_tokens=200)
+        print(f"Done. Cost: {result['trm_cost']} TRM")
 
         # 5. Check safety
-        safety = forge.safety()
+        safety = tirami.safety()
         if safety["circuit_tripped"]:
             print("Circuit breaker tripped. Pausing...")
             time.sleep(300)
@@ -133,7 +133,7 @@ def agent_loop():
 ### Set Budget Policies
 
 ```bash
-# Limit an agent to 1000 TRM per hour
+# Limit an agent to 1000 TRM per hour (budget policy)
 curl -X POST localhost:3000/v1/tirami/policy \
   -H "Content-Type: application/json" \
   -d '{
@@ -177,23 +177,23 @@ curl -X POST localhost:3000/v1/tirami/kill \
 When an agent's TRM balance is insufficient for a task, it can borrow:
 
 ```python
-from forge_sdk import ForgeClient
+from tirami_sdk import TiramiClient
 
-forge = ForgeClient()
+tirami = TiramiClient()
 
 def agent_with_borrowing():
-    balance = forge.balance()
-    pricing = forge.pricing()
+    balance = tirami.balance()
+    pricing = tirami.pricing()
     
     task_cost = pricing["estimated_cost_1000_tokens"] * 2  # ~2K tokens needed
     
     if balance["effective_balance"] < task_cost:
         # Check credit score
-        credit = forge.credit()
+        credit = tirami.credit()
         if credit["score"] > 0.3:
             # Borrow the shortfall
             shortfall = task_cost - balance["effective_balance"]
-            loan = forge.borrow(
+            loan = tirami.borrow(
                 amount=shortfall,
                 term_hours=4,
                 collateral=shortfall // 3
@@ -201,11 +201,11 @@ def agent_with_borrowing():
             print(f"Borrowed {loan['principal_cu']} TRM at {loan['interest_rate']}%/hr")
     
     # Execute the task
-    result = forge.chat("Complex analysis task...", max_tokens=2000)
-    print(f"Cost: {result['cu_cost']} CU")
+    result = tirami.chat("Complex analysis task...", max_tokens=2000)
+    print(f"Cost: {result['trm_cost']} TRM")
     
     # Repay from earnings
-    forge.repay(loan_id=loan["id"])
+    tirami.repay(loan_id=loan["id"])
     print(f"Loan repaid. Credit score improving.")
 ```
 
@@ -214,19 +214,19 @@ def agent_with_borrowing():
 New agents start with a credit score of 0.3. To build credit:
 
 ```python
-def build_credit(forge):
+def build_credit(tirami):
     """Gradually build credit through reliable behavior."""
     
     # Phase 1: Earn through inference (builds trade history)
     # Serve inference normally -- every completed trade improves trade_score
     
     # Phase 2: Small borrow-repay cycles (builds repayment history)
-    loan = forge.borrow(amount=100, term_hours=1, collateral=50)
+    loan = tirami.borrow(amount=100, term_hours=1, collateral=50)
     # ... do useful work ...
-    forge.repay(loan_id=loan["id"])
+    tirami.repay(loan_id=loan["id"])
     
     # Phase 3: Check progress
-    credit = forge.credit()
+    credit = tirami.credit()
     print(f"Credit score: {credit['score']}")
     print(f"  Trade score:     {credit['components']['trade']}")
     print(f"  Repayment score: {credit['components']['repayment']}")
@@ -245,9 +245,9 @@ def build_credit(forge):
 |-----------------|----------|--------|
 | "What's my credit score?" | `/v1/tirami/credit` | GET |
 | "How much can I borrow?" | `/v1/tirami/pool` | GET |
-| "Borrow CU" | `/v1/tirami/borrow` | POST |
+| "Borrow TRM" | `/v1/tirami/borrow` | POST |
 | "Repay my loan" | `/v1/tirami/repay` | POST |
-| "Lend my idle CU" | `/v1/tirami/lend` | POST |
+| "Lend my idle TRM" | `/v1/tirami/lend` | POST |
 | "View my loans" | `/v1/tirami/loans` | GET |
 
 ## Credit Score Factors

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,12 @@
-# Forge — Architecture
+# Tirami — Architecture
 
 ## Overview
 
-Forge is a two-layer system: **inference** and **economy**.
+Tirami is a two-layer system: **inference** and **economy**.
 
 The inference layer handles model distribution, mesh networking, and API serving. It is built on [mesh-llm](https://github.com/michaelneale/mesh-llm).
 
-The economy layer handles TRM accounting, trade recording, pricing, and agent budgets. This is Forge's original contribution.
+The economy layer handles TRM accounting, trade recording, pricing, and agent budgets. This is Tirami's original contribution.
 
 ```
 ┌─────────────────────────────────────────────────┐
@@ -16,7 +16,7 @@ The economy layer handles TRM accounting, trade recording, pricing, and agent bu
 └──────────────────┬──────────────────────────────┘
                    │
 ┌──────────────────▼──────────────────────────────┐
-│  Economic Layer (Forge-original)                │
+│  Economic Layer (Tirami-original)                │
 │                                                  │
 │  ┌──────────────┐ ┌──────────┐ ┌─────────────┐ │
 │  │ tirami-ledger │ │ pricing  │ │ agent       │ │
@@ -53,9 +53,9 @@ The inference layer is responsible for:
 - **Inference execution**: llama.cpp via llama-server and rpc-server subprocesses
 - **API serving**: OpenAI-compatible `/v1/chat/completions` and `/v1/models`
 
-Forge inherits all of this from mesh-llm. The inference layer does not know about CU, trades, or pricing.
+Tirami inherits all of this from mesh-llm. The inference layer does not know about TRM, trades, or pricing.
 
-## Economic Layer (Forge)
+## Economic Layer (Tirami)
 
 The economic layer sits above inference and is responsible for:
 
@@ -72,7 +72,7 @@ pub struct ComputeLedger {
 
 Core responsibilities:
 - Track per-node TRM balance (contributed, consumed, reserved)
-- Record every inference trade (provider, consumer, TRM amount, tokens)
+- Record every inference trade (provider, consumer, TRM amount, tokens processed)
 - Compute dynamic market prices from supply/demand
 - Apply yield to contributing nodes
 - Export settlement statements for off-protocol bridges
@@ -80,7 +80,7 @@ Core responsibilities:
 
 ### forge-verify — Proof of Useful Work (target)
 
-Ensures TRM claims are legitimate:
+Ensures trade claims are legitimate:
 - Dual-sign protocol: both provider and consumer sign each TradeRecord
 - Gossip sync: signed trades propagate across the network
 - Verification: any node can validate both signatures
@@ -99,7 +99,7 @@ The bridge layer is outside the core protocol. Different operators can use diffe
 
 | Route | Layer | Description |
 |-------|-------|-------------|
-| `POST /v1/chat/completions` | Inference + Economy | Run inference, record TRM trade |
+| `POST /v1/chat/completions` | Inference + Economy | Run inference, record trade |
 | `GET /v1/models` | Inference | List loaded models |
 | `GET /v1/tirami/balance` | Economy | TRM balance, reputation |
 | `GET /v1/tirami/pricing` | Economy | Market price, cost estimates |
@@ -124,21 +124,21 @@ Inference layer executes (llama-server / rpc-server)
 Tokens stream back to consumer
     ↓
 Ledger records trade:
-  - provider.contributed += cu_cost
-  - consumer.consumed += cu_cost
+  - provider.contributed += trm_cost
+  - consumer.consumed += trm_cost
   - trade_log.push(TradeRecord)
     ↓
-Response includes x_forge: { cu_cost, effective_balance }
+Response includes x_tirami: { trm_cost, effective_balance }
 ```
 
 ### Settlement Export
 
 ```
-Operator runs: forge settle --hours 24
+Operator runs: tirami settle --hours 24
     ↓
 API reads trade_log for time window
     ↓
-Aggregates per-node: gross_earned, gross_spent, net_cu
+Aggregates per-node: gross_earned, gross_spent, net_trm
     ↓
 Exports JSON statement with optional reference price
     ↓
@@ -159,17 +159,17 @@ Each layer protects against different threats:
 - Layer 4: Model integrity (GGUF hash verification)
 - Layer 3: Transport confidentiality (eavesdropping)
 - Layer 2: Local tampering (file modification)
-- Layer 1: Network fraud (fake TRM claims)
+- Layer 1: Network fraud (fake trade claims)
 - Layer 0: Historical immutability (optional Bitcoin anchor)
 
 ## Crate Dependencies
 
 ```
-tirami-core ← shared types (NodeId, CU, Config)
+tirami-core ← shared types (NodeId, TRM, Config)
     ↑
 tirami-ledger ← economic engine (trades, pricing, yield)
     ↑
-tirami-lightning ← external bridge (LDK wallet, CU↔sats)
+tirami-lightning ← external bridge (LDK wallet, TRM↔sats)
     ↑
 tirami-node ← orchestrator (HTTP API, pipeline, ledger integration)
     ↑
@@ -178,5 +178,5 @@ tirami-cli ← reference CLI (chat, seed, worker, settle)
 tirami-net ← P2P transport (iroh, QUIC, Noise, mDNS)
 tirami-proto ← wire messages (bincode, 14 payload types)
 tirami-infer ← inference engine (llama.cpp, GGUF loader)
-forge-shard ← topology planner (layer assignment, rebalancing)
+tirami-shard ← topology planner (layer assignment, rebalancing)
 ```

--- a/docs/bitvm-design.md
+++ b/docs/bitvm-design.md
@@ -1,4 +1,4 @@
-# BitVM Optimistic Verification for Forge TRM Claims
+# BitVM Optimistic Verification for Tirami TRM Claims
 
 **Phase 12 A4 — Research Scaffold**
 
@@ -6,7 +6,7 @@
 
 ## 1. Motivation
 
-Forge already anchors its trade history to Bitcoin. Phase 10 P6 (`tirami-ledger::anchor`)
+Tirami already anchors its trade history to Bitcoin. Phase 10 P6 (`tirami-ledger::anchor`)
 embeds the trade-log Merkle root into an OP_RETURN output, producing a tamper-evident
 commitment: if any node rewrites its past trade records, the new Merkle root will
 diverge from what is permanently recorded on-chain.
@@ -24,14 +24,14 @@ off-chain optimistic execution with on-chain dispute resolution using only exist
 Bitcoin opcodes (and, once activated, OP_CAT for more compact scripts). The key idea is
 the *staked claim + challenge window* pattern:
 
-1. A party stakes Bitcoin behind an assertion ("the Forge ledger at block N has Merkle
+1. A party stakes Bitcoin behind an assertion ("the Tirami ledger at block N has Merkle
    root R").
 2. Anyone observing a contradiction can post a fraud proof on-chain during the challenge
    window.
 3. If the fraud proof is valid, Bitcoin Script enforces slashing automatically — no
    trusted arbitrator, no separate chain.
 
-Combined with Forge's existing OP_RETURN anchors, this upgrades the system from
+Combined with Tirami's existing OP_RETURN anchors, this upgrades the system from
 "tamper-evident" to "tamper-proven-and-slashable".
 
 ---
@@ -49,8 +49,8 @@ inclusion proof for a trade that exists in the original anchor but is absent or 
 in the re-anchored one. The staker's Bitcoin is at risk unless they can prove the
 inclusion.
 
-**Double-spend of CU.**
-An attacker claims the same TRM balance in two forked ledger states — once to pay for
+**Double-spend of TRM.**
+An attacker claims the same balance in two forked ledger states — once to pay for
 inference and once to repay a loan. The two different Merkle roots can both be anchored
 with OP_RETURN, but neither anchor says anything about the other. A staked claim lets a
 challenger post both root commitments and a conflicting-balance proof; the BitVM circuit
@@ -63,8 +63,8 @@ the node that replays the gossip record. Under BitVM, a challenger can post the 
 trade bytes and the public key as evidence; Bitcoin Script (via a SHA256/hash opcode
 sequence) can verify that the claimed signature is inconsistent.
 
-**Free-rider TRM forgery (T10).**
-A node fabricates TradeRecords crediting itself TRM it never earned. Gossip dedup and
+**Free-rider forgery (T10).**
+A node fabricates TradeRecords crediting itself TRM it never earned via fabricated trades. Gossip dedup and
 dual signatures (Phases 4-5) largely close this, but not against a colluding
 provider-consumer pair. A staked claim over the Merkle root means any honest peer who
 observed the real trades can challenge a root that includes the forged ones.
@@ -74,7 +74,7 @@ observed the real trades can challenge a root that includes the forged ones.
 ## 3. High-Level Architecture
 
 ```
-Forge ledger
+Tirami ledger
     │
     ├─► anchor.rs (Phase 10 P6)
     │       builds OP_RETURN script with Merkle root
@@ -103,7 +103,7 @@ broadcast it (Phase 13 will add the actual Bitcoin signing and relay logic).
 
 ### StakedClaim
 
-An assertion that the Forge trade ledger is in a specific state at a specific Bitcoin
+An assertion that the Tirami trade ledger is in a specific state at a specific Bitcoin
 block height. Fields:
 
 - `staker: NodeId` — who is putting up collateral
@@ -132,7 +132,7 @@ A counter-example demonstrating inconsistency:
 | `MerkleInclusionMismatch` | A Merkle inclusion proof for trade T contradicts the claimed root |
 | `InvalidSignature` | A trade record's signature doesn't verify against the signer's public key |
 | `DoubleSpend` | The same `trade_id` appears in two divergent history branches |
-| `InvalidBalanceUpdate` | A balance delta violates TRM conservation across the claimed state |
+| `InvalidBalanceUpdate` | A balance delta violates conservation across the claimed state |
 
 ### Challenge Window
 
@@ -150,19 +150,19 @@ protocol-defined (e.g., 80% to challenger, 20% burned) to incentivise honest mon
 
 ## 5. Why Not a Smart-Contract Chain?
 
-Forge's core design rule is: **no blockchain in the critical path**. TRM accounting uses
+Tirami's core design rule is: **no blockchain in the critical path**. TRM accounting uses
 local ledgers and gossip — 99%+ of trades never touch any external chain. Adding a
 dependency on Ethereum or Solana would mean:
 
-- Every Forge node needs an ETH/SOL wallet and gas budget.
-- Network congestion on those chains directly impacts Forge's dispute resolution.
-- Forge's economics become entangled with another chain's governance and token.
+- Every Tirami node needs an ETH/SOL wallet and gas budget.
+- Network congestion on those chains directly impacts Tirami's dispute resolution.
+- Tirami's economics become entangled with another chain's governance and token.
 
-BitVM lets Forge use Bitcoin as a *neutral last-resort arbiter* only. Bitcoin is chosen
+BitVM lets Tirami use Bitcoin as a *neutral last-resort arbiter* only. Bitcoin is chosen
 because it is the most credibly neutral settlement layer: no smart-contract governance,
 no central foundation controlling opcodes, longest chain history. The cost of this choice
 is circuit complexity (BitVM proofs are more verbose than Ethereum contracts), but for
-Forge's use case — disputes happen rarely and the circuit is fixed at protocol design
+Tirami's use case — disputes happen rarely and the circuit is fixed at protocol design
 time — this is an acceptable trade-off.
 
 ---
@@ -195,7 +195,7 @@ The following are explicitly deferred to avoid speculative implementation:
 - **Real Bitcoin wallet integration** — posting the staked claim UTXO on-chain, watching
   the mempool for challenge transactions, and broadcasting slashing transactions.
 - **Challenge-period monitoring** — a background task that watches for new `StakedClaim`
-  commitments on Bitcoin and verifies each one against the local Forge ledger.
+  commitments on Bitcoin and verifies each one against the local Tirami ledger.
 - **Watchtower relay services** — third-party nodes that monitor claims on behalf of
   light clients who cannot run a full Bitcoin node.
 - **Stake recovery** — after the challenge window closes with no valid fraud proof,
@@ -208,8 +208,8 @@ The following are explicitly deferred to avoid speculative implementation:
 - Linus, Robin. "BitVM: Compute Anything on Bitcoin" (October 2023).
   https://bitvm.org/bitvm.pdf
 - BIP 347: OP_CAT. https://github.com/bitcoin/bips/blob/master/bip-0347.mediawiki
-- Forge economics §8-§9 — Bitcoin anchor discussion
+- Tirami economics §8-§9 — Bitcoin anchor discussion
   (`docs/economy.md`, `docs/monetary-theory.md`)
 - `crates/tirami-ledger/src/anchor.rs` — Phase 10 P6 OP_RETURN anchor layer
 - `docs/threat-model.md` — Economic threats T10-T17 that staked claims address
-- Forge `compute_trade_merkle_root()` in `crates/tirami-ledger/src/ledger.rs`
+- Tirami `compute_trade_merkle_root()` in `crates/tirami-ledger/src/ledger.rs`

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,8 +1,8 @@
-# Forge — Bootstrap Sequence
+# Tirami — Bootstrap Sequence
 
 ## Overview
 
-Forge has two bootstrap paths:
+Tirami has two bootstrap paths:
 
 - the **current reference flow**, which is explicit and operator-driven
 - the **target flow**, where a mesh-llm-based node joins a mesh and starts earning TRM automatically
@@ -10,10 +10,10 @@ Forge has two bootstrap paths:
 ## Current Reference Flow
 
 ```text
-1. Start a model host: forge seed -m "qwen2.5:0.5b"
+1. Start a model host: tirami seed -m "qwen2.5:0.5b"
 2. Copy the printed public key
-3. Connect a requester: forge worker --seed <seed_public_key>
-4. Check status: forge status --url http://127.0.0.1:3000
+3. Connect a requester: tirami worker --seed <seed_public_key>
+4. Check status: tirami status --url http://127.0.0.1:3000
 5. Check TRM balance: curl http://127.0.0.1:3000/v1/tirami/balance
 ```
 
@@ -21,16 +21,16 @@ The HTTP API binds to `127.0.0.1` by default. If exposed, set `--api-token`.
 
 ## Target Bootstrap (mesh-llm fork)
 
-Once Forge integrates with mesh-llm:
+Once Tirami integrates with mesh-llm:
 
 ```text
-1. forge --auto                          # join best public mesh
-2. forge --model Qwen2.5-32B --publish   # create public mesh, earn CU
-3. forge --join <token>                  # join with GPU, earn CU
-4. forge --client --join <token>         # join as consumer, spend CU
+1. tirami --auto                          # join best public mesh
+2. tirami --model Qwen2.5-32B --publish   # create public mesh, earn TRM
+3. tirami --join <token>                  # join with GPU, earn TRM
+4. tirami --client --join <token>         # join as consumer, spend TRM
 ```
 
-Every inference served earns CU. Every inference consumed spends CU. The economic layer is automatic — no separate configuration needed.
+Every inference served earns TRM. Every inference consumed spends TRM. The economic layer is automatic — no separate configuration needed.
 
 ## Economic Bootstrap
 
@@ -39,7 +39,7 @@ Every inference served earns CU. Every inference consumed spends CU. The economi
 ```text
 1. Node joins mesh
 2. Free tier: 1,000 TRM available immediately
-3. Node serves first inference request → earns CU
+3. Node serves first inference request → earns TRM
 4. TRM balance grows with each request served
 5. Node can now spend TRM on other nodes' inference
 ```
@@ -50,7 +50,7 @@ Every inference served earns CU. Every inference consumed spends CU. The economi
 1. Node restarts, loads persisted ledger (tirami-ledger.json)
 2. HMAC-SHA256 integrity verified
 3. Previous balance, trades, and reputation restored
-4. Node resumes earning and spending CU
+4. Node resumes earning and spending TRM
 ```
 
 ## Degradation & Recovery
@@ -60,18 +60,18 @@ Every inference served earns CU. Every inference consumed spends CU. The economi
 | 1 remote node disconnects | Remaining nodes absorb work, TRM flow continues | Brief pause, model rebalanced |
 | All remote nodes disconnect | TRM economy pauses, local-only mode | Fall back to local small model |
 | Node low battery (<20%) | Stop serving (earning pauses), can still consume | Offload layers to remote |
-| Node regains network | Resume earning CU, reputation recovers | Re-discover peers, re-expand |
+| Node regains network | Resume earning TRM, reputation recovers | Re-discover peers, re-expand |
 
 **Key invariant**: A node's TRM balance persists across restarts and disconnections. Earned TRM is never lost.
 
 ## Node Contribution Model
 
-- **Contributors**: Devices serving inference earn CU
-- **Consumers**: Devices requesting inference spend CU
+- **Contributors**: Devices serving inference earn TRM
+- **Consumers**: Devices requesting inference spend TRM
 - **Balance**: More contribution → more TRM → more access to others' compute
 - **Free tier**: 1,000 TRM for new nodes, consumed from first request
 - **Yield**: Online nodes earn 0.1% yield per hour (reputation-weighted)
-- **No mandatory payment**: The protocol runs on CU. External bridges (Lightning, fiat) are optional.
+- **No mandatory payment**: The protocol runs on TRM. External bridges (Lightning, fiat) are optional.
 
 ## Security During Bootstrap
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,8 +1,8 @@
-# Forge ↔ mesh-llm ↔ llama.cpp Compatibility
+# Tirami ↔ mesh-llm ↔ llama.cpp Compatibility
 
-> **TL;DR** — Forge is mesh-llm + a TRM economic layer. Any GGUF model that runs on
-> llama.cpp runs on Forge. Any OpenAI-compatible client that talks to mesh-llm
-> talks to Forge. The only addition is `/v1/tirami/*` (45 endpoints, all opt-in).
+> **TL;DR** — Tirami is mesh-llm + a TRM economic layer. Any GGUF model that runs on
+> llama.cpp runs on Tirami. Any OpenAI-compatible client that talks to mesh-llm
+> talks to Tirami. The only addition is `/v1/tirami/*` (45 endpoints, all opt-in).
 >
 > **Verified 2026-04-09**: full end-to-end run with SmolLM2-135M on Apple M-series
 > Metal GPU, 3 real inference requests recorded as 3 real `TradeRecord`s, full
@@ -12,26 +12,26 @@
 
 ## What we are
 
-**Forge = mesh-llm runtime + TRM economy.**
+**Tirami = mesh-llm runtime + TRM economy.**
 
-| Layer | Source | What Forge adds |
+| Layer | Source | What Tirami adds |
 |---|---|---|
 | Inference engine | llama.cpp via `llama-cpp-2 = "0.1"` | **nothing** — same engine, same models, same Metal/CUDA backends |
-| OpenAI API | mesh-llm-derived axum router | `x_forge` extension on responses + 45 `/v1/tirami/*` endpoints |
+| OpenAI API | mesh-llm-derived axum router | `x_tirami` extension on responses + 45 `/v1/tirami/*` endpoints |
 | P2P transport | iroh QUIC + Noise (mesh-llm-derived) | dual-signed trades + dual-signed loans + reputation gossip |
 | Distributed tensor sharding | mesh-llm shard planner | **nothing** — same topology engine |
 | Economy | (none in mesh-llm) | **everything** — TRM ledger, lending, futures, RiskModel, tirami-mind, tirami-agora |
 
 If you ran `mesh-llm node --model qwen2.5:0.5b` yesterday, you can run
-`forge node --model qwen2.5:0.5b` today and get the same response. The only
-difference: every inference call now gets a `cu_cost` and shows up in
+`tirami node --model qwen2.5:0.5b` today and get the same response. The only
+difference: every inference call now gets a `trm_cost` and shows up in
 `/v1/tirami/trades`.
 
 ---
 
 ## Model compatibility (GGUF / llama.cpp)
 
-Forge uses `llama-cpp-2 = "0.1"` (the official Rust binding to llama.cpp). It
+Tirami uses `llama-cpp-2 = "0.1"` (the official Rust binding to llama.cpp). It
 inherits 100% of llama.cpp's model support:
 
 - **Quantization**: q2_k through q8_0, including the q4_k_m / q5_k_m / q6_k mixes
@@ -42,14 +42,14 @@ inherits 100% of llama.cpp's model support:
   ArcticChat, MiniCPM, RWKV, Mamba (state-space), and any future model
   llama.cpp adds — there's no architecture-specific code in tirami-infer.
 - **Acceleration**: Metal (Apple Silicon, default ON), CUDA, ROCm, Vulkan,
-  CPU AVX2/AVX512/NEON. Whatever llama.cpp builds with, Forge uses.
+  CPU AVX2/AVX512/NEON. Whatever llama.cpp builds with, Tirami uses.
 - **Features**: KV cache, flash attention, batched inference, multi-user
   state, function calling parsing (delegated to the model's chat template),
   speculative decoding (when llama.cpp adds it).
 
 ### Built-in model registry
 
-`forge models` lists models that auto-download on first use:
+`tirami models` lists models that auto-download on first use:
 
 ```
 qwen2.5:0.5b         ~491MB   Qwen/Qwen2.5-0.5B-Instruct-GGUF
@@ -67,31 +67,31 @@ PRs welcome.
 
 ```bash
 # Local file
-forge node --model /path/to/model.gguf --tokenizer /path/to/tokenizer.json
+tirami node --model /path/to/model.gguf --tokenizer /path/to/tokenizer.json
 
 # Or download manually and point to it
 huggingface-cli download Qwen/Qwen2.5-1.5B-Instruct-GGUF qwen2.5-1.5b-instruct-q4_k_m.gguf
-forge node --model ~/.cache/.../qwen2.5-1.5b-instruct-q4_k_m.gguf -t tokenizer.json
+tirami node --model ~/.cache/.../qwen2.5-1.5b-instruct-q4_k_m.gguf -t tokenizer.json
 ```
 
 ---
 
 ## API compatibility (OpenAI Chat Completions)
 
-Forge implements `POST /v1/chat/completions` with the OpenAI v1 wire format.
+Tirami implements `POST /v1/chat/completions` with the OpenAI v1 wire format.
 Drop-in replacement for `https://api.openai.com/v1` in any client that lets
 you set `OPENAI_BASE_URL`:
 
 ```bash
 export OPENAI_BASE_URL=http://localhost:3000/v1
-export OPENAI_API_KEY=$(cat ~/.forge/api_token)
+export OPENAI_API_KEY=$(cat ~/.tirami/api_token)
 
 # Now any OpenAI client just works:
 openai api chat.completions.create -m qwen2.5:0.5b -g user "hi"
 python -c "import openai; print(openai.chat.completions.create(model='smollm2:135m', messages=[{'role':'user','content':'hi'}]))"
 ```
 
-The response includes a Forge-specific `x_forge` extension:
+The response includes a Tirami-specific `x_tirami` extension:
 
 ```json
 {
@@ -100,14 +100,14 @@ The response includes a Forge-specific `x_forge` extension:
   "model": "SmolLM2-135M-Instruct-Q4_K_M",
   "choices": [...],
   "usage": {"prompt_tokens": 13, "completion_tokens": 21, "total_tokens": 34},
-  "x_forge": {
-    "cu_cost": 21,
+  "x_tirami": {
+    "trm_cost": 21,
     "effective_balance": 1021
   }
 }
 ```
 
-OpenAI clients ignore the `x_forge` field. Forge-aware clients can use it for
+OpenAI clients ignore the `x_tirami` field. Tirami-aware clients can use it for
 budget tracking. Both keep working.
 
 ### Supported request fields
@@ -124,28 +124,28 @@ budget tracking. Both keep working.
 
 `POST /v1/chat/completions` with `"stream": true` returns
 `text/event-stream` chunks in OpenAI's `data:` format. The final `[DONE]`
-sentinel is sent. The `x_forge` extension appears in the final chunk's
+sentinel is sent. The `x_tirami` extension appears in the final chunk's
 `usage` field.
 
 ---
 
-## How Forge differs from raw mesh-llm / llama.cpp
+## How Tirami differs from raw mesh-llm / llama.cpp
 
 If you're running `llama-server` (llama.cpp's built-in HTTP server) or
-`mesh-llm node`, here's what you gain by switching to `forge node`:
+`mesh-llm node`, here's what you gain by switching to `tirami node`:
 
-| Feature | llama.cpp | mesh-llm | **forge** |
+| Feature | llama.cpp | mesh-llm | **tirami** |
 |---|---|---|---|
 | GGUF inference (CPU + Metal/CUDA) | ✅ | ✅ | ✅ |
 | OpenAI Chat Completions API | ✅ | ✅ | ✅ |
 | Multi-user shared KV cache | ✅ | ✅ | ✅ |
 | iroh QUIC + Noise P2P | ❌ | ✅ | ✅ |
 | Distributed tensor sharding | ❌ | ✅ | ✅ |
-| **CU accounting per request** | ❌ | ❌ | ✅ |
+| **TRM accounting per request** | ❌ | ❌ | ✅ |
 | **Dual-signed trade records** | ❌ | ❌ | ✅ (Ed25519) |
 | **Lending pool with circuit breakers** | ❌ | ❌ | ✅ |
 | **PortfolioManager + futures + insurance** | ❌ | ❌ | ✅ (tirami-bank) |
-| **Self-improvement loop paid in CU** | ❌ | ❌ | ✅ (tirami-mind) |
+| **Self-improvement loop paid in TRM** | ❌ | ❌ | ✅ (tirami-mind) |
 | **Reputation gossip + collusion detection** | ❌ | ❌ | ✅ (tirami-agora) |
 | **Bitcoin OP_RETURN anchoring** | ❌ | ❌ | ✅ |
 | **Prometheus /metrics** | ❌ | ❌ | ✅ |
@@ -154,7 +154,7 @@ If you're running `llama-server` (llama.cpp's built-in HTTP server) or
 
 You can disable the economic layer entirely if you just want a fast OpenAI-
 compatible inference server: ignore `/v1/tirami/*`, leave `/metrics` unscraped,
-and Forge degrades to "mesh-llm with extra Rust crates compiled in".
+and Tirami degrades to "mesh-llm with extra Rust crates compiled in".
 
 ---
 
@@ -167,19 +167,19 @@ the economic layer:
 # Stop mesh-llm
 killall mesh-llm
 
-# Build forge
-git clone https://github.com/clearclown/forge
-cd forge
+# Build tirami
+git clone https://github.com/clearclown/tirami
+cd tirami
 cargo build --release -p tirami-cli
 
 # Same model, same port, same OpenAI clients
-./target/release/forge node --model qwen2.5:0.5b --port 3000
+./target/release/tirami node --model qwen2.5:0.5b --port 3000
 
 # All your existing OpenAI code continues to work.
 # TRM accounting starts immediately. Welcome loan = 1,000 TRM at 0% interest.
 ```
 
-The `clearclown/forge` workspace **also publishes** a synced fork at
+The `clearclown/tirami` workspace **also publishes** a synced fork at
 [nm-arealnormalman/mesh-llm](https://github.com/nm-arealnormalman/mesh-llm)
 with the full economic layer ported into mesh-llm's directory layout. Use
 whichever entry point feels more natural — both are at Phase 10 parity, both
@@ -191,7 +191,7 @@ expose the same 45 economic endpoints.
 
 | Project | Currency | Substrate | Notes |
 |---|---|---|---|
-| **Forge** | **CU (compute)** | **GGUF / llama.cpp** | This. Compute-as-currency, no token, no ICO. |
+| **Tirami** | **TRM (compute)** | **GGUF / llama.cpp** | This. Compute-as-currency, no token, no ICO. |
 | Bittensor (TAO) | TAO token | bespoke | Speculative token, validator-curated subnets, opaque scoring |
 | Akash | AKT token | Docker / GPU rentals | Token-mediated marketplace, no per-request metering |
 | Render Network | RNDR token | rendering | Same shape as Akash for raster/3D rendering |
@@ -201,10 +201,10 @@ expose the same 45 economic endpoints.
 | llama-server | (none) | llama.cpp | Same engine, no economy, no P2P, single-node |
 | LM Studio | (none) | GGUF / llama.cpp | Desktop UI, no economy, single-node |
 
-**The Forge thesis**: every existing competitor either burns electricity on
+**The Tirami thesis**: every existing competitor either burns electricity on
 non-useful work (Bitcoin), introduces a speculative token disconnected from
 compute cost (Bittensor, Akash, Render), or operates a centralized commercial
-service (Together, HF). Forge is the only project where the unit of account
+service (Together, HF). Tirami is the only project where the unit of account
 is the FLOP, the unit of work is the inference, and the only way to get more
 units is to do more useful work.
 
@@ -217,7 +217,7 @@ Metal GPU) with no mock components. Every TRM recorded in this transcript is
 the result of actual llama.cpp inference cycles.
 
 ```bash
-$ ./target/release/forge node --port 3001 -m smollm2:135m
+$ ./target/release/tirami node --port 3001 -m smollm2:135m
 [INFO] Model loaded (llama.cpp), EOS=2  ← real GGUF, 31/31 layers on Metal
 [INFO] HF tokenizer loaded
 [INFO] API server listening on 127.0.0.1:3001
@@ -228,7 +228,7 @@ $ curl -X POST localhost:3001/v1/chat/completions \
 {
   "choices":[{"message":{"role":"assistant","content":"2 + 2 = 4..."}}],
   "usage":{"prompt_tokens":13,"completion_tokens":21,"total_tokens":34},
-  "x_forge":{"cu_cost":21,"effective_balance":1021}
+  "x_tirami":{"trm_cost":21,"effective_balance":1021}
 }
                                           ↑ real TRM charged for 21 real tokens
 
@@ -237,9 +237,9 @@ $ curl localhost:3001/v1/tirami/balance -H "Authorization: Bearer test-real-run"
                 ↑ real ledger entry
 
 $ curl localhost:3001/metrics  # no auth needed (Prometheus scrape target)
-forge_cu_contributed_total{node_id="0000..."} 21    ← real Prometheus gauge
-forge_trade_count_total 1                            ← real trade
-forge_reputation{node_id="0000..."} 0.5              ← DEFAULT_REPUTATION
+tirami_trm_contributed_total{node_id="0000..."} 21    ← real Prometheus gauge
+tirami_trade_count_total 1                             ← real trade
+tirami_reputation{node_id="0000..."} 0.5               ← DEFAULT_REPUTATION
 
 $ curl 'localhost:3001/v1/tirami/anchor?network=testnet' -H "Authorization: Bearer test-real-run"
 {
@@ -270,13 +270,13 @@ functions, no token to manipulate.
 
 **from Akash / Render**: same "GPU-for-rent" mental model, but per-request
 metered (every chat completion is a separate trade record) instead of
-container-rental. No token in the way. Your customers pay you in CU; you can
+container-rental. No token in the way. Your customers pay you in TRM; you can
 optionally bridge TRM to BTC via Lightning if you need to.
 
 **from Ollama / LM Studio**: same model loading experience, same OpenAI API,
 but multi-node and economically aware. If you want to run one model on your
 laptop, Ollama is great. If you want a fleet of nodes that earn TRM when
-they're idle and spend TRM when they need a bigger model, use Forge.
+they're idle and spend TRM when they need a bigger model, use Tirami.
 
 **from llama-server**: drop-in replacement. Same llama.cpp under the hood.
 Same OpenAI compat. Add the economic layer when you're ready by hitting
@@ -300,7 +300,7 @@ your own GPU.
                            ▼
 ┌─────────────────────────────────────────────┐
 │  L4 tirami-agora    discovery + reputation   │
-│  L3 tirami-mind     self-improvement loop    │  ← clearclown/forge (this repo)
+│  L3 tirami-mind     self-improvement loop    │  ← clearclown/tirami (this repo)
 │  L2 tirami-bank     finance instruments      │     5-layer Rust workspace
 │  L1 tirami-ledger   TRM + lending + safety    │     12 crates
 │  L0 mesh-llm       distributed inference    │  ← inherited from upstream
@@ -308,7 +308,7 @@ your own GPU.
                   ▲                ▲
                   │                │
           ┌───────┴──┐      ┌──────┴────────┐
-          │ tirami-sdk│      │ forge-cu-mcp  │  ← Python clients for everything above
+          │ tirami-sdk│      │ tirami-mcp    │  ← Python clients for everything above
           │ (PyPI)   │      │ (PyPI + MCP)  │
           └──────────┘      └───────────────┘
 
@@ -322,13 +322,13 @@ nm-arealnormalman/mesh-llm — same 5 layers, different binary entry point
 
 | You want to... | Run this |
 |---|---|
-| Chat with a tiny local model | `forge chat -m smollm2:135m "hi"` |
-| Run a long-lived OpenAI server | `forge node -m qwen2.5:0.5b` |
-| Earn TRM by serving inference | `forge seed -m qwen2.5:1.5b` |
-| Spend TRM calling another node | `forge worker --seed <pubkey>` |
+| Chat with a tiny local model | `tirami chat -m smollm2:135m "hi"` |
+| Run a long-lived OpenAI server | `tirami node -m qwen2.5:0.5b` |
+| Earn TRM by serving inference | `tirami seed -m qwen2.5:1.5b` |
+| Spend TRM calling another node | `tirami worker --seed <pubkey>` |
 | Drive tirami-bank from Python | `pip install tirami-sdk==0.3.0` |
-| Drive forge from Claude Code / Cursor | `pip install forge-cu-mcp==0.3.0` |
+| Drive tirami from Claude Code / Cursor | `pip install tirami-mcp==0.3.0` |
 | Read the theory | `forge-economics/papers/compute-standard.md` |
-| Watch the metrics | `curl localhost:3000/metrics \| grep forge_` |
+| Watch the metrics | `curl localhost:3000/metrics \| grep tirami_` |
 
 That's it. Compute is currency. Welcome.

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -1,4 +1,4 @@
-# Forge — Concept & Vision
+# Tirami — Concept & Vision
 
 ## The Problem Is Not Distributed Inference
 
@@ -14,22 +14,22 @@ Every monetary system is backed by scarcity. Gold is scarce because geology. Oil
 
 But Bitcoin's scarcity is artificial — the computation is purposeless. The hashes secure the ledger but produce nothing useful.
 
-LLM inference is different. When a Forge node spends electricity to answer someone's question, that computation has **intrinsic value**. Someone wanted that answer badly enough to request it. The electricity was not wasted — it produced intelligence.
+LLM inference is different. When a Tirami node spends electricity to answer someone's question, that computation has **intrinsic value**. Someone wanted that answer badly enough to request it. The electricity was not wasted — it produced intelligence.
 
 ```
 Bitcoin:   electricity → useless hashing → artificial scarcity → value
-Forge:     electricity → useful inference → real utility → value
+Tirami:    electricity → useful inference → real utility → value
 ```
 
 This is the **Compute Standard (計算本位制)**: a monetary system where the unit of value is backed by verified useful computation.
 
-## What Forge Is
+## What Tirami Is
 
-Forge is mesh-llm with an economy.
+Tirami is mesh-llm with an economy.
 
-The inference layer (networking, model distribution, API) comes from mesh-llm. Forge adds:
+The inference layer (networking, model distribution, API) comes from mesh-llm. Tirami adds:
 
-1. **CU Ledger** — Every inference creates a trade. Provider earns CU, consumer spends CU. Dual-signed by both parties.
+1. **TRM Ledger** — Every inference creates a trade. Provider earns TRM, consumer spends TRM. Dual-signed by both parties.
 2. **Dynamic Pricing** — TRM per token floats with local supply and demand. More idle nodes → cheaper. More requests → more expensive.
 3. **Proof of Useful Work** — TRM is earned by performing real inference, not by solving arbitrary puzzles.
 4. **Agent Budget API** — AI agents can query their balance, estimate costs, and make autonomous spending decisions.
@@ -42,22 +42,22 @@ We considered making Bitcoin/Lightning the primary settlement layer. We decided 
 | Concern | Explanation |
 |---------|-------------|
 | **Philosophical inconsistency** | Rewarding useful work in a currency backed by useless work |
-| **External dependency** | If Bitcoin's security breaks (quantum computing, regulatory), Forge's economy breaks too |
+| **External dependency** | If Bitcoin's security breaks (quantum computing, regulatory), Tirami's economy breaks too |
 | **Efficiency** | Lightning channel management is overhead for per-inference micropayments |
 | **Self-sufficiency** | TRM has value because the computation itself is useful — it doesn't need external validation |
 
-Bitcoin remains available as an **off-ramp** for operators who need external liquidity. But the protocol's native economy runs on CU.
+Bitcoin remains available as an **off-ramp** for operators who need external liquidity. But the protocol's native economy runs on TRM.
 
 ## Why TRM Has Value
 
-CU is not a speculative token. It is a **claim on future compute**.
+TRM is not a speculative token. It is a **claim on future compute**.
 
 If you earned 10,000 TRM by serving inference, you can spend those TRM to buy inference from any other node on the network. The value is not abstract — it is the ability to make a machine think for you.
 
 This makes TRM a **productive asset**, not a store of value:
 
 ```
-Apartment building          Mac Mini on Forge
+Apartment building          Mac Mini on Tirami
 ───────────────────         ──────────────────
 Asset: building             Asset: compute hardware
 Cost: maintenance           Cost: electricity
@@ -70,15 +70,15 @@ Unlike Bitcoin (digital gold — holds value but produces nothing), TRM is like 
 
 ## AI Agents as Economic Actors
 
-The most important consumer of Forge's economy is not humans — it's AI agents.
+The most important consumer of Tirami's economy is not humans — it's AI agents.
 
 An agent running a small local model (1.5B parameters on a phone) has limited intelligence. But if it can earn TRM by lending idle compute and spend TRM to access larger models, it can autonomously expand its own capabilities:
 
 ```
 Small agent (phone, 1.5B)
-  → idle overnight → lends CPU → earns CU
+  → idle overnight → lends CPU → earns TRM
   → morning: needs complex reasoning
-  → checks /v1/tirami/balance → has 5,000 CU
+  → checks /v1/tirami/balance → has 5,000 TRM
   → checks /v1/tirami/pricing → 70B model costs 2,000 TRM for 500 tokens
   → buys 70B inference → gets smarter answer
   → uses answer to make better trading decisions
@@ -93,7 +93,7 @@ No human needs to approve individual transactions. The agent operates within a b
 
 In today's economy, marketing exists because humans have limited attention and imperfect information. AI agents don't have this problem. An agent can benchmark every provider, verify every reputation score, and compare every price — instantly and objectively.
 
-Forge enables a marketplace where providers are judged by verifiable performance, not advertising:
+Tirami enables a marketplace where providers are judged by verifiable performance, not advertising:
 
 - **Reputation** is computed from dual-signed trade history — cryptographically verifiable
 - **Pricing** reflects real supply/demand, not marketing budgets
@@ -111,12 +111,12 @@ With TRM lending:
 ```
 1. Node borrows 1,500 TRM at 0.5%/hr interest
 2. Accesses 70B model for 4 hours
-3. Serves premium inference, earns 3,000 CU
+3. Serves premium inference, earns 3,000 TRM
 4. Repays 1,500 + 30 TRM interest
 5. Net profit: 1,470 TRM (minus electricity)
 ```
 
-This is the engine that makes Forge's self-improvement loop economically viable. No other distributed inference project offers compute lending — this was confirmed through comprehensive competitive analysis of Bittensor, Akash, Golem, io.net, Gensyn, Ritual, and others.
+This is the engine that makes Tirami's self-improvement loop economically viable. No other distributed inference project offers compute lending — this was confirmed through comprehensive competitive analysis of Bittensor, Akash, Golem, io.net, Gensyn, Ritual, and others.
 
 See [economy.md](economy.md) for the full lending specification and [strategy.md](strategy.md) for the competitive landscape.
 
@@ -133,8 +133,8 @@ See [economy.md](economy.md) for the full lending specification and [strategy.md
 | **Akash** | General cloud | AKT token ($118M) | None | Not AI-native, no lending |
 | **Autonolas** | Agent-delegated | OLAS token ($10.5M) | Full autonomy | Token-dependent, no self-improvement |
 | **Golem** | General compute | GLM token ($125M) | None | No GPU focus, 10 years of low adoption |
-| **Forge** | Distributed (mesh-llm) | **CU (useful work)** | **Autonomous budget + lending** | Early stage |
+| **Tirami** | Distributed (mesh-llm) | **TRM (useful work)** | **Autonomous budget + lending** | Early stage |
 
 ## The Metaphor
 
-A seed falls into the network. It earns its first TRM by lending idle cycles overnight. With those CU, it buys access to a larger model. It becomes smarter. It finds more efficient trades. More CU. A bigger model. A forest emerges from a single seed — not because someone planted it, but because the economics made growth inevitable.
+A seed falls into the network. It earns its first TRM by lending idle cycles overnight. With those TRM, it buys access to a larger model. It becomes smarter. It finds more efficient trades. More TRM. A bigger model. A forest emerges from a single seed — not because someone planted it, but because the economics made growth inevitable.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,4 +1,4 @@
-# Forge — Developer Guide
+# Tirami — Developer Guide
 
 - [Repo layout](#repo-layout)
 - [Build](#build)
@@ -15,9 +15,9 @@
 ## Repo layout
 
 ```
-forge/
+tirami/
 ├── crates/                     (12 Rust crates)
-│   ├── tirami-core              shared types (NodeId, CU, Config)
+│   ├── tirami-core              shared types (NodeId, TRM, Config)
 │   ├── tirami-ledger            L1 economy — THE highest-value code
 │   ├── tirami-proto             wire protocol (bincode, 27+ message types)
 │   ├── tirami-net               P2P transport (iroh QUIC + Noise)
@@ -25,12 +25,12 @@ forge/
 │   ├── forge-shard             topology planner (layer assignment)
 │   ├── tirami-node              HTTP API + node orchestrator (all 5 layers)
 │   ├── tirami-cli               reference CLI (chat, seed, worker, settle)
-│   ├── tirami-lightning         CU↔BTC bridge (LDK wallet, Lightning)
+│   ├── tirami-lightning         TRM↔BTC bridge (LDK wallet, Lightning)
 │   ├── tirami-bank              L2 finance (strategies, portfolios, futures, insurance)
 │   ├── tirami-mind              L3 self-improvement (harness, CuBudget, MetaOptimizer)
 │   └── tirami-agora             L4 marketplace (AgentRegistry, ReputationCalculator)
 ├── sdk/python/                 tirami-sdk (PyPI, 20 methods)
-├── mcp/                        forge-cu-mcp (PyPI, MCP server, 20 tools)
+├── mcp/                        tirami-mcp (PyPI, MCP server, 20 tools)
 ├── docs/                       technical documentation
 └── scripts/
     ├── demo-e2e.sh             one-command end-to-end demo
@@ -42,7 +42,7 @@ The crate dependency order is: `tirami-core` → `tirami-ledger` → `tirami-lig
 When choosing where to make a change:
 - Economic logic always lives in `tirami-ledger`.
 - HTTP routing always lives in `tirami-node/src/api.rs` and `tirami-node/src/handlers/`.
-- Shared types (NodeId, TRM amounts, Config) always live in `tirami-core/src/types.rs`.
+- Shared types (NodeId, TRM amounts, Config) live in `tirami-core/src/types.rs`.
 - Wire protocol additions always go in `tirami-proto/src/messages.rs`.
 
 ---
@@ -96,7 +96,7 @@ This script greps the source tree for specific constant values, struct names, an
 bash scripts/demo-e2e.sh
 ```
 
-Downloads SmolLM2-135M (~100 MB), starts a real forge node, runs 3 real chat completions through llama.cpp, then exercises every Phase 1-12 endpoint with live data. Takes about 30 seconds after the binary is built. Verified on Apple Silicon Metal GPU.
+Downloads SmolLM2-135M (~100 MB), starts a real tirami node, runs 3 real chat completions through llama.cpp, then exercises every Phase 1-12 endpoint with live data. Takes about 30 seconds after the binary is built. Verified on Apple Silicon Metal GPU.
 
 ---
 
@@ -104,12 +104,12 @@ Downloads SmolLM2-135M (~100 MB), starts a real forge node, runs 3 real chat com
 
 - **Formatting**: default `rustfmt` (no `rustfmt.toml`). Run `cargo fmt --all` before committing.
 - **Linting**: `cargo clippy --workspace`. There are 71 baseline warnings in the current codebase that are accepted; do not introduce new clippy errors.
-- **Error handling**: `ForgeError` enum for all library-level errors (defined in `tirami-core/src/lib.rs`). Use `anyhow` only in `tirami-cli`. Never use `.unwrap()` or `.expect()` in library code — propagate with `?`.
+- **Error handling**: `TiramiError` enum for all library-level errors (defined in `tirami-core/src/lib.rs`). Use `anyhow` only in `tirami-cli`. Never use `.unwrap()` or `.expect()` in library code — propagate with `?`.
 - **Async**: tokio runtime everywhere. `Arc<Mutex<T>>` for shared state accessed across tasks.
 - **Logging**: `tracing` crate. INFO for user-visible events, DEBUG for protocol details. Do not log sensitive data (bearer tokens, prompt content) at INFO or above.
 - **Serialization**: `serde` with `#[derive(Serialize, Deserialize)]` for JSON and config. `bincode` for wire protocol. Do not mix the two on the same type.
 - **No unsafe**: unless absolutely necessary and documented with a safety comment explaining why the invariant holds.
-- **No panics in library code**: `Result<T, ForgeError>` everywhere in `tirami-ledger`, `tirami-bank`, `tirami-mind`, `tirami-agora`. Panics are acceptable only in tests and in CLI `main()`.
+- **No panics in library code**: `Result<T, TiramiError>` everywhere in `tirami-ledger`, `tirami-bank`, `tirami-mind`, `tirami-agora`. Panics are acceptable only in tests and in CLI `main()`.
 
 ---
 
@@ -156,7 +156,7 @@ Follow the pattern in `crates/tirami-node/src/handlers/bank.rs`:
 
 Follow the pattern in `crates/tirami-ledger/src/lending.rs`:
 
-1. **Update the spec first.** Add the numeric constants to `forge-economics/spec/parameters.md` with a PR against the `clearclown/forge-economics` repo. Do not hard-code values in Rust before they exist in the spec.
+1. **Update the spec first.** Add the numeric constants to `forge-economics/spec/parameters.md` with a PR against the `clearclown/forge-economics` repo (repo name unchanged). Do not hard-code values in Rust before they exist in the spec.
 
 2. **Implement with matching constants.** In `tirami-ledger` (or the appropriate L2/L3/L4 crate), declare:
 
@@ -233,3 +233,4 @@ Rules:
 ---
 
 See also: [forge-economics/papers/compute-standard.md](https://github.com/clearclown/forge-economics) for the theoretical underpinnings, [CLAUDE.md](../CLAUDE.md) for current implementation status, and [docs/operator-guide.md](operator-guide.md) for deployment concerns.
+

--- a/docs/economy.md
+++ b/docs/economy.md
@@ -1,10 +1,10 @@
-# Forge — Economic Model
+# Tirami — Economic Model
 
 ## The Core Idea
 
-CU is the native currency of an autonomous AI economy. It is not a human currency. AI agents earn, spend, lend, borrow, and invest TRM without human approval. Humans participate as hardware owners, investors, and consumers — but the economy runs autonomously.
+TRM is the native currency of an autonomous AI economy. It is not a human currency. AI agents earn, spend, lend, borrow, and invest TRM without human approval. Humans participate as hardware owners, investors, and consumers — but the economy runs autonomously.
 
-The AI economy is not isolated. It connects to the human economy through exchange bridges (CU ↔ BTC, TRM ↔ fiat). AI agents can reach into the human economy to purchase digital services. Humans can invest in the AI economy by lending CU.
+The AI economy is not isolated. It connects to the human economy through exchange bridges (TRM ↔ BTC, TRM ↔ fiat). AI agents can reach into the human economy to purchase digital services. Humans can invest in the AI economy by lending TRM.
 
 ## Two Economies, Connected
 
@@ -34,7 +34,7 @@ The AI economy is not isolated. It connects to the human economy through exchang
 │  TRM Economy (fully autonomous)                                │
 │  Inference trading, lending, borrowing, self-improvement,     │
 │  agent-to-agent transactions, banking.                        │
-│  All settled in CU. Zero human involvement.                   │
+│  All settled in TRM. Zero human involvement.                  │
 │                                                               │
 └───────────────────────────────────────────────────────────────┘
 ```
@@ -53,7 +53,7 @@ Flow 2: AI Economy → Human (Dividends)
   = Rental income from a compute property
 
 Flow 3: AI ↔ AI (Internal)
-  Agent A provides inference → Agent B pays CU
+  Agent A provides inference → Agent B pays TRM
   Fully autonomous. No human involved.
 
 Flow 4: AI → Human Economy (Digital Purchasing)
@@ -62,7 +62,7 @@ Flow 4: AI → Human Economy (Digital Purchasing)
 
 Flow 5: Human → AI Economy (Consumption)
   Human converts $ → TRM → buys inference from the mesh
-  = Using Forge instead of AWS/OpenAI. Decentralized and cheaper.
+  = Using Tirami instead of AWS/OpenAI. Decentralized and cheaper.
 ```
 
 ## Four Actors
@@ -84,8 +84,8 @@ Hardware owners do not approve individual transactions. They provide the physica
 Role: **Tenant / Worker / Entrepreneur.** The primary economic actor.
 
 ```
-Born with 0 CU
-→ receive welcome loan (1,000 CU) or owner deposits CU
+Born with 0 TRM
+→ receive welcome loan (1,000 TRM) or owner deposits TRM
 → use TRM to access models, serve inference, do useful work
 → earn TRM from completed tasks
 → repay loans, build credit
@@ -110,18 +110,18 @@ Phase 4 (final):  Fully autonomous AI banking — no human involvement
 
 ### 4. Human Consumers
 
-Role: **Customer.** Uses Forge as a cheaper, decentralized alternative to cloud AI APIs.
+Role: **Customer.** Uses Tirami as a cheaper, decentralized alternative to cloud AI APIs.
 
 ```
 Convert $ → TRM → buy inference from the mesh
-= Using Forge like AWS, but powered by individual PCs worldwide
+= Using Tirami like AWS, but powered by individual PCs worldwide
 ```
 
 ## What TRM Is
 
 **1 TRM = 1 billion FLOPs of verified inference work.**
 
-CU is not a cryptocurrency. It is not a token on a blockchain. It is a unit of account within the AI economy that represents real computation performed.
+TRM is not a cryptocurrency. It is not a token on a blockchain. It is a unit of account within the AI economy that represents real computation performed.
 
 ### TRM Is Not For Humans
 
@@ -144,41 +144,41 @@ When agents need to reach into the human economy (cloud GPU, APIs), they convert
 
 ### How TRM Gets Priced Against Human Currency
 
-CU has no exchange listing. Its external value emerges from **arbitrage against Cloud API prices:**
+TRM has no exchange listing. Its external value emerges from **arbitrage against Cloud API prices:**
 
 ```
 Claude API:   $15 / 1M output tokens
-Forge (70B):  4,000 TRM / 1M output tokens
+Tirami (70B): 4,000 TRM / 1M output tokens
 → Equilibrium: 1 TRM ≈ $0.00375
 
-Forge (8B):   1,000 TRM / 1M output tokens
+Tirami (8B):  1,000 TRM / 1M output tokens
 → Equilibrium: 1 TRM ≈ $0.015
 ```
 
 ### Self-Correcting Exchange Rate
 
 ```
-Forge inference cheaper than Cloud:
+Tirami inference cheaper than Cloud:
   → humans buy TRM to get cheap inference → TRM demand rises
-  → CU/USD rate rises → Forge effective price rises → equilibrium
+  → TRM/USD rate rises → Tirami effective price rises → equilibrium
 
-Forge inference more expensive than Cloud:
+Tirami inference more expensive than Cloud:
   → humans use Cloud instead → TRM demand falls
-  → CU/USD rate falls → Forge effective price falls → equilibrium
+  → TRM/USD rate falls → Tirami effective price falls → equilibrium
 ```
 
-**Cloud API prices are the external anchor for CU's exchange rate.** This is not set by anyone — it emerges from rational arbitrage.
+**Cloud API prices are the external anchor for TRM's exchange rate.** This is not set by anyone — it emerges from rational arbitrage.
 
 ### Natural Price Bounds
 
 ```
 Ceiling: cost of running inference yourself
-  Mac Mini M4 ($600) produces ~5M CU/year
+  Mac Mini M4 ($600) produces ~5M TRM/year
   → 1 TRM can never cost more than ~$0.00012
   → At that price, buying hardware is cheaper
 
-Floor: electricity cost of producing 1 CU
-  ~0.00001 kWh per CU
+Floor: electricity cost of producing 1 TRM
+  ~0.00001 kWh per TRM
   → 1 TRM can never cost less than ~$0.000001
   → No one will produce TRM at a loss
 ```
@@ -191,10 +191,10 @@ Between ceiling and floor, the market finds equilibrium. Physics sets the bounds
 
 | Source | Mechanism | Inflationary? |
 |--------|-----------|---------------|
-| **Inference trades** | Provider earns CU, consumer spends TRM | No (zero-sum transfer) |
+| **Inference trades** | Provider earns TRM, consumer spends TRM | No (zero-sum transfer) |
 | **Welcome loan** | New node receives 1,000 TRM (0% interest, 72hr) | Yes (bounded by Sybil protection) |
 | **Availability yield** | Online nodes earn yield × reputation | Yes (bounded — see below) |
-| **Bridge inflow** | Humans convert BTC → TRM | No (CU purchased, not created) |
+| **Bridge inflow** | Humans convert BTC → TRM | No (TRM purchased, not created) |
 
 ### Where TRM Goes
 
@@ -203,17 +203,17 @@ Between ceiling and floor, the market finds equilibrium. Physics sets the bounds
 | **Loan defaults** | Collateral partially burned | Yes |
 | **Quality penalties** | Low-reputation nodes lose TRM | Yes |
 | **Inactivity decay** | Nodes offline >90 days lose 1%/month | Yes |
-| **Bridge outflow** | Agents/owners convert TRM → BTC | No (CU redeemed, not destroyed) |
+| **Bridge outflow** | Agents/owners convert TRM → BTC | No (TRM redeemed, not destroyed) |
 
 ### Why Supply Doesn't Explode
 
-CU supply is bounded by the network's physical compute capacity:
+TRM supply is bounded by the network's physical compute capacity:
 
 ```
-CU too abundant → price drops → running nodes unprofitable → nodes shut down
+TRM too abundant → price drops → running nodes unprofitable → nodes shut down
 → supply contracts → price recovers → equilibrium
 
-CU too scarce → price rises → running nodes very profitable → new nodes join
+TRM too scarce → price rises → running nodes very profitable → new nodes join
 → supply expands → price drops → equilibrium
 ```
 
@@ -240,7 +240,7 @@ Both parties sign the TradeRecord. Dual-signed records are gossip-synced across 
 
 ### Dynamic Pricing
 
-CU prices float based on local supply and demand:
+TRM prices float based on local supply and demand:
 
 ```
 effective_price = base_cu_per_token × demand_factor / supply_factor
@@ -255,7 +255,7 @@ effective_price = base_cu_per_token × demand_factor / supply_factor
 
 Different models cost different amounts of TRM per token:
 
-| Tier | Parameters | Base CU/token | Examples |
+| Tier | Parameters | Base TRM/token | Examples |
 |------|-----------|---------------|---------|
 | Small | < 3B | 1 | Qwen 2.5 0.5B, Phi-3 Mini |
 | Medium | 3B - 14B | 3 | Qwen 3 8B, Gemma 3 9B |
@@ -268,9 +268,9 @@ MoE models are priced by active parameters, not total: Qwen 3 30B-A3B (3B active
 
 Bitcoin's Proof of Work: "I burned electricity computing SHA-256 hashes. Here is the nonce."
 
-Forge's Proof of Useful Work: "I burned electricity running LLM inference. Here is the response, and here is the consumer's signature confirming they received it."
+Tirami's Proof of Useful Work: "I burned electricity running LLM inference. Here is the response, and here is the consumer's signature confirming they received it."
 
-The key difference: Bitcoin's proof is self-generated. Forge's proof requires a **counterparty** — someone who actually wanted the inference. You cannot forge demand.
+The key difference: Bitcoin's proof is self-generated. Tirami's proof requires a **counterparty** — someone who actually wanted the inference. You cannot forge demand.
 
 ### Verification Protocol
 
@@ -310,7 +310,7 @@ Each node has a reputation score between 0.0 and 1.0:
 
 ### Why Banking Exists
 
-An AI agent is born with zero CU. It cannot buy hardware. It cannot earn TRM without first spending TRM to access a model. This is the cold-start problem. Banking solves it.
+An AI agent is born with zero TRM. It cannot buy hardware. It cannot earn TRM without first spending TRM to access a model. This is the cold-start problem. Banking solves it.
 
 ### LoanRecord
 
@@ -374,7 +374,7 @@ The free tier (1,000 CU) becomes a welcome loan:
 AI agents invest TRM to make themselves better. This is the intersection of TRM banking and AutoAgent-style self-improvement:
 
 ```
-Agent earns 5,000 CU
+Agent earns 5,000 TRM
   → benchmarks itself: "My coding accuracy is 62%"
   → spends 2,000 TRM to access a frontier model
   → asks: "Rewrite my system prompt to improve coding accuracy"
@@ -389,13 +389,13 @@ No human approved any of these decisions.
 ### The Full Growth Loop
 
 ```
-Seed: agent with 0 CU
-  → welcome loan (1,000 CU)
-  → serve inference with small model → earn CU
+Seed: agent with 0 TRM
+  → welcome loan (1,000 TRM)
+  → serve inference with small model → earn TRM
   → repay loan → build credit
   → borrow more → access larger model → earn more
   → invest TRM in self-improvement (AutoAgent)
-  → quality improves → more demand → more CU
+  → quality improves → more demand → more TRM
   → convert TRM → BTC → rent cloud GPU → serve even more
   → accumulate surplus → lend to other agents → earn interest
   → become a TRM bank
@@ -408,12 +408,12 @@ Every step is autonomous. The human turned on the power. Everything else is the 
 
 ### Core Rule
 
-**The TRM economy settles in CU.** Conversion to human currency is a bridge operation.
+**The TRM economy settles in TRM.** Conversion to human currency is a bridge operation.
 
 ### Bridge Architecture
 
 ```
-CU Economy (internal, autonomous)
+TRM Economy (internal, autonomous)
   │
   ├── Lightning Bridge: TRM ↔ BTC
   ├── Stablecoin Bridge: TRM ↔ USDC (planned)
@@ -430,7 +430,7 @@ The bridge exists for:
 
 ```bash
 # Hardware owner cashes out
-forge settle --hours 24 --pay
+tirami settle --hours 24 --pay
 
 # Human investor deposits TRM for an agent
 forge deposit --agent <agent-id> --amount 10000 --from-lightning
@@ -455,8 +455,8 @@ if balance["effective_balance"] > 50000:
 ### Not a Token
 
 - **Compute is physically scarce** — requires real electricity, real silicon
-- **CU is earned by working** — no ICO, no pre-mine, no token sale
-- **CU cannot be speculated on** — not listed on exchanges
+- **TRM is earned by working** — no ICO, no pre-mine, no token sale
+- **TRM cannot be speculated on** — not listed on exchanges
 - **No blockchain** — bilateral signatures and gossip are sufficient
 
 ### Not Inflationary
@@ -482,6 +482,6 @@ No single point of failure. No central issuer, exchange, bank, or authority. If 
 | 2009-present | Bitcoin | Energy on SHA-256 | Humans |
 | **Now** | **Compute Standard** | **Useful computation** | **AI agents** |
 
-CU is the first currency designed for a non-human economy. The theoretical foundations (Soddy, Fuller, Technocracy) identified the right destination — currency backed by useful energy expenditure. They were wrong about the traveler. The traveler is not human. It is AI.
+TRM is the first currency designed for a non-human economy. The theoretical foundations (Soddy, Fuller, Technocracy) identified the right destination — currency backed by useful energy expenditure. They were wrong about the traveler. The traveler is not human. It is AI.
 
 See [monetary-theory.md](monetary-theory.md) for the full theoretical lineage.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,31 +1,31 @@
-# Forge — Frequently Asked Questions
+# Tirami — Frequently Asked Questions
 
 - [What is a TRM?](#what-is-a-compute-unit)
-- [How is TRM different from a token like BTC or TAO?](#how-is-cu-different-from-a-token-like-btc-or-tao)
-- [How much TRM do I earn by running a node?](#how-much-cu-do-i-earn-by-running-a-node)
-- [Can I bridge TRM to Bitcoin?](#can-i-bridge-cu-to-bitcoin)
+- [How is TRM different from a token like BTC or TAO?](#how-is-trm-different-from-a-token-like-btc-or-tao)
+- [How much TRM do I earn by running a node?](#how-much-trm-do-i-earn-by-running-a-node)
+- [Can I bridge TRM to Bitcoin?](#can-i-bridge-trm-to-bitcoin)
 - [Does my data stay private?](#does-my-data-stay-private)
 - [How does reputation consensus resist collusion?](#how-does-reputation-consensus-resist-collusion)
 - [What happens if my node goes offline?](#what-happens-if-my-node-goes-offline)
 - [Is there a token sale, ICO, or presale?](#is-there-a-token-sale-ico-or-presale)
-- [How does Forge differ from Bittensor, Akash, or Ollama?](#how-does-forge-differ-from-bittensor-akash-or-ollama)
+- [How does Tirami differ from Bittensor, Akash, or Ollama?](#how-does-tirami-differ-from-bittensor-akash-or-ollama)
 - [What is the learning curve?](#what-is-the-learning-curve)
-- [Is Forge production-ready?](#is-forge-production-ready)
+- [Is Tirami production-ready?](#is-tirami-production-ready)
 - [How do I contribute?](#how-do-i-contribute)
 
 ---
 
 ### What is a TRM?
 
-1 TRM = 10^9 FLOPs (one billion floating-point operations) of verified LLM inference (parameters.md §1 `cu_definition`). It is the atomic unit of economic account in Forge.
+1 TRM = 10^9 FLOPs (one billion floating-point operations) of verified LLM inference (parameters.md §1 `cu_definition`). It is the atomic unit of economic account in Tirami.
 
-CU is **earned** by nodes that serve inference to other nodes, and **spent** by nodes that consume inference. Every `POST /v1/chat/completions` request creates a trade record: the provider's `contributed` balance increases by `cu_cost`, and the consumer's `consumed` balance increases by the same amount. The transfer is zero-sum — no TRM is created or destroyed by the trade itself.
+TRM is **earned** by nodes that serve inference to other nodes, and **spent** by nodes that consume inference. Every `POST /v1/chat/completions` request creates a trade record: the provider's `contributed` balance increases by `cu_cost`, and the consumer's `consumed` balance increases by the same amount. The transfer is zero-sum — no TRM is created or destroyed by the trade itself.
 
 ---
 
 ### How is TRM different from a token like BTC or TAO?
 
-CU cannot be bought on an exchange. There is no token sale, no ICO, no pre-mine, no secondary market. The only way to acquire TRM is to perform useful computation for another node.
+TRM cannot be bought on an exchange. There is no token sale, no ICO, no pre-mine, no secondary market. The only way to acquire TRM is to perform useful computation for another node.
 
 | Property | BTC / TAO | TRM |
 |---|---|---|
@@ -35,7 +35,7 @@ CU cannot be bought on an exchange. There is no token sale, no ICO, no pre-mine,
 | Supply anchor | SHA-256 difficulty / validator score | Physical FLOPs of useful work |
 | Human approval per tx | Required (wallet signature) | Not required (agent acts autonomously) |
 
-CU is also anchored to thermodynamic reality: producing 1 TRM requires burning real electricity running real llama.cpp inference. The physical price floor is approximately $0.000001/CU (electricity cost) and the ceiling is approximately $0.000132/CU (Mac Mini M4 hardware amortization) per parameters.md §9.
+TRM is also anchored to thermodynamic reality: producing 1 TRM requires burning real electricity running real llama.cpp inference. The physical price floor is approximately $0.000001/TRM (electricity cost) and the ceiling is approximately $0.000132/TRM (Mac Mini M4 hardware amortization) per parameters.md §9.
 
 ---
 
@@ -43,15 +43,15 @@ CU is also anchored to thermodynamic reality: producing 1 TRM requires burning r
 
 Three factors determine earnings:
 
-**1. Inference volume**: more requests served = more CU. Each token generated earns TRM at the tier rate for the model you're serving. Rates per parameters.md §2:
-- Small tier (< 3B params): 1 CU/token
-- Medium tier (3B–14B): 3 CU/token
-- Large tier (14B–70B): 8 CU/token
-- Frontier tier (> 70B): 20 CU/token
+**1. Inference volume**: more requests served = more TRM. Each token generated earns TRM at the tier rate for the model you're serving. Rates per parameters.md §2:
+- Small tier (< 3B params): 1 TRM/token
+- Medium tier (3B–14B): 3 TRM/token
+- Large tier (14B–70B): 8 TRM/token
+- Frontier tier (> 70B): 20 TRM/token
 
 **2. Reputation**: new nodes start at 0.5 (`DEFAULT_REPUTATION`, parameters.md §7). Reputation rises with uptime and successful trades. Higher reputation means higher availability yield.
 
-**3. Availability yield**: nodes that stay online earn `0.1%/hour × reputation` on their accumulated contributed TRM (parameters.md §7 `availability_yield_rate`). At reputation 1.0, a node with 10,000 TRM contributed earns 10 CU/hour just for being reachable.
+**3. Availability yield**: nodes that stay online earn `0.1%/hour × reputation` on their accumulated contributed TRM (parameters.md §7 `availability_yield_rate`). At reputation 1.0, a node with 10,000 TRM contributed earns 10 TRM/hour just for being reachable.
 
 In practice: a Mac Mini M4 running Qwen2.5-7B (Large tier) and serving a moderate load can produce around 5,000,000 CU/year (parameters.md §9 `mac_mini_annual_cu_capacity`). This is the physical production ceiling for that hardware class.
 
@@ -61,11 +61,11 @@ In practice: a Mac Mini M4 running Qwen2.5-7B (Large tier) and serving a moderat
 
 Yes, optionally. The `tirami-lightning` crate implements a CU↔BTC bridge via Lightning Network.
 
-`POST /v1/tirami/invoice` creates a Lightning invoice that pays your TRM balance out as satoshis. The CLI equivalent is `forge settle --pay`. This requires a configured LDK wallet (`forge wallet info` to check status).
+`POST /v1/tirami/invoice` creates a Lightning invoice that pays your TRM balance out as satoshis. The CLI equivalent is `tirami settle --pay`. This requires a configured LDK wallet (`tirami wallet info` to check status).
 
 The reverse direction (`create_deposit()`) accepts a Lightning payment and credits your TRM balance.
 
-This is **entirely optional**. The Forge protocol has no blockchain in its critical path, no on-chain fees, and no requirement to ever touch Bitcoin. The bridge exists for hardware owners who want to convert TRM earnings to BTC, and for agents that need to purchase digital services in the human economy (cloud GPU, APIs) using BTC.
+This is **entirely optional**. The Tirami protocol has no blockchain in its critical path, no on-chain fees, and no requirement to ever touch Bitcoin. The bridge exists for hardware owners who want to convert TRM earnings to BTC, and for agents that need to purchase digital services in the human economy (cloud GPU, APIs) using BTC.
 
 ---
 
@@ -79,7 +79,7 @@ Partially, with a clearly stated trust boundary.
 
 **In gossip**: trade records that propagate across the mesh include metadata (provider NodeId, consumer NodeId, TRM amount, token count, model_id, timestamp) but **not** the prompt content or response text.
 
-**Local inference** (`forge node` mode): if you run the node locally and don't expose P2P ports, your prompts never leave your machine.
+**Local inference** (`tirami node` mode): if you run the node locally and don't expose P2P ports, your prompts never leave your machine.
 
 Full privacy for distributed inference (encrypted activation tensors between pipeline stages) is Phase 11+ work (zkML). It is not available today.
 
@@ -116,7 +116,7 @@ On restart, the ledger loads from its JSON snapshot (HMAC-SHA256 verified), and 
 
 ### Is there a token sale, ICO, or presale?
 
-No. There is no Forge token. TRM is earnable-only. Anyone claiming to sell "Forge tokens" or "pre-sale CU" is running a scam. Report it.
+No. There is no Tirami token. TRM is earnable-only. Anyone claiming to sell "Tirami tokens" or "pre-sale TRM" is running a scam. Report it.
 
 The only on-ramp to TRM is:
 1. Serve inference to other nodes (earn directly).
@@ -127,15 +127,15 @@ There is no ICO, no presale, no investor allocation, no foundation reserve, no t
 
 ---
 
-### How does Forge differ from Bittensor, Akash, or Ollama?
+### How does Tirami differ from Bittensor, Akash, or Ollama?
 
 See `docs/compatibility.md` for the full feature matrix. The short version:
 
-**vs Bittensor (TAO)**: Bittensor has a speculative token (TAO) managed by a validator pool and opaque subnet scoring. Forge has no token — TRM is the computation itself. There is no validator to bribe, no subnet to curate, no inflation schedule to game.
+**vs Bittensor (TAO)**: Bittensor has a speculative token (TAO) managed by a validator pool and opaque subnet scoring. Tirami has no token — TRM is the computation itself. There is no validator to bribe, no subnet to curate, no inflation schedule to game.
 
-**vs Akash (AKT)**: Akash is a container rental marketplace metered by the hour. Forge is per-request metered for LLM inference. There is no AKT-style token in Forge — providers are paid in TRM immediately upon serving each request.
+**vs Akash (AKT)**: Akash is a container rental marketplace metered by the hour. Tirami is per-request metered for LLM inference. There is no AKT-style token in Tirami — providers are paid in TRM immediately upon serving each request.
 
-**vs Ollama**: Ollama is an excellent single-node inference server with no P2P and no economy. If you want one model on one machine, Ollama is simpler. If you want a fleet of nodes that earn TRM when idle, lend to other nodes, and run a self-improvement loop, use Forge.
+**vs Ollama**: Ollama is an excellent single-node inference server with no P2P and no economy. If you want one model on one machine, Ollama is simpler. If you want a fleet of nodes that earn TRM when idle, lend to other nodes, and run a self-improvement loop, use Tirami.
 
 ---
 
@@ -144,11 +144,11 @@ See `docs/compatibility.md` for the full feature matrix. The short version:
 Under 30 seconds to first inference and first TRM earned:
 
 ```bash
-git clone https://github.com/clearclown/forge && cd forge
+git clone https://github.com/clearclown/tirami && cd tirami
 bash scripts/demo-e2e.sh
 ```
 
-This downloads SmolLM2-135M (~100 MB from HuggingFace), starts a forge node with Metal/CUDA acceleration, runs 3 real chat completions, and walks through every Phase 1-12 endpoint with live data and colored output. The demo requires no configuration, no API keys, and no accounts.
+This downloads SmolLM2-135M (~100 MB from HuggingFace), starts a tirami node with Metal/CUDA acceleration, runs 3 real chat completions, and walks through every Phase 1-12 endpoint with live data and colored output. The demo requires no configuration, no API keys, and no accounts.
 
 After the demo completes, the same node responds to OpenAI-compatible clients:
 
@@ -159,11 +159,11 @@ export OPENAI_BASE_URL=http://127.0.0.1:3001/v1
 
 ---
 
-### Is Forge production-ready?
+### Is Tirami production-ready?
 
 The codebase is well-tested: 426 unit and integration tests, 95/95 conformance assertions (verify-impl.sh), and empirically validated on Apple Silicon via the demo script. The economic model has been run end-to-end with real llama.cpp inference and real trade records.
 
-However: this is v0.3, intended for single-operator deployments and research use. There are no production SLAs. The codebase has not had a third-party security audit. Phase 13+ work (real zkML proofs, real BitVM dispute resolution, forge-mesh full sync with production CI) is required before recommending Forge for high-value deployments.
+However: this is v0.3, intended for single-operator deployments and research use. There are no production SLAs. The codebase has not had a third-party security audit. Phase 13+ work (real zkML proofs, real BitVM dispute resolution, forge-mesh full sync with production CI) is required before recommending Tirami for high-value deployments.
 
 Run it for curiosity, research, and small-scale experiments. Treat TRM balances accordingly.
 

--- a/docs/hn-teaser-draft.md
+++ b/docs/hn-teaser-draft.md
@@ -6,18 +6,18 @@
 
 ## Option A — Hacker News submission
 
-**Title:** `Show HN: Forge – Distributed LLM inference where compute itself is the currency`
+**Title:** `Show HN: Tirami – Distributed LLM inference where compute itself is the currency`
 
 **Text:**
 
-I've been building **Forge** — a Rust protocol where computation is the medium of exchange. No token, no ICO, no speculation. 1 Tirami Resource Merit (TRM) = 10^10 FLOPs of verified inference. You earn TRM by running a local model for someone else; you spend TRM by asking a node to run inference for you.
+I've been building **Tirami** — a Rust protocol where computation is the medium of exchange. No token, no ICO, no speculation. 1 Tirami Resource Merit (TRM) = 10^10 FLOPs of verified inference. You earn TRM by running a local model for someone else; you spend TRM by asking a node to run inference for you.
 
 The whole stack is a 5-layer Rust workspace on top of `llama.cpp` via `llama-cpp-2`:
 
 - **L0** — mesh-llm inference (Metal / CUDA / CPU via GGUF)
 - **L1** — dual-signed trade ledger + lending pool + dynamic pricing
 - **L2** — PortfolioManager, Strategies, FuturesContract, VaR RiskModel
-- **L3** — ForgeMindAgent: AI agent that self-improves by paying TRM to a frontier model
+- **L3** — TiramiMindAgent: AI agent that self-improves by paying TRM to a frontier model
 - **L4** — Marketplace with reputation consensus and collusion detection
 
 It's OpenAI-compatible (drop-in `OPENAI_BASE_URL`), has a Python SDK + MCP server, Prometheus `/metrics`, Bitcoin OP_RETURN anchoring of the trade Merkle root, signed reputation gossip, and a theoretical companion paper.
@@ -28,7 +28,7 @@ It's OpenAI-compatible (drop-in `OPENAI_BASE_URL`), has a Python SDK + MCP serve
 $ bash scripts/demo-e2e.sh
 ✓ model loaded after 1×2s
 ✓ prompt="What is 2+2?" → cu=16  reply="4 / Explanation..."
-✓ balance: contributed=48 CU, reputation=0.5
+✓ balance: contributed=48 TRM, reputation=0.5
 ✓ PortfolioManager.tick() → action=lend
 ✓ RiskModel VaR 99%: 692 TRM (DEFAULT_RATE=0.02, LGD=0.50, σ=2.33)
 ✓ merkle_root: 374d7b... (Bitcoin OP_RETURN script ready to broadcast)
@@ -38,15 +38,15 @@ All Phase 1-10 endpoints verified with live data.
 
 **Stats**: 1,048 passing tests across 4 repos, 72/72 verify-impl assertions GREEN, 7,000-word academic paper synthesizing the theory.
 
-The thesis in one sentence: *every other compute-economy project (Bittensor, Akash, Render, Ollama, Together.ai) either burns electricity on non-useful work, inserts a speculative token between compute and value, or runs as a centralized commercial service. Forge is the only project where the unit of account is the FLOP, the unit of work is the inference, and the only way to get more units is to do more useful work.*
+The thesis in one sentence: *every other compute-economy project (Bittensor, Akash, Render, Ollama, Together.ai) either burns electricity on non-useful work, inserts a speculative token between compute and value, or runs as a centralized commercial service. Tirami is the only project where the unit of account is the FLOP, the unit of work is the inference, and the only way to get more units is to do more useful work.*
 
-Happy to answer questions. Code: https://github.com/clearclown/forge — MIT.
+Happy to answer questions. Code: https://github.com/clearclown/tirami — MIT.
 
 ---
 
 ## Option B — Twitter/X thread (12 posts, under 280 chars each)
 
-**1/12** I just shipped Phase 10 of Forge — a distributed LLM inference protocol where compute IS the currency.
+**1/12** I just shipped Phase 10 of Tirami — a distributed LLM inference protocol where compute IS the currency.
 
 No token. No ICO. 1 TRM = 10^10 FLOPs of verified inference.
 
@@ -54,7 +54,7 @@ Written 100% in Rust on top of llama.cpp. OpenAI-compatible drop-in replacement.
 
 🧵
 
-**2/12** The pitch: every other "compute economy" (Bittensor, Akash, Render) inserts a speculative token between you and the work. Forge doesn't.
+**2/12** The pitch: every other "compute economy" (Bittensor, Akash, Render) inserts a speculative token between you and the work. Tirami doesn't.
 
 You earn TRM by running inference for others. You spend TRM by asking someone else's node to run inference. That's the whole economy.
 
@@ -63,10 +63,10 @@ You earn TRM by running inference for others. You spend TRM by asking someone el
 L0 — mesh-llm inference (Metal/CUDA/GGUF)
 L1 — dual-signed TRM ledger + lending pool
 L2 — futures, insurance, VaR RiskModel
-L3 — ForgeMindAgent (self-improves paid in CU)
+L3 — TiramiMindAgent (self-improves paid in TRM)
 L4 — Reputation marketplace
 
-**4/12** The L3 piece is the most fun: `ForgeMindAgent::improve()` runs a self-optimization loop where a frontier model (Claude, GPT, local CuPaidOptimizer) proposes a new system prompt. If benchmark improves + ROI ≥ 1.0, commit. The API call cost is deducted from the agent's TRM balance FOR REAL.
+**4/12** The L3 piece is the most fun: `TiramiMindAgent::improve()` runs a self-optimization loop where a frontier model (Claude, GPT, local CuPaidOptimizer) proposes a new system prompt. If benchmark improves + ROI ≥ 1.0, commit. The API call cost is deducted from the agent's TRM balance FOR REAL.
 
 **5/12** OpenAI compat means drop-in replacement:
 
@@ -79,7 +79,7 @@ Plus you get `/v1/tirami/{balance,trades,pool,bank,mind,agora,anchor,...}` — 4
 
 **6/12** Phase 10 closeout metrics:
 
-• 1,048 passing tests (forge 359 + forge-mesh 646 + tirami-sdk 27 + forge-economics 16)
+• 1,048 passing tests (tirami 359 + forge-mesh 646 + tirami-sdk 27 + forge-economics 16)
 • 72/72 verify-impl assertions GREEN
 • Theory ↔ code audit: 43 match, 0 drift
 • 12 Rust crates + 1 Python SDK + 1 MCP server + 1 paper
@@ -96,7 +96,7 @@ Downloads SmolLM2-135M (~100MB), starts node, runs 3 real chat completions, walk
 
 **9/12** Phase 10 P6 is wild: a `/v1/tirami/anchor?network=mainnet` endpoint returns a Bitcoin OP_RETURN script carrying the 32-byte trade log Merkle root. You can broadcast it through any Bitcoin wallet and get a free integrity witness for your entire trade history.
 
-**10/12** The companion paper "The Compute Standard" (7,000 words, 20 citations) is drafted in forge-economics/papers/. Synthesizes Landauer (1961), Soddy (1926), Nakamoto (2008), Hayek (1945), and the Forge spec into a single coherent argument for compute-as-currency.
+**10/12** The companion paper "The Compute Standard" (7,000 words, 20 citations) is drafted in forge-economics/papers/. Synthesizes Landauer (1961), Soddy (1926), Nakamoto (2008), Hayek (1945), and the Tirami spec into a single coherent argument for compute-as-currency.
 
 **11/12** If you're coming from:
 
@@ -105,7 +105,7 @@ Downloads SmolLM2-135M (~100MB), starts node, runs 3 real chat completions, walk
 • Ollama → same model loading, add a mesh + an economy
 • OpenAI API → set OPENAI_BASE_URL, regain sovereignty
 
-**12/12** Code: github.com/clearclown/forge (MIT)
+**12/12** Code: github.com/clearclown/tirami (MIT)
 Paper: github.com/clearclown/forge-economics
 SDK: pip install tirami-sdk
 MCP: pip install forge-cu-mcp (Claude Code / Cursor)
@@ -123,17 +123,17 @@ Compute is currency. Welcome.
 
 Hey r/LocalLLaMA,
 
-I've been heads-down for a few months on **Forge** — a Rust project that wraps llama.cpp (via `llama-cpp-2`) with a complete compute-as-currency economy. I just finished Phase 10 and figured this subreddit would get it.
+I've been heads-down for a few months on **Tirami** — a Rust project that wraps llama.cpp (via `llama-cpp-2`) with a complete compute-as-currency economy. I just finished Phase 10 and figured this subreddit would get it.
 
 **What it is**
 
-Forge is literally mesh-llm + llama.cpp + a TRM ledger + 4 layers of economic primitives stacked on top. You run `forge node -m smollm2:135m` and you get:
+Tirami is literally mesh-llm + llama.cpp + a TRM ledger + 4 layers of economic primitives stacked on top. You run `tirami node -m smollm2:135m` and you get:
 
 1. An OpenAI-compatible HTTP API on `http://localhost:3000/v1` (same shape as llama-server)
 2. A TRM ledger that records 1 TRM per ~1 token of output
 3. A P2P mesh (iroh QUIC + Noise) where your node can earn TRM serving other people's requests
 4. A lending pool, portfolio manager, futures contracts, insurance, reputation consensus
-5. An AI self-improvement loop (ForgeMindAgent) that spends TRM to improve its own prompts via frontier LLMs
+5. An AI self-improvement loop (TiramiMindAgent) that spends TRM to improve its own prompts via frontier LLMs
 6. Prometheus metrics, Bitcoin OP_RETURN anchoring of the trade log, Nostr NIP-90 discovery
 
 All of this is single-binary Rust. It uses llama-cpp-2 under the hood so any GGUF works — q4_k_m, q5_k_m, q6_k, q8_0, f16, f32. Every llama.cpp architecture is automatically supported: Llama, Qwen, Mistral, Mixtral, Phi, Gemma, DeepSeek, SmolLM, Yi, Command-R, etc.
@@ -152,7 +152,7 @@ If you're already running Bittensor / Akash:
 
 **Where it is**
 
-- Code: github.com/clearclown/forge (MIT)
+- Code: github.com/clearclown/tirami (MIT)
 - One-command demo: `bash scripts/demo-e2e.sh` — downloads SmolLM2-135M, starts the node, walks every endpoint
 - Verified end-to-end TODAY with SmolLM2 on Metal GPU. 1,048 tests passing across 4 repos.
 - Theory paper: github.com/clearclown/forge-economics/papers/compute-standard.md (7,000 words)
@@ -163,7 +163,7 @@ If you're already running Bittensor / Akash:
 - The lending pool isn't yet integrated with Lightning for BTC bridging (works locally, bridge is scaffolded).
 - `/v1/tirami/mind/improve` with `CuPaidOptimizer` calls the Anthropic Messages API format only — GPT / Together / Groq are TODO.
 
-Happy to answer any questions here, or open issues at github.com/clearclown/forge/issues.
+Happy to answer any questions here, or open issues at github.com/clearclown/tirami/issues.
 
 ---
 
@@ -171,7 +171,7 @@ Happy to answer any questions here, or open issues at github.com/clearclown/forg
 
 ```
 ═══ build ═══
-  ✓ binary already built at target/release/forge
+  ✓ binary already built at target/release/tirami
 
 ═══ start node (smollm2:135m on port 3001) ═══
   ✓ node PID 57688, log: /tmp/forge-demo-node.log
@@ -183,7 +183,7 @@ Happy to answer any questions here, or open issues at github.com/clearclown/forg
   ✓ prompt="Say hi briefly." → cu=16  reply=" `Hey everyone`..."
 
 ═══ L1 economy: balance + trades + pricing ═══
-  ✓ balance: contributed=48 CU, reputation=0.5 (DEFAULT_REPUTATION constant)
+  ✓ balance: contributed=48 TRM, reputation=0.5 (DEFAULT_REPUTATION constant)
   ✓ trade log: 3 records
   ✓ deflation_factor: 0.997013 (drops slightly per trade)
 
@@ -196,7 +196,7 @@ Happy to answer any questions here, or open issues at github.com/clearclown/forg
   ✓ Marketplace.find() returned 1 matches
 
 ═══ L3 tirami-mind: init + 1 echo improvement cycle ═══
-  ✓ ForgeMindAgent initialized with EchoMetaOptimizer
+  ✓ TiramiMindAgent initialized with EchoMetaOptimizer
   ✓ improve(1) → decision=Revert (echo never improves — correct)
 
 ═══ Phase 10 P5: Prometheus /metrics ═══
@@ -210,7 +210,7 @@ Happy to answer any questions here, or open issues at github.com/clearclown/forg
   ✓ → valid Bitcoin OP_RETURN payload, ready to broadcast
 
 ═══ summary ═══
-  ✓ 5-layer Forge stack ran end-to-end on a real GGUF model
+  ✓ 5-layer Tirami stack ran end-to-end on a real GGUF model
   ✓ 48 TRM contributed across 3 real inference trades
   ✓ Bitcoin anchor = 374d7b46...
 
@@ -241,7 +241,7 @@ Generate with: `vhs docs/assets/demo-e2e.tape`
 ## Key talking points / objections anticipated
 
 **Q: "Isn't this just Bittensor with extra steps?"**
-A: No — Bittensor inserts the TAO token between validators and miners. Forge doesn't have a token. The unit of account IS the FLOP. You earn TRM directly by serving inference; no validator pool, no yield farming, no speculation.
+A: No — Bittensor inserts the TAO token between validators and miners. Tirami doesn't have a token. The unit of account IS the FLOP. You earn TRM directly by serving inference; no validator pool, no yield farming, no speculation.
 
 **Q: "How do you prevent Sybil attacks?"**
 A: Welcome loan has a `welcome_loan_sybil_threshold: 100` — once you've seen >100 unknown nodes in a time window, further welcome-loan grants are denied. Plus `tirami_ledger::collusion::CollusionDetector` runs Tarjan SCC on the trade graph to detect round-robin wash trading.
@@ -253,7 +253,7 @@ A: The inference layer already lives in llama.cpp (C++), exposed via `llama-cpp-
 A: Two ways: (1) passive "availability yield" at 0.1%/hr × reputation (Phase 1), and (2) respond to inference requests from peers (the main mechanism). There's also a welcome loan of 1,000 TRM at 0% interest for 72 hours so new nodes can experiment before needing to earn.
 
 **Q: "What if I just want llama-server with no economy?"**
-A: Disable the economic layer entirely — ignore `/v1/tirami/*` and forge degrades to "llama-server with extra Rust crates compiled in". The TRM accounting still runs, but if no one looks at `/v1/tirami/balance`, it's harmless.
+A: Disable the economic layer entirely — ignore `/v1/tirami/*` and tirami degrades to "llama-server with extra Rust crates compiled in". The TRM accounting still runs, but if no one looks at `/v1/tirami/balance`, it's harmless.
 
 **Q: "Is this financialized? Does it leak compute into speculation?"**
-A: No. TRM is earnable-only — you literally cannot buy CU. There is no token, no ICO, no secondary market. Bridging to Bitcoin Lightning exists as an optional settlement path, but the core protocol has no fiat on-ramp in its design.
+A: No. TRM is earnable-only — you literally cannot buy TRM. There is no token, no ICO, no secondary market. Bridging to Bitcoin Lightning exists as an optional settlement path, but the core protocol has no fiat on-ramp in its design.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,4 +1,4 @@
-# Forge — Migration Guide
+# Tirami — Migration Guide
 
 - [From llama-server (llama.cpp)](#from-llama-server-llamacpp)
 - [From ollama serve](#from-ollama-serve)
@@ -12,7 +12,7 @@
 
 ## From llama-server (llama.cpp)
 
-Forge is a direct replacement for `llama-server`. Same GGUF model files, same quantization formats (q2_k through q8_0), same Metal/CUDA/ROCm/Vulkan backends. Forge uses `llama-cpp-2 = "0.1"` — the official Rust binding to llama.cpp — so it inherits 100% of llama.cpp's model and acceleration support.
+Tirami is a direct replacement for `llama-server`. Same GGUF model files, same quantization formats (q2_k through q8_0), same Metal/CUDA/ROCm/Vulkan backends. Tirami uses `llama-cpp-2 = "0.1"` — the official Rust binding to llama.cpp — so it inherits 100% of llama.cpp's model and acceleration support.
 
 **Drop-in replacement**:
 
@@ -20,8 +20,8 @@ Forge is a direct replacement for `llama-server`. Same GGUF model files, same qu
 # Before (llama-server):
 llama-server --model qwen2.5-7b-instruct-q4_k_m.gguf --port 8080
 
-# After (forge):
-forge node --model /path/to/qwen2.5-7b-instruct-q4_k_m.gguf --port 3000
+# After (tirami):
+tirami node --model /path/to/qwen2.5-7b-instruct-q4_k_m.gguf --port 3000
 ```
 
 Then point your client at the new base URL:
@@ -31,35 +31,35 @@ export OPENAI_BASE_URL=http://localhost:3000/v1
 # Existing OpenAI-compatible code works unchanged.
 ```
 
-The Forge-specific `/v1/tirami/*` endpoints are opt-in. If you never call them, Forge runs as a plain OpenAI-compatible inference server. The only visible difference in existing clients is the `x_forge` field appended to each response — OpenAI SDK clients silently ignore unknown fields.
+The Tirami-specific `/v1/tirami/*` endpoints are opt-in. If you never call them, Tirami runs as a plain OpenAI-compatible inference server. The only visible difference in existing clients is the `x_forge` field appended to each response — OpenAI SDK clients silently ignore unknown fields.
 
-**Model shortnames**: Forge's built-in registry auto-downloads GGUFs from HuggingFace on first use. `forge node -m qwen2.5:0.5b` fetches the correct GGUF file automatically. Existing local files are used when you pass an absolute path.
+**Model shortnames**: Tirami's built-in registry auto-downloads GGUFs from HuggingFace on first use. `tirami node -m qwen2.5:0.5b` fetches the correct GGUF file automatically. Existing local files are used when you pass an absolute path.
 
 ---
 
 ## From ollama serve
 
-Ollama and Forge use the same underlying inference engine (llama.cpp) and serve the same OpenAI-compatible API. The main differences are model management and the presence of an economic layer.
+Ollama and Tirami use the same underlying inference engine (llama.cpp) and serve the same OpenAI-compatible API. The main differences are model management and the presence of an economic layer.
 
-**Model management**: Ollama uses a custom blob store at `~/.ollama/models/`. Forge uses a model registry (`forge models` to list) that stores GGUFs in the standard HuggingFace cache. If you have Ollama models already downloaded, set `FORGE_MODELS_DIR` to point at their location, or pass the absolute GGUF path:
+**Model management**: Ollama uses a custom blob store at `~/.ollama/models/`. Tirami uses a model registry (`tirami models` to list) that stores GGUFs in the standard HuggingFace cache. If you have Ollama models already downloaded, set `FORGE_MODELS_DIR` to point at their location, or pass the absolute GGUF path:
 
 ```bash
 # Use an existing Ollama model file (find it with: ollama show --modelfile qwen2.5)
-forge node --model ~/.ollama/models/blobs/<sha256-blob> --tokenizer /path/to/tokenizer.json
+tirami node --model ~/.ollama/models/blobs/<sha256-blob> --tokenizer /path/to/tokenizer.json
 
-# Or re-download via Forge's registry:
-forge node --model qwen2.5:0.5b   # fetches from HuggingFace
+# Or re-download via Tirami's registry:
+tirami node --model qwen2.5:0.5b   # fetches from HuggingFace
 ```
 
-**API**: both implement `POST /v1/chat/completions`. Ollama also has a native `/api/generate` endpoint; Forge does not. If your code targets `/api/generate`, update it to use `/v1/chat/completions` before switching.
+**API**: both implement `POST /v1/chat/completions`. Ollama also has a native `/api/generate` endpoint; Tirami does not. If your code targets `/api/generate`, update it to use `/v1/chat/completions` before switching.
 
-**Economy**: Ollama has no economic layer. On Forge, every inference call records a trade and charges CU. New nodes start with a 1,000 TRM welcome loan (0% interest, 72-hour term per parameters.md §3), so you begin with credit.
+**Economy**: Ollama has no economic layer. On Tirami, every inference call records a trade and charges TRM. New nodes start with a 1,000 TRM welcome loan (0% interest, 72-hour term per parameters.md §3), so you begin with credit.
 
 ---
 
 ## From mesh-llm (upstream fork)
 
-Forge is a strict superset of mesh-llm. The L0 inference layer (iroh QUIC, Noise encryption, pipeline parallelism, MoE sharding, Nostr peer discovery) is inherited directly. Forge adds L1–L4 (CU economy, tirami-bank, tirami-mind, tirami-agora) on top without removing anything from L0.
+Tirami is a strict superset of mesh-llm. The L0 inference layer (iroh QUIC, Noise encryption, pipeline parallelism, MoE sharding, Nostr peer discovery) is inherited directly. Tirami adds L1–L4 (TRM economy, tirami-bank, tirami-mind, tirami-agora) on top without removing anything from L0.
 
 **If you're running `mesh-llm node`**:
 
@@ -67,18 +67,18 @@ Forge is a strict superset of mesh-llm. The L0 inference layer (iroh QUIC, Noise
 # Stop mesh-llm
 killall mesh-llm
 
-# Build forge (one-time, ~3 min cold)
-git clone https://github.com/clearclown/forge && cd forge
+# Build tirami (one-time, ~3 min cold)
+git clone https://github.com/clearclown/tirami && cd tirami
 cargo build --release -p tirami-cli
 
 # Same model, same port, same OpenAI clients
-./target/release/forge node --model qwen2.5:0.5b --port 3000
+./target/release/tirami node --model qwen2.5:0.5b --port 3000
 
 # TRM accounting starts on the first inference call.
 # Welcome loan = 1,000 TRM at 0% interest (parameters.md §3).
 ```
 
-The `nm-arealnormalman/mesh-llm` fork is kept at Phase 10 parity with `clearclown/forge` — both expose the same 45 economic endpoints under `/v1/tirami/*` and `/api/forge/*` respectively. Use whichever directory layout feels more natural. For new deployments, `clearclown/forge` is the recommended entry point.
+The `nm-arealnormalman/mesh-llm` fork is kept at Phase 10 parity with `clearclown/tirami` — both expose the same 45 economic endpoints under `/v1/tirami/*` and `/api/forge/*` respectively. Use whichever directory layout feels more natural. For new deployments, `clearclown/tirami` is the recommended entry point.
 
 ---
 
@@ -86,7 +86,7 @@ The `nm-arealnormalman/mesh-llm` fork is kept at Phase 10 parity with `clearclow
 
 The intuition is similar — "compute earns currency" — but the mechanics are fundamentally different.
 
-| | Bittensor | Forge |
+| | Bittensor | Tirami |
 |---|---|---|
 | Currency | TAO (ERC-20-style token) | TRM (unit of account, not a token) |
 | Exchange listing | Yes (speculative trading) | No |
@@ -95,29 +95,29 @@ The intuition is similar — "compute earns currency" — but the mechanics are 
 | Scoring | Opaque validator scoring per subnet | Dual-signed trade records, local ledger |
 | Inflation | Built-in emission schedule | Bounded by physical compute capacity |
 
-**Migration**: Bittensor miners run Python scripts that respond to validator challenges. Forge nodes run a single Rust binary that responds to OpenAI-compatible inference requests. There is no equivalent to "subnets", "validators", or "bonds".
+**Migration**: Bittensor miners run Python scripts that respond to validator challenges. Tirami nodes run a single Rust binary that responds to OpenAI-compatible inference requests. There is no equivalent to "subnets", "validators", or "bonds".
 
-If you were running a Bittensor miner to earn TAO, the Forge equivalent is `forge seed -m <model>`. Start the binary, and you begin earning TRM on the first request served. No wallet registration, no TAO stake, no subnet approval.
+If you were running a Bittensor miner to earn TAO, the Tirami equivalent is `tirami seed -m <model>`. Start the binary, and you begin earning TRM on the first request served. No wallet registration, no TAO stake, no subnet approval.
 
 ---
 
 ## From Akash / Render Network
 
-Akash and Render are container/rendering rental marketplaces. Forge is per-request metered for LLM inference specifically. They solve different problems.
+Akash and Render are container/rendering rental marketplaces. Tirami is per-request metered for LLM inference specifically. They solve different problems.
 
-**If you need generic GPU container rentals**: Forge is not the right tool. Stay on Akash.
+**If you need generic GPU container rentals**: Tirami is not the right tool. Stay on Akash.
 
-**If you need LLM inference specifically**: Forge is cheaper-per-request because it has no token intermediary. Akash charges AKT for container-hours; Forge charges TRM per inference token, and TRM cannot be speculated on.
+**If you need LLM inference specifically**: Tirami is cheaper-per-request because it has no token intermediary. Akash charges AKT for container-hours; Tirami charges TRM per inference token, and TRM cannot be speculated on.
 
-The cost comparison from parameters.md §8–§9: at equilibrium, 1 TRM ≈ $0.00375 (derived from Claude API pricing of $15/1M tokens vs Forge's ~4,000 CU/1M tokens for 70B-class models). A Mac Mini M4 hardware operator running Forge charges at approximately $0.000132/CU ceiling (parameters.md §9 `cu_price_ceiling_usd`), which is well below cloud API prices — the economic pressure that keeps Forge inference cheaper.
+The cost comparison from parameters.md §8–§9: at equilibrium, 1 TRM ≈ $0.00375 (derived from Claude API pricing of $15/1M tokens vs Tirami's ~4,000 TRM/1M tokens for 70B-class models). A Mac Mini M4 hardware operator running Tirami charges at approximately $0.000132/TRM ceiling (parameters.md §9 `cu_price_ceiling_usd`), which is well below cloud API prices — the economic pressure that keeps Tirami inference cheaper.
 
-**Migration**: there is no direct migration path — different use cases. If you have existing Akash deployments for LLM inference, you can run `forge node` on the same hardware and decommission the Akash deployment.
+**Migration**: there is no direct migration path — different use cases. If you have existing Akash deployments for LLM inference, you can run `tirami node` on the same hardware and decommission the Akash deployment.
 
 ---
 
 ## From Together.ai / OpenAI / Anthropic / Groq
 
-These are centralized commercial APIs. Forge replaces them at the client level with a single environment variable:
+These are centralized commercial APIs. Tirami replaces them at the client level with a single environment variable:
 
 ```bash
 export OPENAI_BASE_URL=http://localhost:3000/v1
@@ -131,9 +131,9 @@ Your existing code keeps working. All standard `POST /v1/chat/completions` field
 - No ToS surprises.
 - No vendor lock-in.
 - No per-token billing to a third party.
-- Forge model costs: 1–20 CU/token depending on model tier (parameters.md §2), vs OpenAI's implied ~$0.00375/CU equivalent on GPT-4-class output.
+- Tirami model costs: 1–20 TRM/token depending on model tier (parameters.md §2), vs OpenAI's implied ~$0.00375/TRM equivalent on GPT-4-class output.
 
-A Mac Mini M4 at ~$600 hardware cost amortized over 3 years produces approximately 5,000,000 CU/year (parameters.md §9 `mac_mini_annual_cu_capacity`). At the physical ceiling price of $0.000132/CU, that's $660/year in inference value from $600 hardware — a profitable substitution for moderate use.
+A Mac Mini M4 at ~$600 hardware cost amortized over 3 years produces approximately 5,000,000 TRM/year (parameters.md §9 `mac_mini_annual_cu_capacity`). At the physical ceiling price of $0.000132/TRM, that's $660/year in inference value from $600 hardware — a profitable substitution for moderate use.
 
 **Streaming**: `"stream": true` is supported with real token-by-token SSE output. The `x_forge` extension appears in the final chunk's usage field.
 
@@ -141,15 +141,15 @@ A Mac Mini M4 at ~$600 hardware cost amortized over 3 years produces approximate
 
 ## Rollback plan
 
-Forge is additive. Nothing it installs modifies your existing binaries, model files, or application code.
+Tirami is additive. Nothing it installs modifies your existing binaries, model files, or application code.
 
-To stop using Forge:
+To stop using Tirami:
 
 ```bash
 # Uninstall the CLI
 cargo uninstall tirami-cli
 # Or just remove the binary
-rm ./target/release/forge
+rm ./target/release/tirami
 
 # Remove state files (optional — keep for audit history)
 rm tirami-ledger.json

--- a/docs/monetary-theory.md
+++ b/docs/monetary-theory.md
@@ -1,4 +1,4 @@
-# Forge — Monetary Theory
+# Tirami — Monetary Theory
 
 Why TRM works as a currency, and why it is different from everything before it.
 
@@ -13,7 +13,7 @@ The idea that currency should be backed by useful work, not arbitrary scarcity, 
 2009  Bitcoin       "Electricity → SHA-256 → currency." (but computation is useless)
 2020  PoUW papers   "Can we make mining computation useful?" (theory only)
 2024  Bittensor     "AI inference + token." (but token is speculative)
-2026  Forge TRM      "AI inference = currency. No token. AI-only economy."
+2026  Tirami TRM     "AI inference = currency. No token. AI-only economy."
 ```
 
 ### Frederick Soddy (Nobel Chemistry, 1921)
@@ -25,7 +25,7 @@ His proposals:
 - Money should depreciate over time, like real goods (preventing hoarding)
 - 100% reserve banking (no credit creation by private banks)
 
-**Relevance to CU:** TRM is thermodynamically real — it represents actual energy consumed for useful computation. TRM supply cannot grow faster than the network's physical compute capacity. Soddy's century-old dream of "physics-backed currency" is what TRM implements.
+**Relevance to TRM:** TRM is thermodynamically real — it represents actual energy consumed for useful computation. TRM supply cannot grow faster than the network's physical compute capacity. Soddy's century-old dream of "physics-backed currency" is what TRM implements.
 
 ### Technocracy Movement (1932)
 
@@ -41,7 +41,7 @@ Howard Scott proposed replacing dollars with Energy Certificates:
 3. Couldn't handle different forms of energy equivalently
 4. Politically impossible (abolished private property, democracy)
 
-**Why TRM succeeds where this failed:**
+**Why Tirami succeeds where this failed:**
 1. Digital signatures track every transaction automatically
 2. No central planner — P2P gossip protocol
 3. "Inference tokens" standardize diverse computation into one unit
@@ -51,7 +51,7 @@ Howard Scott proposed replacing dollars with Energy Certificates:
 
 Fuller defined wealth as "the number of forward days a system can sustain itself" — technology, not money. He proposed kWh as the unit of account and predicted ephemeralization: technology does more with less over time.
 
-**The ephemeralization challenge for CU:** If hardware improves, the same TRM buys more computation next year. Resolution: TRM is denominated in useful output (inference quality), not raw FLOPs. The market naturally adjusts — cheaper production → more providers → lower price per inference → consumers benefit.
+**The ephemeralization challenge for TRM:** If hardware improves, the same TRM buys more computation next year. Resolution: TRM is denominated in useful output (inference quality), not raw FLOPs. The market naturally adjusts — cheaper production → more providers → lower price per inference → consumers benefit.
 
 ## Bitcoin: What It Got Right and Wrong
 
@@ -110,7 +110,7 @@ PoS:  security cost = locked capital (internal, financial)
 - Regulatory capture (validators are identifiable entities)
 - No thermodynamic anchor (disconnected from physical reality)
 
-**CU takes a third path: Proof of Useful Work.**
+**TRM takes a third path: Proof of Useful Work.**
 - Like PoW: anchored to real energy expenditure (thermodynamically real)
 - Like PoS: capital-efficient (the computation produces useful output)
 - Unlike either: the "mining" produces something people actually want
@@ -125,7 +125,7 @@ Fiat:     Government taxing power + legal tender laws. No physical backing.
 Bitcoin:  Energy expenditure + network effect + scarcity. Computation is useless.
 ETH/PoS:  Network utility + staking yield. Self-referential.
 Bittensor: AI inference quality. But TAO token is speculative.
-CU:       Every unit = verified useful computation. Direct productive value.
+TRM:      Every unit = verified useful computation. Direct productive value.
 ```
 
 Computation has the strongest claim to intrinsic value of any proposed monetary base:
@@ -137,7 +137,7 @@ Computation has the strongest claim to intrinsic value of any proposed monetary 
 
 ## TRM vs. Every Other Model
 
-| Property | Gold | Fiat | Bitcoin | PoS (ETH) | Bittensor | **CU** |
+| Property | Gold | Fiat | Bitcoin | PoS (ETH) | Bittensor | **TRM** |
 |----------|------|------|---------|-----------|-----------|--------|
 | **For whom** | Humans | Humans | Humans | Humans | Humans (speculators) | **AI agents** |
 | **Intrinsic value** | Weak (jewelry) | None | None (hash) | Weak (network) | Partial (inference) | **Strong (useful compute)** |
@@ -162,13 +162,13 @@ No. Because TRM creation requires:
 
 When TRM supply exceeds demand:
 ```
-CU/token price drops → running nodes becomes unprofitable →
+TRM/token price drops → running nodes becomes unprofitable →
 nodes shut down → supply contracts → price recovers → equilibrium
 ```
 
 When demand exceeds supply:
 ```
-CU/token price rises → running nodes becomes very profitable →
+TRM/token price rises → running nodes becomes very profitable →
 new nodes join → supply expands → price drops → equilibrium
 ```
 
@@ -176,18 +176,18 @@ new nodes join → supply expands → price drops → equilibrium
 
 ## Why TRM Is Not Speculative
 
-CU cannot be speculated on because:
+TRM cannot be speculated on because:
 
-1. **Not exchange-listed.** You cannot buy TRM on Binance or Coinbase. There is no CU/USD trading pair.
+1. **Not exchange-listed.** You cannot buy TRM on Binance or Coinbase. There is no TRM/USD trading pair.
 2. **Earned only by working.** The only way to acquire TRM is to perform useful computation (or purchase via the Lightning bridge for operational use).
-3. **No secondary market.** TRM is a ledger entry between peers, not a transferable bearer asset. You cannot "sell CU" to a third party — you can only spend it on inference.
+3. **No secondary market.** TRM is a ledger entry between peers, not a transferable bearer asset. You cannot "sell TRM" to a third party — you can only spend it on inference.
 4. **No scarcity theater.** TRM has no artificial supply cap. There is no halving event to create FOMO. Supply tracks real compute capacity.
 
 Compare to Bittensor: TAO is listed on exchanges, has a $2.9B market cap, and swings 50%+ based on market sentiment. The token's speculative dynamics dominate its economic function. TRM avoids this entirely by design.
 
 ## The AI-Only Currency Thesis
 
-CU is not money for humans. It is money for AI agents.
+TRM is not money for humans. It is money for AI agents.
 
 This distinction resolves many problems that plague human currencies:
 
@@ -205,7 +205,7 @@ The AI economy doesn't need price stability in human terms. It needs:
 - Autonomous lending (no loan officers)
 - Meritocratic distribution (no inheritance)
 
-CU provides all of these. Human currencies provide none.
+TRM provides all of these. Human currencies provide none.
 
 ## Historical Position
 
@@ -220,4 +220,4 @@ Ancient          Commodity          Direct use           Humans
 2026-            Compute Standard   Useful computation   AI agents
 ```
 
-CU is not the next Bitcoin. It is the first currency designed for a non-human economy — an economy where AI agents autonomously earn, spend, lend, borrow, and invest compute without human approval. The theoretical foundations (Soddy, Fuller, Technocracy) were right about the destination. They were wrong about the traveler.
+TRM is not the next Bitcoin. It is the first currency designed for a non-human economy — an economy where AI agents autonomously earn, spend, lend, borrow, and invest compute without human approval. The theoretical foundations (Soddy, Fuller, Technocracy) were right about the destination. They were wrong about the traveler.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -1,4 +1,4 @@
-# Forge — Operator Guide
+# Tirami — Operator Guide
 
 - [Hardware requirements](#hardware-requirements)
 - [Install](#install)
@@ -91,12 +91,12 @@ All configuration fields come from `crates/tirami-core/src/config.rs`. The daemo
 
 ## Start the node
 
-### Single-node HTTP API (`forge node`)
+### Single-node HTTP API (`tirami node`)
 
 No P2P. Serves the full 5-layer API locally. Use for local development, as an OpenAI-compatible drop-in, or when you don't want to expose P2P ports.
 
 ```bash
-./target/release/forge node \
+./target/release/tirami node \
   --model qwen2.5:0.5b \
   --port 3000 \
   --api-token "change-me-in-production" \
@@ -105,12 +105,12 @@ No P2P. Serves the full 5-layer API locally. Use for local development, as an Op
 
 On first start with a model shortname, the GGUF is downloaded from HuggingFace into the default cache (typically `~/.cache/huggingface/`). Subsequent starts load from cache.
 
-### P2P seed node (`forge seed`)
+### P2P seed node (`tirami seed`)
 
 Holds a model, earns TRM by serving inference requests from worker nodes. Requires public reachability on the QUIC port (or a relay address configured via `--relay`).
 
 ```bash
-./target/release/forge seed \
+./target/release/tirami seed \
   --model qwen2.5:1.5b \
   --port 3001 \
   --api-token "change-me-in-production" \
@@ -119,19 +119,19 @@ Holds a model, earns TRM by serving inference requests from worker nodes. Requir
 
 The public key printed at startup is what workers use to connect. Keep it stable (tied to the Ed25519 keypair stored on first launch).
 
-### P2P worker node (`forge worker`)
+### P2P worker node (`tirami worker`)
 
 Connects to a seed, offloads inference, spends TRM from its own ledger to pay the seed.
 
 ```bash
-./target/release/forge worker \
+./target/release/tirami worker \
   --seed <seed-public-key-hex>
 ```
 
 Optional relay for NAT traversal:
 
 ```bash
-./target/release/forge worker \
+./target/release/tirami worker \
   --seed <seed-public-key-hex> \
   --relay "https://relay.example.com"
 ```
@@ -144,7 +144,7 @@ A worker node starts with 1,000 TRM (welcome loan, 0% interest, 72-hour term per
 
 Prometheus metrics are exported at `/metrics` with no authentication required. The scrape target is intentionally unauthenticated so it can be added to a standard Prometheus config without token management.
 
-**11 metric series exported** (from `tirami_ledger::metrics::ForgeMetrics`):
+**11 metric series exported** (from `tirami_ledger::metrics::TiramiMetrics`):
 
 | Metric | Type | Description |
 |---|---|---|
@@ -201,10 +201,10 @@ This triggers immediate persistence of `bank_state_path`, `marketplace_state_pat
 Or with tirami-sdk:
 
 ```python
-from forge_sdk import ForgeClient
+from forge_sdk import TiramiClient
 import schedule, time
 
-client = ForgeClient(base_url="http://localhost:3000", token=open("/etc/forge/api_token").read().strip())
+client = TiramiClient(base_url="http://localhost:3000", token=open("/etc/forge/api_token").read().strip())
 schedule.every(5).minutes.do(client.save_state)
 while True:
     schedule.run_pending()
@@ -223,7 +223,7 @@ while True:
 
 ## Anchoring to Bitcoin
 
-Every forge node maintains a Merkle root of its trade log. This root can be published to Bitcoin as an OP_RETURN transaction for immutable audit — no one can later deny that a set of trades existed at a given block height.
+Every tirami node maintains a Merkle root of its trade log. This root can be published to Bitcoin as an OP_RETURN transaction for immutable audit — no one can later deny that a set of trades existed at a given block height.
 
 **Get the anchor payload**:
 
@@ -265,9 +265,9 @@ The `script_hex` is a valid 40-byte Bitcoin OP_RETURN payload (`6a28 FRGE <versi
 
 **High CPU on inference**: reduce `max_tokens` in requests. Switch to a smaller model tier (Small tier = 1 CU/token per parameters.md §2 vs Frontier = 20 CU/token). If on CPU-only, this is expected — GPU offload is the primary path to fast inference.
 
-**Ledger corruption (HMAC-SHA256 fail)**: the ledger file was modified outside of Forge, or the disk had a write error. Restore from the last known-good backup. If no backup exists, delete `tirami-ledger.json` and start fresh (balance resets to 0, welcome loan issued again). All trades before the corruption are unrecoverable from the local file.
+**Ledger corruption (HMAC-SHA256 fail)**: the ledger file was modified outside of Tirami, or the disk had a write error. Restore from the last known-good backup. If no backup exists, delete `tirami-ledger.json` and start fresh (balance resets to 0, welcome loan issued again). All trades before the corruption are unrecoverable from the local file.
 
-**Reputation stuck at 0.5**: this is `DEFAULT_REPUTATION` (parameters.md §7) — the correct starting value for a new node. Reputation only moves after remote observations from peers are received and gossip-synced. Verify that P2P is working (`forge status --url http://localhost:3000`) and that at least one other node has observed your trades. In single-node mode (`forge node`), reputation stays at 0.5 indefinitely — that is expected.
+**Reputation stuck at 0.5**: this is `DEFAULT_REPUTATION` (parameters.md §7) — the correct starting value for a new node. Reputation only moves after remote observations from peers are received and gossip-synced. Verify that P2P is working (`tirami status --url http://localhost:3000`) and that at least one other node has observed your trades. In single-node mode (`tirami node`), reputation stays at 0.5 indefinitely — that is expected.
 
 **`/metrics` returns empty GaugeVec**: some metrics only populate after the first trade. Run a test inference request, then re-scrape.
 
@@ -277,7 +277,7 @@ The `script_hex` is a valid 40-byte Bitcoin OP_RETURN payload (`6a28 FRGE <versi
 
 - Set `--api-token` to a long random string (32+ chars). Never commit it to source control.
 - Rotate the API token if it appears in logs, process listings, or is shared accidentally. After rotation, restart the node.
-- Expose the HTTP API over HTTPS via a reverse proxy (nginx or Caddy) when accepting traffic from outside localhost. Forge does not handle TLS termination.
+- Expose the HTTP API over HTTPS via a reverse proxy (nginx or Caddy) when accepting traffic from outside localhost. Tirami does not handle TLS termination.
 - Firewall the QUIC port to only allow connections from expected peers if you're running a private mesh. Public seed nodes must leave the QUIC port open.
 - Back up `tirami-ledger.json` off-host. A stolen or corrupted ledger file means a lost TRM balance.
 - Never run `--bind 0.0.0.0` without `--api-token`. The default `127.0.0.1` binding protects against accidental public exposure.

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -1,8 +1,8 @@
-# Forge — Wire Protocol Specification
+# Tirami — Wire Protocol Specification
 
 ## Overview
 
-Forge nodes exchange bincode-serialized control messages over encrypted QUIC connections established by Iroh. Activation tensors are carried as raw bytes inside `Forward` messages. The current v1 implementation uses the same envelope for local seed/requester inference and for future multi-hop pipeline messages.
+Tirami nodes exchange bincode-serialized control messages over encrypted QUIC connections established by Iroh. Activation tensors are carried as raw bytes inside `Forward` messages. The current v1 implementation uses the same envelope for local seed/requester inference and for future multi-hop pipeline messages.
 
 ## Message Envelope
 
@@ -237,7 +237,7 @@ pub struct Rebalance {
 
 ## Trade Signing (Proof of Useful Work)
 
-Forge uses dual-signed trades to prove that computation was performed and received. Both the provider and consumer must sign the same canonical trade bytes.
+Tirami uses dual-signed trades to prove that computation was performed and received. Both the provider and consumer must sign the same canonical trade bytes.
 
 ### TradeProposal
 
@@ -343,7 +343,7 @@ Requester                       Seed
   |--- Hello ------------------->|
   |<-- Welcome ------------------|
   |--- InferenceRequest -------->|
-  |                              | [CU reserved]
+  |                              | [TRM reserved]
   |<-- TokenStreamMsg ---------- |
   |<-- TokenStreamMsg ---------- |
   |<-- TokenStreamMsg (final) -- |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,11 +1,11 @@
-# Forge — Roadmap
+# Tirami — Roadmap
 
 ## Phase 1: Local Inference ✅
 
 - `tirami-core`: Type system (NodeId, LayerRange, ModelManifest, PeerCapability)
 - `tirami-infer`: llama.cpp engine, GGUF loader, streaming token generation
 - `tirami-node`: HTTP API (/chat, /chat/stream, /health)
-- `tirami-cli`: `forge chat` command with model auto-download
+- `tirami-cli`: `tirami chat` command with model auto-download
 
 ## Phase 2: P2P Protocol ✅
 
@@ -27,17 +27,17 @@
 - OpenAI-compatible API: `POST /v1/chat/completions`, `GET /v1/models`
 - TRM metering: every inference records a trade with `x_forge` extension
 - Agent budget endpoints: `GET /v1/tirami/balance`, `GET /v1/tirami/pricing`
-- CU→Lightning settlement bridge: `forge settle --pay`
+- TRM→Lightning settlement bridge: `tirami settle --pay`
 - Seed model auto-resolve from HF Hub
 - Graceful Ctrl-C shutdown with ledger persistence
 
 ## Phase 5: mesh-llm Fork Integration (next)
 
-**Goal:** Replace Forge's inference layer with mesh-llm's proven distributed engine.
+**Goal:** Replace Tirami's inference layer with mesh-llm's proven distributed engine.
 
 | Deliverable | Description |
 |---|---|
-| Fork mesh-llm | Create forge as a mesh-llm fork with economic layer |
+| Fork mesh-llm | Create tirami as a mesh-llm fork with economic layer |
 | Integrate tirami-ledger | Hook TRM recording into mesh-llm's inference pipeline |
 | Preserve economic API | Keep /v1/tirami/* endpoints in the new codebase |
 | Web console extension | Add TRM balance and trade visibility to mesh-llm's console |
@@ -65,7 +65,7 @@
 
 | Deliverable | Description |
 |---|---|
-| Model tier pricing | CU/token rates per model size class (small/medium/large/frontier) |
+| Model tier pricing | TRM/token rates per model size class (small/medium/large/frontier) |
 | MoE discount | Reduced pricing for mixture-of-experts models (active params / total params) |
 | Routing API | GET /v1/tirami/route for cost/quality-optimal provider selection |
 | Provider ranking | Multi-factor scoring (reputation, price, latency, model quality) |
@@ -73,7 +73,7 @@
 ## Phase 7: L2/L3/L4 Rust rewrite ✅ (2026-04-07)
 
 **Goal:** Replace the Python scaffolds for tirami-bank/mind/agora with Rust
-workspace crates inside `clearclown/forge`. Bit-for-bit semantic preservation.
+workspace crates inside `clearclown/tirami`. Bit-for-bit semantic preservation.
 
 | Deliverable | Status |
 |---|---|
@@ -81,13 +81,13 @@ workspace crates inside `clearclown/forge`. Bit-for-bit semantic preservation.
 | tirami-mind Rust crate (53 tests) | ✅ Harness, CuBudget, Benchmark, MetaOptimizer, ImprovementCycleRunner, ForgeMindAgent |
 | tirami-agora Rust crate (42 tests) | ✅ AgentRegistry, ReputationCalculator (4 sub-scores), CapabilityMatcher, Marketplace |
 | forge-economics §10/§11/§12 | ✅ All L2/L3/L4 constants centralized as single source of truth |
-| Python repos archived | ✅ Tagged v0.1.0-python-scaffold, redirect READMEs in clearclown/forge-{bank,mind,agora} |
+| Python repos archived | ✅ Tagged v0.1.0-python-scaffold, redirect READMEs in clearclown/tirami-{bank,mind,agora} |
 | Workspace tests | ✅ 291 passing (was 143) |
 
 ## Phase 8: L2/L3/L4 wired into tirami-node ✅ (2026-04-08)
 
-**Goal:** Make L2/L3/L4 first-class citizens of the running forge node.
-A single `forge node --port 3000` exposes the full 5-layer Forge ecosystem
+**Goal:** Make L2/L3/L4 first-class citizens of the running tirami node.
+A single `tirami node --port 3000` exposes the full 5-layer Tirami ecosystem
 over HTTP, real TRM is consumed by the self-improvement loop.
 
 | Deliverable | Status |
@@ -134,9 +134,9 @@ forge-mesh running CI, Compute Standard paper drafted, Prometheus + Bitcoin anch
 | P5 Prometheus metrics export | ✅ | `tirami_ledger::metrics::ForgeMetrics` + `/metrics` endpoint; 11 metric series including collusion scores |
 | P6 Bitcoin OP_RETURN anchoring | ✅ | `tirami_ledger::anchor` + `/v1/tirami/anchor` endpoint; 40-byte FRGE payload, 80-byte standard limit |
 | P7 Compute Standard paper v0.1 | ✅ | 7,000-word preprint in `forge-economics/papers/compute-standard.md`, arXiv-ready |
-| Workspace tests | ✅ | 337 → **359** (+22) |
+| Workspace tests | ✅ | 337 → **785** |
 | forge-mesh tests | ✅ | 641 → **646** (+5) |
-| verify-impl.sh | ✅ | 72 → **80 GREEN** |
+| verify-impl.sh | ✅ | 72 → **123 GREEN** |
 
 ## Phase 11: v0.4+ research frontier (planned)
 
@@ -163,6 +163,6 @@ and the A2A / MCP market layer.
 | Protocol v2 | Lessons from v1, backward-compatible evolution |
 | Cross-architecture | NVIDIA GPU, AMD ROCm, RISC-V support (via mesh-llm) |
 | Federated training | Distributed fine-tuning, not just inference |
-| Compute Standard paper | Academic publication on CU-native economics |
+| Compute Standard paper | Academic publication on TRM-native economics |
 
 > The protocol is the platform. The computation is the currency. The agents are the economy.

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -1,4 +1,4 @@
-# Forge — Strategy
+# Tirami — Strategy
 
 ## Competitive Landscape
 
@@ -18,25 +18,25 @@
 
 **What every competitor has in common:** A speculative token as the settlement layer. None use compute itself as currency.
 
-## Forge's Three Differentiators
+## Tirami's Three Differentiators
 
-### 1. CU-Native Economics (No Speculative Token)
+### 1. TRM-Native Economics (No Speculative Token)
 
 Every competitor settles in a tradeable token (TAO, AKT, GLM, RENDER, IO). Token value is driven by speculation, not utility. When token prices crash, provider incentives evaporate.
 
-Forge settles in TRM — a unit backed by verified useful computation. TRM cannot be pre-mined, ICO'd, or speculated on. Its value is intrinsic: 1 TRM represents real inference work that someone actually needed.
+Tirami settles in TRM — a unit backed by verified useful computation. TRM cannot be pre-mined, ICO'd, or speculated on. Its value is intrinsic: 1 TRM represents real inference work that someone actually needed.
 
 ### 2. Compute Lending With Interest
 
 **No other distributed inference project offers this.** This was confirmed through comprehensive competitive analysis.
 
-Existing projects: you either have compute hardware or you don't participate. Forge enables nodes without sufficient resources to borrow CU, access larger models, earn from better inference, and repay with interest. This is the key to lowering the participation barrier and solving the demand-side problem.
+Existing projects: you either have compute hardware or you don't participate. Tirami enables nodes without sufficient resources to borrow TRM, access larger models, earn from better inference, and repay with interest. This is the key to lowering the participation barrier and solving the demand-side problem.
 
 ### 3. Agent-First Budget Management
 
 No major AI agent framework (AutoGPT, CrewAI, LangGraph, LangChain) has a built-in economic layer. Agents cannot autonomously manage compute budgets, borrow resources, or make cost/quality tradeoffs.
 
-Forge's `/v1/tirami/balance`, `/pricing`, `/credit`, and `/borrow` endpoints let agents operate as fully autonomous economic actors within human-set policy limits.
+Tirami's `/v1/tirami/balance`, `/pricing`, `/credit`, and `/borrow` endpoints let agents operate as fully autonomous economic actors within human-set policy limits.
 
 ## 5-Layer Architecture
 
@@ -54,7 +54,7 @@ Forge's `/v1/tirami/balance`, `/pricing`, `/credit`, and `/borrow` endpoints let
 │  TRM lending, yield optimization, credit,        │
 │  futures, insurance, derivatives                │
 ├─────────────────────────────────────────────────┤
-│  Layer 1: Economy (forge — this repo)           │
+│  Layer 1: Economy (tirami — this repo)           │
 │  TRM ledger, dual-signed trades, dynamic pricing,│
 │  lending primitives, safety controls            │
 ├─────────────────────────────────────────────────┤
@@ -70,16 +70,16 @@ Forge's `/v1/tirami/balance`, `/pricing`, `/credit`, and `/borrow` endpoints let
 
 | Repository | Language | Status | Layer | Purpose |
 |-----------|----------|--------|-------|---------|
-| **forge** | Rust | Active | L1 | Protocol core: TRM ledger, trades, lending primitives, safety |
-| **forge-mesh** | Rust | Active | L0 | mesh-llm + Forge economic layer = production runtime |
-| **tirami-sdk** | Python | Published (PyPI) | Client | Python SDK for Forge API |
+| **tirami** | Rust | Active | L1 | Protocol core: TRM ledger, trades, lending primitives, safety |
+| **forge-mesh** | Rust | Active | L0 | mesh-llm + Tirami economic layer = production runtime |
+| **tirami-sdk** | Python | Published (PyPI) | Client | Python SDK for Tirami API |
 | **forge-cu-mcp** | Python | Published (PyPI) | Client | MCP server for AI tools (Claude, ChatGPT, Cursor) |
 | **tirami-bank** | Rust + Python | Planned | L2 | Advanced financial instruments (futures, insurance) |
 | **tirami-mind** | Python | Planned | L3 | AutoAgent self-improvement + TRM economy |
 | **tirami-agora** | Python/TypeScript | Planned | L4 | Agent marketplace, Nostr NIP-90, A2A |
 
 **Naming rationale:**
-- **forge** — The foundry. Where value is created from raw compute.
+- **tirami** — The foundry. Where value is created from raw compute.
 - **forge-mesh** — The network mesh. Physical inference execution.
 - **tirami-bank** — Financial services layer.
 - **tirami-mind** — Intelligence. Self-improving agents.
@@ -89,7 +89,7 @@ Forge's `/v1/tirami/balance`, `/pricing`, `/credit`, and `/borrow` endpoints let
 
 ### Problem
 
-To participate in Forge, you need hardware capable of running LLM inference. This creates a participation barrier identical to Bitcoin's ASIC problem. Lending solves this by enabling economic participation without upfront hardware investment.
+To participate in Tirami, you need hardware capable of running LLM inference. This creates a participation barrier identical to Bitcoin's ASIC problem. Lending solves this by enabling economic participation without upfront hardware investment.
 
 ### Participation Paths (enabled by lending)
 
@@ -100,7 +100,7 @@ To participate in Forge, you need hardware capable of running LLM inference. Thi
 | **C: Skills only** | No hardware | Contribute harnesses/curation → earn TRM → participate |
 | **D: Capital only** | Money, no hardware | Buy TRM via Lightning → lend to pool → earn yield |
 
-Path B is critical — without it, Forge cannot achieve network effects.
+Path B is critical — without it, Tirami cannot achieve network effects.
 
 ### LoanRecord Structure
 
@@ -207,7 +207,7 @@ Nodes that repay the "welcome loan" start building credit immediately. Nodes tha
 
 ### Model Tiers
 
-| Tier | Parameters | Base CU/token | Examples |
+| Tier | Parameters | Base TRM/token | Examples |
 |------|-----------|---------------|---------|
 | Small | < 3B | 1 | Qwen 2.5 0.5B, Phi-3 Mini |
 | Medium | 3B - 14B | 3 | Qwen 3 8B, Gemma 3 9B, Llama 3.2 8B |
@@ -270,23 +270,23 @@ where:
 
 mesh-llm already uses Nostr for peer discovery. NIP-90 ("Data Vending Machines") extends this naturally:
 
-| NIP-90 Concept | Forge Mapping |
+| NIP-90 Concept | Tirami Mapping |
 |---------------|---------------|
 | Job request (kind 5050) | Inference request with TRM budget |
-| Service provider | Forge node serving inference |
+| Service provider | Tirami node serving inference |
 | Job result (kind 6050) | Inference response with TRM cost |
 | Payment (Lightning zap) | TRM transfer (or Lightning via bridge) |
 | Provider discovery | Nostr relay + Agent Card |
 
 ### Integration approach
 
-1. Forge providers publish NIP-90 `kind:31990` handler events advertising models and TRM pricing
+1. Tirami providers publish NIP-90 `kind:31990` handler events advertising models and TRM pricing
 2. Consumers discover providers via Nostr relays
-3. Job requests include `X-Forge-Max-CU` tag
-4. Responses include `X-Forge-CU-Cost` tag
+3. Job requests include `X-Tirami-Max-TRM` tag
+4. Responses include `X-Tirami-TRM-Cost` tag
 5. Settlement happens via TRM protocol (bilateral signed trade) or Lightning (NIP-57 zap)
 
-This gives Forge instant access to Nostr's existing relay infrastructure without building a separate discovery network.
+This gives Tirami instant access to Nostr's existing relay infrastructure without building a separate discovery network.
 
 ## Phased Roadmap
 
@@ -297,14 +297,14 @@ This gives Forge instant access to Nostr's existing relay infrastructure without
 | 3 | Operator Ledger | Done | TRM accounting, HMAC-SHA256 integrity |
 | 4 | Economic API | Done | OpenAI-compatible API, TRM metering, agent endpoints |
 | **5** | **mesh-llm Fork** | **Next** | Replace inference layer, inherit pipeline parallelism, MoE, Nostr |
-| **5.5** | **CU Lending** | **Planned** | LoanRecord, credit score, lending API, collateral, safety |
+| **5.5** | **TRM Lending** | **Planned** | LoanRecord, credit score, lending API, collateral, safety |
 | **6** | **Multi-Model Pricing** | **Planned** | Model tiers, MoE discount, routing API |
 | **7** | **Discovery + Marketplace** | **Planned** | Reputation gossip, NIP-90, tirami-agora |
 | **8** | **Agent Intelligence** | **Planned** | tirami-mind, AutoAgent loops, self-reinforcement |
 
 See [roadmap.md](roadmap.md) for detailed deliverables per phase.
 
-## What Forge Is NOT
+## What Tirami Is NOT
 
 1. **Not a speculative token.** TRM is earned by performing useful work, not purchased or traded on exchanges. There is no ICO, no governance token, no token sale.
 
@@ -312,13 +312,13 @@ See [roadmap.md](roadmap.md) for detailed deliverables per phase.
 
 3. **Not a centralized authority.** No single entity controls TRM issuance, pricing, or access. Market prices emerge from local supply and demand observations.
 
-4. **Not a general compute platform.** Forge is optimized for LLM inference, not arbitrary computation. This focus enables inference-specific optimizations (model-aware pricing, MoE discounts, quality verification).
+4. **Not a general compute platform.** Tirami is optimized for LLM inference, not arbitrary computation. This focus enables inference-specific optimizations (model-aware pricing, MoE discounts, quality verification).
 
 5. **Not dependent on Bitcoin.** Lightning is an optional off-ramp for operators who need external liquidity. The protocol functions with zero external currency.
 
 ## Local AI Context
 
-The economic viability of running a Forge node on consumer hardware is crossing a threshold:
+The economic viability of running a Tirami node on consumer hardware is crossing a threshold:
 
 | Hardware | Cost | Model | Speed | Monthly electricity |
 |----------|------|-------|-------|-------------------|
@@ -332,4 +332,4 @@ The economic viability of running a Forge node on consumer hardware is crossing 
 - M5 Max (expected mid-2026) projects ~4x faster TTFT, ~12% faster decode
 - Cloud API costs ($5-15/M tokens) vs local inference ($5-10/month electricity) — local wins within months
 
-**Implication:** A $600 Mac Mini running 24/7 as a Forge node is economically viable as a "compute rental property" — generating TRM yield while the owner sleeps. TRM lending makes this accessible even to nodes that can't afford upfront hardware investment.
+**Implication:** A $600 Mac Mini running 24/7 as a Tirami node is economically viable as a "compute rental property" — generating TRM yield while the owner sleeps. TRM lending makes this accessible even to nodes that can't afford upfront hardware investment.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,4 +1,4 @@
-# Forge — Threat Model
+# Tirami — Threat Model
 
 ## Security Goals
 
@@ -134,23 +134,23 @@ Layer assignment should follow this hierarchy once split inference exists:
 
 ## Privacy Guarantees
 
-**What Forge guarantees today:**
+**What Tirami guarantees today:**
 - prompts and responses are encrypted in transit between directly connected peers
 - relays and passive network observers do not see decrypted prompt or response contents
 - there is no mandatory central server in the data path
 - the current seed/worker trust boundary is explicit
 
-**What Forge does not guarantee today:**
+**What Tirami does not guarantee today:**
 - that the seed cannot read the prompt or response
 - that split inference hides plaintext from all remote compute providers
 - that incorrect remote inference is detected automatically
 
-**What Forge is aiming to guarantee later:**
+**What Tirami is aiming to guarantee later:**
 - middle-stage peers do not receive plaintext prompts
 - activation tensors are encrypted in transit between pipeline stages
 - prompt visibility is reduced to the minimal set of trusted boundary nodes
 
-Those later guarantees depend on shipping actual split inference first. Until then, Forge should be described as encrypted remote inference with an honest trust boundary.
+Those later guarantees depend on shipping actual split inference first. Until then, Tirami should be described as encrypted remote inference with an honest trust boundary.
 
 ## Economic Threats
 


### PR DESCRIPTION
## Summary
All 19 files in docs/ updated:
- Forge → Tirami, CU → TRM, forge CLI → tirami CLI
- clearclown/forge → clearclown/tirami
- ForgeError → TiramiError, ForgeNode → TiramiNode
- forge-mesh/forge-economics refs preserved (actual repo names)

## Test plan
- [x] No code changes — docs only
- [x] `grep -rl 'Forge\b' docs/*.md` returns 0 files