### PR TITLE
fix: issues #60 #61 #62 — rate limiter + consumer ID + worker API

### DIFF
--- a/crates/tirami-cli/src/main.rs
+++ b/crates/tirami-cli/src/main.rs
@@ -74,6 +74,26 @@ enum Commands {
         /// Seed relay URL (optional, for NAT traversal)
         #[arg(long)]
         relay: Option<String>,
+
+        /// Port for the local HTTP API
+        #[arg(short, long, default_value = "3000")]
+        port: u16,
+
+        /// Bind address for the local HTTP API
+        #[arg(long, default_value = "127.0.0.1")]
+        bind: String,
+
+        /// Optional bearer token protecting administrative HTTP API routes
+        #[arg(long)]
+        api_token: Option<String>,
+
+        /// Path to the persisted ledger snapshot
+        #[arg(long, default_value = "forge-ledger.json")]
+        ledger: String,
+
+        /// Run as daemon (no interactive prompt)
+        #[arg(long)]
+        daemon: bool,
     },
 
     /// Start a local API server (no P2P)
@@ -426,8 +446,14 @@ async fn main() -> anyhow::Result<()> {
 
             node.run_seed().await?;
         }
-        Commands::Worker { seed, relay } => {
-            let config = Config::default();
+        Commands::Worker { seed, relay, port, bind, api_token, ledger, daemon } => {
+            let config = Config {
+                api_port: port,
+                api_bind_addr: bind.clone(),
+                api_bearer_token: resolve_api_token(api_token),
+                ledger_path: Some(PathBuf::from(&ledger)),
+                ..Config::default()
+            };
             let mut node = tirami_node::TiramiNode::new(config);
 
             let public_key: iroh::PublicKey = seed
@@ -445,46 +471,97 @@ async fn main() -> anyhow::Result<()> {
             let transport = node.connect_to_seed(seed_addr).await?;
             tracing::info!("Connected to seed. Ready for inference.");
 
-            // Interactive worker chat
-            let node_id = transport.tirami_node_id();
-            let peers = transport.connected_peers().await;
-            let seed_peer_id = peers
-                .first()
-                .ok_or_else(|| anyhow::anyhow!("no seed peer found"))?
-                .clone();
+            // Spawn HTTP API server in background (same pattern as Seed)
+            node.spawn_api();
 
-            println!("Forge Worker (connected to seed)");
-            println!("Type a prompt to send to the seed for inference.");
-            println!("---");
-
-            let stdin = io::stdin();
-            loop {
-                print!("> ");
-                io::stdout().flush()?;
-
-                let mut input = String::new();
-                stdin.lock().read_line(&mut input)?;
-                let input = input.trim();
-
-                if input.is_empty() {
-                    continue;
+            // Install Ctrl-C handler for graceful shutdown
+            let shutdown_ledger = node.ledger.clone();
+            let shutdown_ledger_path = node.config.ledger_path.clone();
+            let shutdown_bank = node.bank.clone();
+            let shutdown_marketplace = node.marketplace.clone();
+            let shutdown_mind = node.mind_agent.clone();
+            let shutdown_config = node.config.clone();
+            tokio::spawn(async move {
+                if tokio::signal::ctrl_c().await.is_ok() {
+                    tracing::info!("Received Ctrl-C, persisting state...");
+                    if let Some(path) = shutdown_ledger_path {
+                        if let Err(e) = shutdown_ledger.lock().await.save_to_path(&path) {
+                            tracing::warn!("Failed to persist ledger on shutdown: {}", e);
+                        } else {
+                            tracing::info!("Ledger persisted to {}", path.display());
+                        }
+                    }
+                    if let Some(ref path) = shutdown_config.bank_state_path {
+                        let bank = shutdown_bank.lock().await;
+                        if let Err(e) = tirami_node::state_persist::save_bank(&*bank, path) {
+                            tracing::warn!("Failed to persist bank state: {}", e);
+                        }
+                    }
+                    if let Some(ref path) = shutdown_config.marketplace_state_path {
+                        let mp = shutdown_marketplace.lock().await;
+                        if let Err(e) = tirami_node::state_persist::save_marketplace(&*mp, path) {
+                            tracing::warn!("Failed to persist marketplace state: {}", e);
+                        }
+                    }
+                    if let Some(ref path) = shutdown_config.mind_state_path {
+                        let mind = shutdown_mind.lock().await;
+                        if let Some(agent) = mind.as_ref() {
+                            if let Err(e) = tirami_node::state_persist::save_mind(agent, path) {
+                                tracing::warn!("Failed to persist mind state: {}", e);
+                            }
+                        }
+                    }
+                    std::process::exit(0);
                 }
-                if input == "quit" || input == "exit" {
-                    break;
-                }
+            });
 
-                match tirami_node::pipeline::PipelineCoordinator::request_inference(
-                    &transport,
-                    &seed_peer_id,
-                    &node_id,
-                    input,
-                    256,
-                    0.7,
-                )
-                .await
-                {
-                    Ok(response) => println!("{}", response),
-                    Err(e) => eprintln!("Error: {}", e),
+            if daemon {
+                tracing::info!("Worker running in daemon mode (Ctrl-C to stop)");
+                // Block forever — the HTTP API runs in the background
+                std::future::pending::<()>().await;
+            } else {
+                // Interactive worker chat
+                let node_id = transport.tirami_node_id();
+                let peers = transport.connected_peers().await;
+                let seed_peer_id = peers
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("no seed peer found"))?
+                    .clone();
+
+                println!("Tirami Worker (connected to seed)");
+                println!("HTTP API at http://{}:{}", bind, port);
+                println!("Type a prompt to send to the seed for inference.");
+                println!("---");
+
+                let stdin = io::stdin();
+                loop {
+                    print!("> ");
+                    io::stdout().flush()?;
+
+                    let mut input = String::new();
+                    stdin.lock().read_line(&mut input)?;
+                    let input = input.trim();
+
+                    if input.is_empty() {
+                        continue;
+                    }
+                    if input == "quit" || input == "exit" {
+                        break;
+                    }
+
+                    match tirami_node::pipeline::PipelineCoordinator::request_inference(
+                        &transport,
+                        &seed_peer_id,
+                        &node_id,
+                        input,
+                        256,
+                        0.7,
+                    )
+                    .await
+                    {
+                        Ok(response) => println!("{}", response),
+                        Err(e) => eprintln!("Error: {}", e),
+                    }
                 }
             }
         }

--- a/crates/tirami-net/src/transport.rs
+++ b/crates/tirami-net/src/transport.rs
@@ -202,28 +202,37 @@ impl ForgeTransport {
         peers: Arc<Mutex<HashMap<String, PeerConnection>>>,
         recent_msg_ids: Arc<Mutex<HashMap<String, ReplayWindow>>>,
     ) {
-        // Rate limit: max 100 messages per second per peer
-        let mut msg_count_this_second: u32 = 0;
-        let mut last_rate_reset = tokio::time::Instant::now();
-        const MAX_MESSAGES_PER_SECOND: u32 = 100;
+        // Token bucket rate limiter: 500 msg/s sustained, 200 burst capacity,
+        // with a 5-second grace period after connection to absorb handshake bursts.
+        const MAX_MESSAGES_PER_SECOND: u32 = 500;
+        const BURST_CAPACITY: u32 = 200;
+        const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(5);
+
+        let connection_start = tokio::time::Instant::now();
+        let mut tokens: f64 = BURST_CAPACITY as f64;
+        let mut last_refill = tokio::time::Instant::now();
 
         loop {
-            // Reset rate counter every second
-            if last_rate_reset.elapsed() >= std::time::Duration::from_secs(1) {
-                msg_count_this_second = 0;
-                last_rate_reset = tokio::time::Instant::now();
-            }
+            // Refill tokens based on elapsed time
+            let now = tokio::time::Instant::now();
+            let elapsed = now.duration_since(last_refill).as_secs_f64();
+            tokens = (tokens + elapsed * MAX_MESSAGES_PER_SECOND as f64)
+                .min(BURST_CAPACITY as f64);
+            last_refill = now;
 
             match peer.recv_message().await {
                 Ok(envelope) => {
-                    msg_count_this_second += 1;
-                    if msg_count_this_second > MAX_MESSAGES_PER_SECOND {
+                    // Grace period: no rate limiting in first 5 seconds
+                    let in_grace = connection_start.elapsed() < GRACE_PERIOD;
+                    if !in_grace && tokens < 1.0 {
                         tracing::warn!(
-                            "Rate limit exceeded for peer {} ({} msg/s), dropping message",
+                            "Rate limit exceeded for peer {} (token bucket empty), dropping message",
                             peer_id,
-                            msg_count_this_second
                         );
                         continue;
+                    }
+                    if !in_grace {
+                        tokens -= 1.0;
                     }
 
                     if let Err(err) = envelope.validate_for_peer(peer.peer_node_id()) {
@@ -325,5 +334,84 @@ impl ForgeTransport {
         self.closed.store(true, Ordering::SeqCst);
         self.shutdown.notify_waiters();
         self.endpoint.close().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that the token bucket rate limiter allows bursts during the
+    /// grace period and correctly limits after the grace period expires.
+    #[test]
+    fn token_bucket_grace_period() {
+        const MAX_MESSAGES_PER_SECOND: u32 = 500;
+        const BURST_CAPACITY: u32 = 200;
+        const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(5);
+
+        // Simulate connection start (grace period active)
+        let connection_start = std::time::Instant::now();
+        let mut tokens: f64 = BURST_CAPACITY as f64;
+
+        // During grace period, messages should never be dropped even if
+        // we exceed BURST_CAPACITY.
+        let in_grace = connection_start.elapsed() < GRACE_PERIOD;
+        assert!(in_grace, "should be in grace period immediately after start");
+
+        // Drain all tokens — during grace period this should not matter
+        for _ in 0..300 {
+            // In grace period: tokens are not consumed
+            if in_grace {
+                // no token deduction
+            } else {
+                tokens -= 1.0;
+            }
+        }
+
+        // Tokens should be untouched because we were in grace period
+        assert_eq!(tokens, BURST_CAPACITY as f64);
+
+        // After grace period: simulate token consumption
+        let mut tokens: f64 = BURST_CAPACITY as f64;
+        let mut dropped = 0u32;
+        for _ in 0..250 {
+            if tokens < 1.0 {
+                dropped += 1;
+                continue;
+            }
+            tokens -= 1.0;
+        }
+
+        // Should have dropped 50 messages (250 - 200 burst capacity)
+        assert_eq!(dropped, 50);
+        assert!(tokens < 1.0, "tokens should be exhausted");
+
+        // Simulate refill: 0.1 seconds at 500/s = 50 tokens
+        let refill_elapsed = 0.1_f64;
+        tokens = (tokens + refill_elapsed * MAX_MESSAGES_PER_SECOND as f64)
+            .min(BURST_CAPACITY as f64);
+        assert!((tokens - 50.0).abs() < 1.0, "should have ~50 tokens after refill");
+    }
+
+    #[test]
+    fn replay_window_dedup() {
+        let mut window = ReplayWindow::default();
+        assert!(window.record(1));
+        assert!(window.record(2));
+        assert!(!window.record(1), "duplicate should be rejected");
+        assert!(window.record(3));
+    }
+
+    #[test]
+    fn replay_window_eviction() {
+        let mut window = ReplayWindow::default();
+        for i in 0..MAX_RECENT_MSG_IDS_PER_PEER + 100 {
+            assert!(window.record(i as u64));
+        }
+        // Old IDs should have been evicted
+        assert!(
+            window.record(0),
+            "msg_id 0 should be accepted again after eviction"
+        );
     }
 }

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -719,10 +719,23 @@ async fn model_name(manifest: &ModelState) -> String {
         .unwrap_or_else(|| "forge-no-model".to_string())
 }
 
+/// Parse an `X-Tirami-Node-Id` header (64-char hex → NodeId).
+fn parse_consumer_header(headers: &axum::http::HeaderMap) -> Option<NodeId> {
+    let hex_str = headers.get("X-Tirami-Node-Id")?.to_str().ok()?;
+    if hex_str.len() == 64 {
+        let mut id = [0u8; 32];
+        hex::decode_to_slice(hex_str, &mut id).ok()?;
+        Some(NodeId(id))
+    } else {
+        None
+    }
+}
+
 /// Record a trade in the ledger after inference.
 async fn record_api_trade(
     ledger: &LedgerState,
     provider: &NodeId,
+    consumer: Option<NodeId>,
     tokens: u32,
     model_id: &str,
 ) -> u64 {
@@ -730,7 +743,7 @@ async fn record_api_trade(
     let trm_cost = ledger.estimate_cost(tokens as u64, 1, 1);
     let trade = TradeRecord {
         provider: provider.clone(),
-        consumer: NodeId([255u8; 32]), // API caller (anonymous local)
+        consumer: consumer.unwrap_or(NodeId([255u8; 32])),
         trm_amount: trm_cost,
         tokens_processed: tokens as u64,
         timestamp: now_millis(),
@@ -906,6 +919,7 @@ async fn chat_stream(
 /// POST /v1/chat/completions — OpenAI-compatible chat completions.
 async fn openai_chat_completions(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<OpenAIChatRequest>,
 ) -> Result<Response, (StatusCode, String)> {
     use axum::response::IntoResponse;
@@ -972,11 +986,12 @@ async fn openai_chat_completions(
 
     let model = model_name(&state.model_manifest).await;
     let stream = req.stream.unwrap_or(false);
+    let consumer_id = parse_consumer_header(&headers);
 
     if stream {
-        openai_stream_response(state, prompt, max_tokens, temperature, top_p, top_k, model, has_tools).await
+        openai_stream_response(state, prompt, max_tokens, temperature, top_p, top_k, model, has_tools, consumer_id).await
     } else {
-        openai_sync_response(state, prompt, max_tokens, temperature, top_p, top_k, model, has_tools)
+        openai_sync_response(state, prompt, max_tokens, temperature, top_p, top_k, model, has_tools, consumer_id)
             .await
             .map(|json| json.into_response())
     }
@@ -992,6 +1007,7 @@ async fn openai_sync_response(
     top_k: Option<i32>,
     model: String,
     has_tools: bool,
+    consumer_id: Option<NodeId>,
 ) -> Result<Json<OpenAIChatResponse>, (StatusCode, String)> {
     let mut engine = state.engine.lock().await;
     if !engine.is_loaded() {
@@ -1035,7 +1051,7 @@ async fn openai_sync_response(
 
     // Record trade in ledger
     let trm_cost =
-        record_api_trade(&state.ledger, &state.local_node_id, completion_tokens, &model).await;
+        record_api_trade(&state.ledger, &state.local_node_id, consumer_id, completion_tokens, &model).await;
     let effective_balance = state.ledger.lock().await.effective_balance(&state.local_node_id);
 
     // If tools were injected, try to extract a tool call from the model output.
@@ -1119,6 +1135,7 @@ async fn openai_stream_response(
     top_k: Option<i32>,
     model: String,
     has_tools: bool,
+    consumer_id: Option<NodeId>,
 ) -> Result<Response, (StatusCode, String)> {
     use axum::response::IntoResponse;
     use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -1272,7 +1289,7 @@ async fn openai_stream_response(
 
         // Record trade in ledger asynchronously after streaming finishes.
         rt.spawn(async move {
-            record_api_trade(&ledger_arc, &provider_id, count, &model_for_trade).await;
+            record_api_trade(&ledger_arc, &provider_id, consumer_id, count, &model_for_trade).await;
         });
     });
 
@@ -3099,5 +3116,54 @@ mod tests {
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn record_api_trade_uses_consumer_from_header() {
+        let ledger: LedgerState = Arc::new(Mutex::new(ComputeLedger::new()));
+        let provider = NodeId([1u8; 32]);
+
+        // With an explicit consumer
+        let consumer = NodeId([42u8; 32]);
+        record_api_trade(&ledger, &provider, Some(consumer.clone()), 100, "test-model").await;
+
+        let trades = ledger.lock().await.recent_trades(1);
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].consumer, consumer);
+    }
+
+    #[tokio::test]
+    async fn record_api_trade_falls_back_to_anonymous() {
+        let ledger: LedgerState = Arc::new(Mutex::new(ComputeLedger::new()));
+        let provider = NodeId([1u8; 32]);
+
+        // Without a consumer (None) → anonymous
+        record_api_trade(&ledger, &provider, None, 100, "test-model").await;
+
+        let trades = ledger.lock().await.recent_trades(1);
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].consumer, NodeId([255u8; 32]));
+    }
+
+    #[test]
+    fn parse_consumer_header_valid_hex() {
+        let mut headers = axum::http::HeaderMap::new();
+        let hex_id = "aa".repeat(32); // 64-char hex → [0xaa; 32]
+        headers.insert("X-Tirami-Node-Id", hex_id.parse().unwrap());
+        let result = parse_consumer_header(&headers);
+        assert_eq!(result, Some(NodeId([0xaa; 32])));
+    }
+
+    #[test]
+    fn parse_consumer_header_missing() {
+        let headers = axum::http::HeaderMap::new();
+        assert_eq!(parse_consumer_header(&headers), None);
+    }
+
+    #[test]
+    fn parse_consumer_header_wrong_length() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("X-Tirami-Node-Id", "abcdef".parse().unwrap());
+        assert_eq!(parse_consumer_header(&headers), None);
     }
 }

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -187,41 +187,11 @@ impl TiramiNode {
         Ok(())
     }
 
-    /// Initialize P2P transport.
-    pub async fn init_transport(&mut self) -> Result<Arc<ForgeTransport>, tirami_core::TiramiError> {
-        if let Some(transport) = self.transport.as_ref() {
-            return Ok(transport.clone());
-        }
-
-        let transport = ForgeTransport::new()
-            .await
-            .map_err(|e| tirami_core::TiramiError::NetworkError(format!("transport: {e}")))?;
-        let transport = Arc::new(transport);
-        let local_capability = build_local_capability(&self.config, transport.tirami_node_id());
-        self.cluster = Some(Arc::new(ClusterManager::new(
-            transport.clone(),
-            local_capability,
-        )));
-        self.transport = Some(transport.clone());
-        Ok(transport)
-    }
-
-    /// Run as a Seed node — holds model, serves inference, earns CU.
-    pub async fn run_seed(&mut self) -> Result<(), tirami_core::TiramiError> {
-        let transport = self.init_transport().await?;
-
-        let addr = transport.endpoint_addr();
-        let id = transport.endpoint_id();
-        tracing::info!("=== FORGE SEED NODE ===");
-        tracing::info!("Public key: {}", id);
-        tracing::info!("Node ID: {}", transport.tirami_node_id());
-        tracing::info!("Full address: {:?}", addr);
-        tracing::info!("Workers connect with: forge worker --seed {}", id);
-
-        // Accept connections
-        let _accept_handle = transport.start_accepting();
-
-        // API server in background
+    /// Spawn the HTTP API server as a background tokio task.
+    ///
+    /// Returns a `JoinHandle` so the caller can optionally await it, but
+    /// typically it runs until the process exits.
+    pub fn spawn_api(&self) -> tokio::task::JoinHandle<()> {
         let engine_api = self.engine.clone();
         let ledger_api = self.ledger.clone();
         let manifest_api = self.model_manifest.clone();
@@ -257,7 +227,45 @@ impl TiramiNode {
                 tracing::info!("HTTP API at http://{}", addr);
                 let _ = axum::serve(listener, app).await;
             }
-        });
+        })
+    }
+
+    /// Initialize P2P transport.
+    pub async fn init_transport(&mut self) -> Result<Arc<ForgeTransport>, tirami_core::TiramiError> {
+        if let Some(transport) = self.transport.as_ref() {
+            return Ok(transport.clone());
+        }
+
+        let transport = ForgeTransport::new()
+            .await
+            .map_err(|e| tirami_core::TiramiError::NetworkError(format!("transport: {e}")))?;
+        let transport = Arc::new(transport);
+        let local_capability = build_local_capability(&self.config, transport.tirami_node_id());
+        self.cluster = Some(Arc::new(ClusterManager::new(
+            transport.clone(),
+            local_capability,
+        )));
+        self.transport = Some(transport.clone());
+        Ok(transport)
+    }
+
+    /// Run as a Seed node — holds model, serves inference, earns CU.
+    pub async fn run_seed(&mut self) -> Result<(), tirami_core::TiramiError> {
+        let transport = self.init_transport().await?;
+
+        let addr = transport.endpoint_addr();
+        let id = transport.endpoint_id();
+        tracing::info!("=== FORGE SEED NODE ===");
+        tracing::info!("Public key: {}", id);
+        tracing::info!("Node ID: {}", transport.tirami_node_id());
+        tracing::info!("Full address: {:?}", addr);
+        tracing::info!("Workers connect with: forge worker --seed {}", id);
+
+        // Accept connections
+        let _accept_handle = transport.start_accepting();
+
+        // API server in background
+        self.spawn_api();
 
         // Run pipeline coordinator with ledger
         let coordinator = PipelineCoordinator::new(transport);


### PR DESCRIPTION
## Summary
Fixes 3 open issues:

**#60 P2P rate limiter too aggressive**
- Token bucket (500/s, burst 200) replaces hard 100 msg/s counter
- 5-second grace period after connection for handshake burst

**#61 Anonymous consumer in HTTP API trades**
- `X-Tirami-Node-Id` header support in chat completion handlers
- Enables agent credit building via REST API

**#62 Worker lacks HTTP API**
- `--port`, `--bind`, `--api-token`, `--ledger`, `--daemon` flags added
- HTTP API spawned in background (same pattern as seed)
- Workers are now full economic participants

## Metrics
- 793 tests (was 785), 0 failing
- 123/123 verify-impl GREEN

## Test plan
- [x] `cargo test --workspace --lib` — 793 pass
- [x] `cargo check --workspace` — clean
- [x] `bash scripts/verify-impl.sh` — 123/123 GREEN

Closes #60 Closes #61 Closes #62