### PR TITLE
Polish: challenger-side audit loop + SDK/MCP anchor bindings + CLAUDE.md refresh (+7 tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ Tirami is a distributed LLM inference protocol where **compute is currency**. Th
 
 | Repo | Language | Status | Layer | Purpose |
 |------|----------|--------|-------|---------|
-| `clearclown/tirami` (this) | Rust | Active (785 tests) | L1-L4 | Protocol core + finance, intelligence, marketplace + tokenomics + governance + staking + signed reputation gossip + collusion detection + NIP-90 relay publish + Prometheus metrics + Bitcoin OP_RETURN anchoring (Rust workspace, 14 crates) |
+| `clearclown/tirami` (this) | Rust | Active (891 tests) | L1-L4 | Protocol core + finance, intelligence, marketplace + tokenomics + governance + staking + signed reputation gossip + collusion detection + NIP-90 relay + Prometheus metrics + Bitcoin OP_RETURN anchoring + **PeerRegistry + PriceSignal + select_provider (Phase 14) + FLOP measurement + tirami start (Phase 15) + audit challenge-response + hybrid-chain anchor (Phase 16)** (Rust workspace, 15 crates) |
+| `clearclown/tirami-contracts` | Solidity (Foundry) | Skeleton | On-chain | TRM ERC-20 + TiramiBridge (Phase 16). Target: Base L2. Not deployed. |
 | `nm-arealnormalman/mesh-llm` | Rust | Active (43 tests) | L0 | mesh-llm + Tirami economy = production runtime |
 | `clearclown/tirami-bank` | Python (archived) | Scaffold v0.1 (45 tests) | — | Superseded by `crates/tirami-bank/` in this repo |
 | `clearclown/tirami-mind` | Python (archived) | Scaffold v0.1 (40 tests) | — | Superseded by `crates/tirami-mind/` in this repo |
@@ -51,7 +52,7 @@ The integrated fork at `/Users/ablaze/Projects/forge-mesh` contains mesh-llm's f
 
 ```bash
 cargo build --release          # Full build
-cargo test --workspace         # All tests (785 across 14 crates)
+cargo test --workspace         # All tests (891 across 15 crates)
 cargo check --workspace        # Fast type check
 cargo clippy --workspace       # Lint
 ```
@@ -147,6 +148,16 @@ Inference Layer (mesh-llm-derived)  ← This is inherited
 
 ### Tirami Routing (Phase 6 — implemented)
 - `GET /v1/tirami/route?model=X&max_cu=Y&mode=cost|quality|balanced` — Optimal provider selection
+
+### Tirami Unified Scheduler (Phase 14 — implemented)
+- `GET /v1/tirami/peers` — PeerRegistry dump (price_multiplier, available_cu, audit_tier, latency_ema_ms, models)
+- `POST /v1/tirami/schedule` — Ledger-as-Brain probe. `{model_id, max_tokens, consumer?}` → `{provider, estimated_trm_cost}` (read-only, no TRM reserved)
+- Chat completions now attribute trades via `X-Tirami-Node-Id` header (Phase 14.3) and record `flops_estimated` on every `TradeRecord` (Phase 15)
+
+### Tirami Hybrid Chain Anchor (Phase 16 — implemented, MockChainClient default)
+- `GET /v1/tirami/anchors` — list submitted batches: `batch_id`, `tx_hash`, `merkle_root_hex`, `submitted_at_ms`, `node_count`, `flops_total`
+- Anchor loop runs every `config.anchor_interval_secs` (default 3600 dev, 600 prod per §20)
+- Swappable `ChainClient` trait — `MockChainClient` in-memory default; future `BaseClient` for Base L2
 
 ### Tirami Bank L2 (Phase 8 — implemented)
 - `GET /v1/tirami/bank/portfolio` — Portfolio snapshot + cash/lent/borrowed/exposure

--- a/crates/tirami-ledger/src/peer_registry.rs
+++ b/crates/tirami-ledger/src/peer_registry.rs
@@ -207,6 +207,41 @@ impl PeerRegistry {
         self.peers.retain(|_, s| now_ms.saturating_sub(s.last_seen) < stale_threshold_ms);
         before - self.peers.len()
     }
+
+    /// Phase 14.3 — probabilistically select peers for audit based on their
+    /// `AuditTier`. Each peer is rolled independently against its tier
+    /// probability. Returns cloned NodeIds plus the ModelId they advertise
+    /// (required for a challenge).
+    ///
+    /// - `now_ms` — used to skip peers that haven't been seen in > 24h.
+    /// - `rng_sample` — callback returning a uniform float in `[0, 1)`.
+    ///   Tests pass a deterministic sampler; production uses `rand::random`.
+    pub fn select_audit_targets<F>(
+        &self,
+        now_ms: u64,
+        mut rng_sample: F,
+    ) -> Vec<(NodeId, ModelId)>
+    where
+        F: FnMut() -> f64,
+    {
+        const STALE_THRESHOLD_MS: u64 = 24 * 60 * 60 * 1000; // 24h
+        self.peers
+            .iter()
+            .filter(|(_, s)| now_ms.saturating_sub(s.last_seen) < STALE_THRESHOLD_MS)
+            .filter_map(|(id, s)| {
+                let prob = s.audit_tier.audit_probability();
+                if rng_sample() < prob {
+                    // Pick any served model — audit needs a real model id.
+                    s.price_signal
+                        .as_ref()
+                        .and_then(|sig| sig.model_capabilities.first().cloned())
+                        .map(|m| (id.clone(), m))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 // ===========================================================================
@@ -357,6 +392,49 @@ mod tests {
         let node = sample_node(1);
         r.record_verified_trade(&node);
         assert_eq!(r.get(&node).unwrap().audit_tier, AuditTier::Probationary);
+    }
+
+    #[test]
+    fn select_audit_targets_picks_unverified_always() {
+        let mut r = PeerRegistry::new();
+        r.ingest_price_signal(&sample_signal(sample_node(1), 1.0, 100));
+        // Even with rng returning 0.99, Unverified probability is 1.0.
+        let picks = r.select_audit_targets(200, || 0.99);
+        assert_eq!(picks.len(), 1);
+        assert_eq!(picks[0].0, sample_node(1));
+    }
+
+    #[test]
+    fn select_audit_targets_skips_trusted_on_high_roll() {
+        let mut r = PeerRegistry::new();
+        r.ingest_price_signal(&sample_signal(sample_node(1), 1.0, 100));
+        // Promote to Trusted.
+        for _ in 0..3 {
+            r.record_audit_result(&sample_node(1), true);
+        }
+        assert_eq!(r.get(&sample_node(1)).unwrap().audit_tier, AuditTier::Trusted);
+        // Trusted probability = 0.01; roll of 0.5 must skip.
+        let picks = r.select_audit_targets(200, || 0.5);
+        assert!(picks.is_empty());
+    }
+
+    #[test]
+    fn select_audit_targets_skips_stale_peers() {
+        let mut r = PeerRegistry::new();
+        r.ingest_price_signal(&sample_signal(sample_node(1), 1.0, 100));
+        // 25 hours later — stale.
+        let now = 100 + 25 * 60 * 60 * 1000;
+        let picks = r.select_audit_targets(now, || 0.0);
+        assert!(picks.is_empty());
+    }
+
+    #[test]
+    fn select_audit_targets_requires_model_advertised() {
+        let mut r = PeerRegistry::new();
+        // Peer with default state (no price_signal) — can't audit.
+        r.ensure(&sample_node(1));
+        let picks = r.select_audit_targets(100, || 0.0);
+        assert!(picks.is_empty());
     }
 
     #[test]

--- a/crates/tirami-mcp/src/main.rs
+++ b/crates/tirami-mcp/src/main.rs
@@ -192,6 +192,7 @@ impl ForgeMcpServer {
                 }
                 self.client.post("/v1/tirami/schedule", body).await
             }
+            "tirami_anchors" => self.client.get("/v1/tirami/anchors").await,
             "tirami_chat_as" => {
                 let consumer_hex = obj
                     .get("consumer_hex")
@@ -503,14 +504,14 @@ mod tests {
     use super::tools;
 
     #[test]
-    fn test_tool_list_has_43_tools() {
-        // Phase 15 added 3 tools: tirami_peers, tirami_schedule, tirami_chat_as.
+    fn test_tool_list_has_44_tools() {
+        // Phase 15 added 3 (peers/schedule/chat_as); Phase 16 added tirami_anchors.
         let tools = tools::build_tool_list();
-        assert_eq!(tools.len(), 43, "expected 43 tools, got {}", tools.len());
+        assert_eq!(tools.len(), 44, "expected 44 tools, got {}", tools.len());
     }
 
     #[test]
-    fn test_phase_15_tools_present() {
+    fn test_phase_15_16_tools_present() {
         let tools = tools::build_tool_list();
         let names: std::collections::HashSet<String> = tools
             .iter()
@@ -519,6 +520,7 @@ mod tests {
         assert!(names.contains("tirami_peers"), "tirami_peers missing");
         assert!(names.contains("tirami_schedule"), "tirami_schedule missing");
         assert!(names.contains("tirami_chat_as"), "tirami_chat_as missing");
+        assert!(names.contains("tirami_anchors"), "tirami_anchors missing");
     }
 
     #[test]

--- a/crates/tirami-mcp/src/tools.rs
+++ b/crates/tirami-mcp/src/tools.rs
@@ -161,6 +161,16 @@ pub fn build_tool_list() -> Vec<Tool> {
                 "required": ["consumer_hex", "prompt", "max_tokens"]
             })),
         ),
+        Tool::new(
+            "tirami_anchors",
+            "Phase 16 — List on-chain batch anchors submitted by this node. Each entry \
+             includes batch_id, tx_hash, merkle_root_hex, submitted_at_ms, node_count, \
+             and flops_total. Uses the configured ChainClient (MockChainClient by default).",
+            schema(json!({
+                "type": "object",
+                "properties": {}
+            })),
+        ),
 
         // ====================================================================
         // Safety (2 tools)

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -283,6 +283,10 @@ impl TiramiNode {
         // by default; real Base L2 wiring lands once tirami-contracts ships).
         self.spawn_anchor_loop();
 
+        // Phase 14.3 — challenger-side audit loop: periodically picks peers
+        // per their AuditTier probability and sends AuditChallenge messages.
+        self.spawn_audit_challenger_loop(transport.clone());
+
         // Run pipeline coordinator with ledger
         let coordinator = PipelineCoordinator::new(transport);
         coordinator
@@ -346,6 +350,135 @@ impl TiramiNode {
     }
 
     /// Spawn the periodic price signal broadcast task (30s default).
+    /// Phase 14.3 — challenger-side audit loop.
+    ///
+    /// Every 60s: roll each peer's `AuditTier.audit_probability()` and, for
+    /// those selected, compute the expected output hash locally (via our own
+    /// engine's `generate_audit`) then send an `AuditChallenge`. Responses
+    /// flow through the pipeline handler which calls `record_audit_result`.
+    ///
+    /// Requires a loaded model: we can only validate hashes for models we can
+    /// run ourselves. If no model is loaded the loop is a no-op.
+    fn spawn_audit_challenger_loop(&self, transport: Arc<ForgeTransport>) {
+        let ledger = self.ledger.clone();
+        let engine = self.engine.clone();
+        let model_manifest = self.model_manifest.clone();
+        let my_id = transport.tirami_node_id();
+
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
+            // Skip the immediate first tick — let peers register first.
+            ticker.tick().await;
+
+            loop {
+                ticker.tick().await;
+
+                // Only run if we have a model loaded — audit requires running
+                // the same forward pass locally.
+                let Some(local_model) = model_manifest.lock().await.as_ref().map(|m| m.id.clone())
+                else {
+                    continue;
+                };
+
+                // Select audit targets from the PeerRegistry.
+                let now_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0);
+                let targets: Vec<_> = {
+                    let guard = ledger.lock().await;
+                    guard
+                        .peer_registry
+                        .select_audit_targets(now_ms, || rand::random::<f64>())
+                        .into_iter()
+                        // Must match our own loaded model.
+                        .filter(|(_, m)| *m == local_model)
+                        // Never audit ourselves.
+                        .filter(|(id, _)| *id != my_id)
+                        .collect()
+                };
+
+                if targets.is_empty() {
+                    continue;
+                }
+
+                // Build a deterministic challenge input. For simplicity the
+                // current revision uses a canned sequence of tokens; future
+                // versions could pick from a shared corpus.
+                let input_tokens: Vec<u32> = (1..=16).collect();
+
+                for (target, model_id) in targets {
+                    use tirami_infer::InferenceEngine;
+
+                    // Compute the expected hash with our own engine.
+                    let expected_hash = {
+                        let mut eng = engine.lock().await;
+                        match eng.generate_audit(&input_tokens) {
+                            Ok(h) => h,
+                            Err(e) => {
+                                tracing::warn!(%e, "generate_audit (challenger) failed");
+                                continue;
+                            }
+                        }
+                    };
+
+                    // Register the pending challenge.
+                    let challenge = {
+                        let mut guard = ledger.lock().await;
+                        guard.audit_tracker.issue_challenge(
+                            target.clone(),
+                            model_id.clone(),
+                            expected_hash,
+                            now_ms,
+                        )
+                    };
+
+                    // Send over P2P transport.
+                    let msg = tirami_proto::Envelope {
+                        msg_id: rand::random(),
+                        sender: my_id.clone(),
+                        timestamp: now_ms,
+                        payload: tirami_proto::Payload::AuditChallenge(
+                            tirami_proto::AuditChallengeMsg {
+                                challenge_id: challenge.challenge_id,
+                                challenger: my_id.clone(),
+                                target: target.clone(),
+                                model_id,
+                                input_tokens: input_tokens.clone(),
+                                expected_output_hash: expected_hash,
+                                timestamp: now_ms,
+                            },
+                        ),
+                    };
+
+                    // Convert target NodeId → PeerId for transport send.
+                    // tirami-net uses a stringified peer id; we match by hex.
+                    let peers = transport.connected_peers().await;
+                    if let Some(peer_id) = peers.iter().find(|p| {
+                        p.to_string().contains(&hex::encode(&target.0[..8]))
+                    }) {
+                        if let Err(e) = transport.send_to(peer_id, &msg).await {
+                            tracing::debug!(%e, "audit challenge send failed");
+                        } else {
+                            tracing::info!(
+                                target = %target.to_hex(),
+                                challenge_id = challenge.challenge_id,
+                                "sent audit challenge"
+                            );
+                        }
+                    }
+                }
+
+                // House-keeping: drop expired challenges.
+                let mut guard = ledger.lock().await;
+                let pruned = guard.audit_tracker.prune_expired(now_ms);
+                if pruned > 0 {
+                    tracing::debug!(count = pruned, "pruned expired audit challenges");
+                }
+            }
+        });
+    }
+
     /// Phase 16 — spawn the periodic on-chain anchor loop.
     ///
     /// Default uses `MockChainClient` (in-memory). The anchor interval comes

--- a/crates/tirami-sdk/src/client.rs
+++ b/crates/tirami-sdk/src/client.rs
@@ -140,6 +140,16 @@ impl TiramiClient {
         Ok(serde_json::from_value(v)?)
     }
 
+    /// `GET /v1/tirami/anchors` — Phase 16 anchor history.
+    ///
+    /// Lists every on-chain batch submission this node has observed from
+    /// its configured `ChainClient`. MockChainClient returns in-memory
+    /// history; a real Base L2 client would return the chain-side record.
+    pub async fn anchors(&self) -> Result<AnchorsResponse, SdkError> {
+        let v = self.get("/v1/tirami/anchors").await?;
+        Ok(serde_json::from_value(v)?)
+    }
+
     /// `POST /v1/tirami/schedule` — Phase 14.2 Ledger-as-Brain probe.
     ///
     /// Asks the node "given this model + token budget, who would you pick

--- a/crates/tirami-sdk/src/types.rs
+++ b/crates/tirami-sdk/src/types.rs
@@ -93,3 +93,25 @@ pub struct Schedule {
     pub model_id: String,
     pub max_tokens: u64,
 }
+
+// ---------------------------------------------------------------------------
+// Phase 16 — Anchor history response
+// ---------------------------------------------------------------------------
+
+/// A single batch submission observed via ChainClient.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AnchorSubmission {
+    pub batch_id: u64,
+    pub tx_hash: String,
+    pub merkle_root_hex: String,
+    pub submitted_at_ms: u64,
+    pub node_count: usize,
+    pub flops_total: u64,
+}
+
+/// Response from `GET /v1/tirami/anchors`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AnchorsResponse {
+    pub count: usize,
+    pub anchors: Vec<AnchorSubmission>,
+}

--- a/crates/tirami-sdk/tests/phase_15_api.rs
+++ b/crates/tirami-sdk/tests/phase_15_api.rs
@@ -1,8 +1,8 @@
-//! Phase 14-15 SDK additions: Schedule / Peers / chat_as (consumer header).
+//! Phase 14-16 SDK additions: Schedule / Peers / chat_as / anchors.
 //!
 //! These are deserialization smoke tests — no live node required.
 
-use tirami_sdk::{PeerInfo, PeersResponse, Schedule, TiramiUsage};
+use tirami_sdk::{AnchorSubmission, AnchorsResponse, PeerInfo, PeersResponse, Schedule, TiramiUsage};
 
 #[test]
 fn schedule_deserializes_from_api_response() {
@@ -93,4 +93,59 @@ fn peers_empty_registry() {
     let r: PeersResponse = serde_json::from_value(json).expect("deserialize");
     assert_eq!(r.count, 0);
     assert!(r.peers.is_empty());
+}
+
+// --- Phase 16 — anchors ---
+
+#[test]
+fn anchors_response_deserializes() {
+    let json = serde_json::json!({
+        "count": 2,
+        "anchors": [
+            {
+                "batch_id": 0,
+                "tx_hash": "mock_0000000000000000000000000000000000000000000000000000000000000000",
+                "merkle_root_hex": "ac2050945bdae994baa9ee4e6aca0b6e56e9ea67fdf04258275da13d368a31a4",
+                "submitted_at_ms": 1776379712432u64,
+                "node_count": 2,
+                "flops_total": 50_000_000_000u64
+            },
+            {
+                "batch_id": 1,
+                "tx_hash": "mock_...",
+                "merkle_root_hex": "ff".to_string().repeat(32),
+                "submitted_at_ms": 1776379722432u64,
+                "node_count": 3,
+                "flops_total": 75_000_000_000u64
+            }
+        ]
+    });
+    let r: AnchorsResponse = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(r.count, 2);
+    assert_eq!(r.anchors.len(), 2);
+    assert_eq!(r.anchors[0].batch_id, 0);
+    assert_eq!(r.anchors[1].flops_total, 75_000_000_000);
+}
+
+#[test]
+fn anchor_submission_parses_single() {
+    let json = serde_json::json!({
+        "batch_id": 42,
+        "tx_hash": "mock_abc",
+        "merkle_root_hex": "0000000000000000000000000000000000000000000000000000000000000001",
+        "submitted_at_ms": 1u64,
+        "node_count": 1,
+        "flops_total": 1_000_000_000u64
+    });
+    let s: AnchorSubmission = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(s.batch_id, 42);
+    assert_eq!(s.flops_total, 1_000_000_000);
+}
+
+#[test]
+fn anchors_empty_history() {
+    let json = serde_json::json!({ "count": 0, "anchors": [] });
+    let r: AnchorsResponse = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(r.count, 0);
+    assert!(r.anchors.is_empty());
 }


### PR DESCRIPTION
## Summary

"さらなる完璧" pass on top of #64 and #65. Closes the remaining scaffolding gaps.

- **891 tests passing** (up from 884)
- **Audit challenger loop**: daemon now actually issues AuditChallenge messages on a 60s cadence (was: responder-only)
- **SDK + MCP anchor bindings**: `anchors()` method + `tirami_anchors` MCP tool (symmetric with #64 schedule/peers/chat_as)
- **CLAUDE.md refresh**: reflects 15 crates, 891 tests, new API surface, Phase 14/15/16 contributions

## What's new

### Perfect-1 — Challenger-side audit loop

The scaffold in #65 wired the responder (receives challenge → runs
`generate_audit` → sends AuditResponse) and the resolver (receives
AuditResponse → `record_audit_result`). Missing: who actually issues
the challenges?

- `PeerRegistry::select_audit_targets(now_ms, rng_sample)` — rolls each
  peer's `AuditTier.audit_probability()`, skips stale (>24h) or model-less
  peers. 4 new tests covering Unverified vs Trusted rolls, stale-skip,
  and "requires advertised model".
- `TiramiNode::spawn_audit_challenger_loop(transport)` — 60s ticker:
  selects targets → computes expected hash with local engine → calls
  `audit_tracker.issue_challenge` → sends P2P AuditChallenge. Prunes
  expired pending challenges every tick.

The loop requires a locally-loaded model (we only validate hashes for
models we can run ourselves); no-op when none loaded.

### Perfect-2 — SDK + MCP anchor bindings

- `TiramiClient::anchors()` returns `AnchorsResponse { count, anchors }`
  with `AnchorSubmission { batch_id, tx_hash, merkle_root_hex,
  submitted_at_ms, node_count, flops_total }`.
- MCP tool `tirami_anchors` exposes the same endpoint to agent clients.
  Tool count 43 → 44.

### Perfect-4 — CLAUDE.md

- 785 tests / 14 crates → **891 tests / 15 crates**
- Repository table row expanded with Phase 14/15/16 feature names.
- New companion row: `clearclown/tirami-contracts`.
- Two new API sections:
  - **Tirami Unified Scheduler (Phase 14)** — `/v1/tirami/peers`,
    `/v1/tirami/schedule`, `X-Tirami-Node-Id` header, `flops_estimated`
  - **Tirami Hybrid Chain Anchor (Phase 16)** — `/v1/tirami/anchors`,
    default interval, swappable ChainClient

## Test plan
- [x] `cargo test --workspace` — 891 passing
- [x] `bash scripts/verify-impl.sh` — 123/123 GREEN
- [x] `/v1/tirami/anchors` reachable on both local + remote (`count: 0`
  until first anchor interval fires; MockChainClient in-memory)
- [x] MCP tool count assertion — 44 tools, all Phase 15/16 tools present

## Breaking changes
**None.** All 785 pre-Phase-14 tests still pass.

## Builds on

- #64 (Phase 14-16 main) — merge-pending
- #65 (Phase E+F audit full + anchor integration) — merge-pending

To review in order, read #64 → #65 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
