### PR TITLE
Fix #73–#78 — E2E cleanup before testnet-B

### DIFF
--- a/crates/tirami-cli/src/daemon.rs
+++ b/crates/tirami-cli/src/daemon.rs
@@ -67,12 +67,19 @@ enum DaemonCommand {
     },
 }
 
+/// Default tracing filter when `RUST_LOG` is unset (keep in sync with
+/// `main.rs::DEFAULT_TRACING_FILTER`). Silences iroh's multicast and
+/// IPv6-relay probe warnings that flood non-multicast / IPv4-only
+/// hosts (fix #75). `RUST_LOG=info` restores the raw output.
+const DEFAULT_TRACING_FILTER: &str =
+    "info,swarm_discovery=error,iroh::socket::transports::relay=error,iroh_relay=error,noq_udp=error";
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(DEFAULT_TRACING_FILTER)),
         )
         .init();
 

--- a/crates/tirami-cli/src/main.rs
+++ b/crates/tirami-cli/src/main.rs
@@ -339,7 +339,7 @@ enum WalletAction {
         /// Amount in satoshis
         amount_sats: u64,
         /// Description
-        #[arg(short, long, default_value = "Forge inference")]
+        #[arg(short, long, default_value = "Tirami inference")]
         description: String,
     },
     /// Pay a Lightning invoice
@@ -431,7 +431,7 @@ async fn main() -> anyhow::Result<()> {
                 println!("{}", response);
                 eprintln!("\n---\nGenerated in {:.2}s", elapsed.as_secs_f64());
             } else {
-                println!("Forge Chat (type 'quit' to exit)");
+                println!("Tirami Chat (type 'quit' to exit)");
                 println!("Model: {}", model);
                 println!("---");
 
@@ -668,7 +668,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let llama_cli = tirami_infer::distributed::find_llama_cli().ok_or_else(|| {
                 anyhow::anyhow!(
-                    "llama-cli not found. Set FORGE_LLAMA_CLI_PATH or install llama.cpp"
+                    "llama-cli not found. Set TIRAMI_LLAMA_CLI_PATH or install llama.cpp"
                 )
             })?;
 
@@ -784,7 +784,7 @@ async fn main() -> anyhow::Result<()> {
             let status: tirami_node::api::StatusResponse =
                 request.send().await?.error_for_status()?.json().await?;
 
-            println!("Forge status: {}", status.status);
+            println!("Tirami status: {}", status.status);
             println!("Model loaded: {}", status.model_loaded);
             println!(
                 "Market price: {:.2} CU/token (demand {:.2} / supply {:.2})",
@@ -843,7 +843,7 @@ async fn main() -> anyhow::Result<()> {
             let topology: tirami_node::api::TopologyResponse =
                 request.send().await?.error_for_status()?.json().await?;
 
-            println!("Forge topology: {}", topology.status);
+            println!("Tirami topology: {}", topology.status);
             if let Some(model) = topology.model {
                 println!(
                     "Model: {} (layers={}, hidden={}, quant={})",
@@ -1253,7 +1253,11 @@ async fn main() -> anyhow::Result<()> {
 }
 
 fn resolve_api_token(flag: Option<String>) -> Option<String> {
-    flag.or_else(|| std::env::var("FORGE_API_TOKEN").ok())
+    // `TIRAMI_API_TOKEN` is the primary env var; `FORGE_API_TOKEN` is
+    // accepted as a legacy alias so older operator scripts still work
+    // (fix #77).
+    flag.or_else(|| std::env::var("TIRAMI_API_TOKEN").ok())
+        .or_else(|| std::env::var("FORGE_API_TOKEN").ok())
         .filter(|token| !token.is_empty())
 }
 

--- a/crates/tirami-cli/src/main.rs
+++ b/crates/tirami-cli/src/main.rs
@@ -57,6 +57,14 @@ enum Commands {
         /// Use 0.0.0.0 to accept remote requests.
         #[arg(long, default_value = "127.0.0.1")]
         bind: String,
+
+        /// Run in pure-server mode without auto-configuring a
+        /// PersonalAgent. Default is OFF (agent auto-configured);
+        /// pass --no-agent to opt out. Useful for hosting nodes
+        /// that serve the mesh but don't need a user-facing agent
+        /// state on that machine.
+        #[arg(long, default_value_t = false)]
+        no_agent: bool,
     },
 
     /// Start as a seed node (holds model, serves inference)
@@ -353,8 +361,8 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Start { model, port, bind } => {
-            run_start_command(model, port, bind).await?;
+        Commands::Start { model, port, bind, no_agent } => {
+            run_start_command(model, port, bind, no_agent).await?;
         }
         Commands::Models => {
             tirami_infer::model_registry::list_models();
@@ -1253,6 +1261,7 @@ async fn run_start_command(
     model: String,
     port: u16,
     bind: String,
+    no_agent: bool,
 ) -> anyhow::Result<()> {
     use std::fs;
 
@@ -1330,6 +1339,10 @@ async fn run_start_command(
         api_bearer_token: None, // localhost by default, no token needed
         ledger_path: Some(ledger_path.clone()),
         share_compute: true,
+        // Phase 18.5-part-3e — killer-app ergonomics: `tirami start`
+        // yields a configured PersonalAgent by default. --no-agent
+        // flips this off for operators running pure-server nodes.
+        personal_agent_enabled: !no_agent,
         ..Config::default()
     };
     let mut node = tirami_node::TiramiNode::new(config);

--- a/crates/tirami-cli/src/main.rs
+++ b/crates/tirami-cli/src/main.rs
@@ -349,12 +349,20 @@ enum WalletAction {
     },
 }
 
+/// Default tracing filter when `RUST_LOG` is unset.
+///
+/// `"info"` for Tirami internals, `error` for iroh's multicast / IPv6
+/// relay probes which spam WARN on Tailscale or IPv4-only hosts
+/// (fix #75). Operators who want the raw firehose: `RUST_LOG=info`.
+const DEFAULT_TRACING_FILTER: &str =
+    "info,swarm_discovery=error,iroh::socket::transports::relay=error,iroh_relay=error,noq_udp=error";
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(DEFAULT_TRACING_FILTER)),
         )
         .init();
 

--- a/crates/tirami-core/src/config.rs
+++ b/crates/tirami-core/src/config.rs
@@ -149,6 +149,15 @@ pub struct Config {
     /// load on quiet nodes.
     #[serde(default = "default_agent_tick_interval_secs")]
     pub agent_tick_interval_secs: u64,
+
+    /// Phase 18.5-part-3e — auto-configure a [`PersonalAgent`] at
+    /// `run_seed` time using the local node identity as the wallet.
+    /// Default `true` so `tirami start` immediately gives the user
+    /// a working agent (the killer-app commitment from
+    /// `docs/killer-app.md`). Operators running a pure-server node
+    /// can set this to `false` (CLI: `tirami start --no-agent`).
+    #[serde(default = "default_personal_agent_enabled")]
+    pub personal_agent_enabled: bool,
 }
 
 fn default_anchor_interval_secs() -> u64 {
@@ -177,6 +186,10 @@ fn default_proof_policy() -> String {
 
 fn default_agent_tick_interval_secs() -> u64 {
     30
+}
+
+fn default_personal_agent_enabled() -> bool {
+    true
 }
 
 impl Config {
@@ -261,6 +274,7 @@ impl Default for Config {
             archive_path: None,
             proof_policy: "disabled".to_string(),
             agent_tick_interval_secs: 30,
+            personal_agent_enabled: true,
         }
     }
 }

--- a/crates/tirami-core/src/types.rs
+++ b/crates/tirami-core/src/types.rs
@@ -15,7 +15,12 @@ impl NodeId {
     }
 
     pub fn from_hex(value: &str) -> Result<Self, String> {
-        let value = value.strip_prefix("forge_").unwrap_or(value);
+        // Accept both the current `tirami_` prefix and the legacy
+        // `forge_` prefix (pre-rename snapshots / config files).
+        let value = value
+            .strip_prefix("tirami_")
+            .or_else(|| value.strip_prefix("forge_"))
+            .unwrap_or(value);
         let bytes = hex::decode(value).map_err(|e| format!("decode node id: {e}"))?;
         if bytes.len() != 32 {
             return Err(format!("expected 32 bytes, got {}", bytes.len()));
@@ -29,7 +34,7 @@ impl NodeId {
 
 impl std::fmt::Display for NodeId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "forge_{}", hex::encode(&self.0[..8]))
+        write!(f, "tirami_{}", hex::encode(&self.0[..8]))
     }
 }
 
@@ -338,6 +343,39 @@ mod tests {
         let original = NodeId([7u8; 32]);
         let parsed = original.to_hex().parse::<NodeId>().unwrap();
         assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn node_id_display_uses_tirami_prefix() {
+        let id = NodeId([0xABu8; 32]);
+        let shown = format!("{}", id);
+        assert!(
+            shown.starts_with("tirami_"),
+            "expected tirami_ prefix, got {shown}"
+        );
+    }
+
+    #[test]
+    fn node_id_parser_accepts_tirami_prefix() {
+        let raw = format!("tirami_{}", hex::encode([0x12u8; 32]));
+        let parsed = NodeId::from_hex(&raw).unwrap();
+        assert_eq!(parsed, NodeId([0x12u8; 32]));
+    }
+
+    #[test]
+    fn node_id_parser_accepts_legacy_forge_prefix() {
+        // Backward compat (fix #77): saved snapshots / config files
+        // from the pre-rename era must still parse.
+        let raw = format!("forge_{}", hex::encode([0x34u8; 32]));
+        let parsed = NodeId::from_hex(&raw).unwrap();
+        assert_eq!(parsed, NodeId([0x34u8; 32]));
+    }
+
+    #[test]
+    fn node_id_parser_accepts_bare_hex() {
+        let raw = hex::encode([0x56u8; 32]);
+        let parsed = NodeId::from_hex(&raw).unwrap();
+        assert_eq!(parsed, NodeId([0x56u8; 32]));
     }
 
     // ------------------------------------------------------------------

--- a/crates/tirami-infer/src/distributed.rs
+++ b/crates/tirami-infer/src/distributed.rs
@@ -35,12 +35,16 @@ pub struct DistributedConfig {
 
 /// Find the llama-cli binary from trusted locations.
 pub fn find_llama_cli() -> Option<PathBuf> {
-    // Check env var first
-    if let Ok(path) = std::env::var("FORGE_LLAMA_CLI_PATH") {
-        let p = PathBuf::from(&path);
-        if let Ok(canonical) = p.canonicalize() {
-            if canonical.is_file() {
-                return Some(canonical);
+    // Check env vars first. `TIRAMI_LLAMA_CLI_PATH` is the current
+    // name; `FORGE_LLAMA_CLI_PATH` is accepted as a legacy alias so
+    // operators with older setups still work (fix #77).
+    for env_name in ["TIRAMI_LLAMA_CLI_PATH", "FORGE_LLAMA_CLI_PATH"] {
+        if let Ok(path) = std::env::var(env_name) {
+            let p = PathBuf::from(&path);
+            if let Ok(canonical) = p.canonicalize() {
+                if canonical.is_file() {
+                    return Some(canonical);
+                }
             }
         }
     }

--- a/crates/tirami-ledger/src/metrics.rs
+++ b/crates/tirami-ledger/src/metrics.rs
@@ -1,17 +1,17 @@
-//! Prometheus / OpenMetrics export for Forge telemetry.
+//! Prometheus / OpenMetrics export for Tirami telemetry.
 //!
 //! Exposes:
-//! - forge_cu_contributed_total   (gauge, per-node_id)
-//! - forge_cu_consumed_total      (gauge, per-node_id)
-//! - forge_reputation             (gauge, per-node_id)
-//! - forge_trade_count_total      (counter, global)
-//! - forge_active_loan_count      (gauge, global)
-//! - forge_pool_total_trm          (gauge, global)
-//! - forge_pool_reserve_ratio     (gauge, global)
-//! - forge_collusion_tight_cluster_score  (gauge, per-node_id)
-//! - forge_collusion_volume_spike_score   (gauge, per-node_id)
-//! - forge_collusion_round_robin_score    (gauge, per-node_id)
-//! - forge_collusion_trust_penalty        (gauge, per-node_id)
+//! - tirami_cu_contributed_total   (gauge, per-node_id)
+//! - tirami_cu_consumed_total      (gauge, per-node_id)
+//! - tirami_reputation             (gauge, per-node_id)
+//! - tirami_trade_count_total      (counter, global)
+//! - tirami_active_loan_count      (gauge, global)
+//! - tirami_pool_total_trm         (gauge, global)
+//! - tirami_pool_reserve_ratio     (gauge, global)
+//! - tirami_collusion_tight_cluster_score  (gauge, per-node_id)
+//! - tirami_collusion_volume_spike_score   (gauge, per-node_id)
+//! - tirami_collusion_round_robin_score    (gauge, per-node_id)
+//! - tirami_collusion_trust_penalty        (gauge, per-node_id)
 
 use crate::collusion::CollusionDetector;
 use crate::ledger::ComputeLedger;
@@ -53,7 +53,7 @@ impl TiramiMetrics {
 
         let cu_contributed = GaugeVec::new(
             Opts::new(
-                "forge_cu_contributed_total",
+                "tirami_cu_contributed_total",
                 "Total CU contributed (earned) by a node",
             ),
             &["node_id"],
@@ -62,7 +62,7 @@ impl TiramiMetrics {
 
         let cu_consumed = GaugeVec::new(
             Opts::new(
-                "forge_cu_consumed_total",
+                "tirami_cu_consumed_total",
                 "Total CU consumed (spent) by a node",
             ),
             &["node_id"],
@@ -70,38 +70,38 @@ impl TiramiMetrics {
         .expect("valid gauge vec opts");
 
         let reputation = GaugeVec::new(
-            Opts::new("forge_reputation", "Reputation score for a node (0.0–1.0)"),
+            Opts::new("tirami_reputation", "Reputation score for a node (0.0–1.0)"),
             &["node_id"],
         )
         .expect("valid gauge vec opts");
 
         let trade_count = IntCounter::with_opts(Opts::new(
-            "forge_trade_count_total",
+            "tirami_trade_count_total",
             "Total number of trades recorded in the ledger",
         ))
         .expect("valid counter opts");
 
         let active_loan_count = IntGauge::with_opts(Opts::new(
-            "forge_active_loan_count",
+            "tirami_active_loan_count",
             "Number of currently active loans in the lending pool",
         ))
         .expect("valid gauge opts");
 
         let pool_total_trm = IntGauge::with_opts(Opts::new(
-            "forge_pool_total_trm",
+            "tirami_pool_total_trm",
             "Total CU deposited into the lending pool",
         ))
         .expect("valid gauge opts");
 
         let pool_reserve_ratio = Gauge::with_opts(Opts::new(
-            "forge_pool_reserve_ratio",
+            "tirami_pool_reserve_ratio",
             "Lending pool reserve ratio (available / total)",
         ))
         .expect("valid gauge opts");
 
         let collusion_tight = GaugeVec::new(
             Opts::new(
-                "forge_collusion_tight_cluster_score",
+                "tirami_collusion_tight_cluster_score",
                 "Tight-cluster collusion sub-score for a node (0.0–1.0)",
             ),
             &["node_id"],
@@ -110,7 +110,7 @@ impl TiramiMetrics {
 
         let collusion_spike = GaugeVec::new(
             Opts::new(
-                "forge_collusion_volume_spike_score",
+                "tirami_collusion_volume_spike_score",
                 "Volume-spike collusion sub-score for a node (0.0–1.0)",
             ),
             &["node_id"],
@@ -119,7 +119,7 @@ impl TiramiMetrics {
 
         let collusion_robin = GaugeVec::new(
             Opts::new(
-                "forge_collusion_round_robin_score",
+                "tirami_collusion_round_robin_score",
                 "Round-robin collusion sub-score for a node (0.0–1.0)",
             ),
             &["node_id"],
@@ -128,7 +128,7 @@ impl TiramiMetrics {
 
         let collusion_penalty = GaugeVec::new(
             Opts::new(
-                "forge_collusion_trust_penalty",
+                "tirami_collusion_trust_penalty",
                 "Final trust penalty applied to node reputation (0.0–0.5)",
             ),
             &["node_id"],
@@ -469,17 +469,27 @@ mod tests {
         metrics.observe(&ledger, 1_700_000_000_000);
         let output = metrics.encode().unwrap();
         assert!(
-            output.contains("forge_cu_contributed_total"),
-            "missing forge_cu_contributed_total in:\n{output}"
+            output.contains("tirami_cu_contributed_total"),
+            "missing tirami_cu_contributed_total in:\n{output}"
         );
         assert!(
-            output.contains("forge_reputation"),
-            "missing forge_reputation"
+            output.contains("tirami_reputation"),
+            "missing tirami_reputation"
         );
         // collusion gauges only appear if trades exist; check a global metric instead.
         assert!(
-            output.contains("forge_trade_count_total"),
-            "missing forge_trade_count_total"
+            output.contains("tirami_trade_count_total"),
+            "missing tirami_trade_count_total"
+        );
+        // Regression: ensure the legacy forge_* prefix is no longer emitted
+        // (fix #76).
+        assert!(
+            !output.contains("forge_cu_contributed_total"),
+            "legacy forge_cu_contributed_total should be gone"
+        );
+        assert!(
+            !output.contains("forge_reputation"),
+            "legacy forge_reputation should be gone"
         );
         // Verify the format includes HELP/TYPE metadata.
         assert!(output.contains("# HELP"), "missing # HELP");
@@ -494,7 +504,7 @@ mod tests {
         let metrics = TiramiMetrics::new();
         metrics.observe(&ledger, 1_700_000_000_000);
         let output = metrics.encode().unwrap();
-        assert!(output.contains("forge_reputation"), "forge_reputation missing");
+        assert!(output.contains("tirami_reputation"), "tirami_reputation missing");
         assert!(
             output.contains(&node.to_hex()),
             "node hex {} not in output",
@@ -529,11 +539,11 @@ mod tests {
         let output = metrics.encode().unwrap();
 
         assert!(
-            output.contains("forge_collusion_tight_cluster_score"),
+            output.contains("tirami_collusion_tight_cluster_score"),
             "tight_cluster metric missing"
         );
         assert!(
-            output.contains("forge_collusion_trust_penalty"),
+            output.contains("tirami_collusion_trust_penalty"),
             "trust_penalty metric missing"
         );
         // Both nodes should appear.

--- a/crates/tirami-node/src/agent_loop.rs
+++ b/crates/tirami-node/src/agent_loop.rs
@@ -80,9 +80,12 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
-/// Run the tick logic once against a personal-agent slot. If the
-/// slot is empty, the call is a no-op and `stats.ticks` is left
-/// untouched (we don't count "no-op" ticks as real work).
+/// Run the tick logic once against a personal-agent slot.
+///
+/// Invariant (fix #78): the tick counter ALWAYS increments, even
+/// when the slot is empty. That gives operators a way to distinguish
+/// "loop alive, nothing to do" from "loop stuck / panicked". When
+/// the slot is empty, `last_action` is set to `"no_agent"`.
 ///
 /// Exposed (non-`pub` outside the crate) so unit tests can drive it
 /// deterministically without spawning the tokio loop.
@@ -92,44 +95,34 @@ pub(crate) async fn run_tick_once(
     input: &AgentTickInput,
 ) {
     let tick_ms = now_ms();
-    let mut guard = agent_slot.lock().await;
-    let Some(agent) = guard.as_mut() else {
-        return;
-    };
-    let ctx = TickContext {
-        now_ms: tick_ms,
-        local_utilization: input.local_utilization,
-        seconds_idle: input.seconds_idle,
-        pending_task: input.pending_task.as_ref().map(|(_, t)| t.clone()),
-        pending_task_id: input.pending_task.as_ref().map(|(id, _)| id.clone()),
-        current_balance_trm: input.current_balance_trm,
-        incoming_serving_request: input.incoming_serving_request.clone(),
-    };
-    let action = agent.tick(&ctx);
-    let kind = action_kind(&action);
+    let kind: &'static str = {
+        let mut guard = agent_slot.lock().await;
+        match guard.as_mut() {
+            None => "no_agent",
+            Some(agent) => {
+                let ctx = TickContext {
+                    now_ms: tick_ms,
+                    local_utilization: input.local_utilization,
+                    seconds_idle: input.seconds_idle,
+                    pending_task: input.pending_task.as_ref().map(|(_, t)| t.clone()),
+                    pending_task_id: input.pending_task.as_ref().map(|(id, _)| id.clone()),
+                    current_balance_trm: input.current_balance_trm,
+                    incoming_serving_request: input.incoming_serving_request.clone(),
+                };
+                let action = agent.tick(&ctx);
+                let k = action_kind(&action);
 
-    // Apply the pieces of the action the agent can handle on its
-    // own. Anything that requires an HTTP call / provider selection
-    // is left to the pipeline (surfaced via tracing for now).
-    match &action {
-        TickAction::ResetDailyTally => {
-            agent.reset_daily_tally(tick_ms);
+                // Apply the pieces of the action the agent can handle on
+                // its own. Anything that requires an HTTP call / provider
+                // selection is left to the pipeline (surfaced via tracing
+                // for now).
+                if let TickAction::ResetDailyTally = action {
+                    agent.reset_daily_tally(tick_ms);
+                }
+                k
+            }
         }
-        TickAction::Idle | TickAction::StartEarning => {
-            // Nothing to persist on the agent side. Real earning
-            // happens when a peer hits the chat endpoint; the
-            // loop's role is just to say "we're open for business".
-        }
-        TickAction::ServeRequest { .. }
-        | TickAction::RejectServeRequest { .. }
-        | TickAction::RunLocal { .. }
-        | TickAction::RunRemote { .. }
-        | TickAction::AskUser { .. } => {
-            // Dispatch is the caller's responsibility (pipeline /
-            // API handler). The loop only records the decision.
-        }
-    }
-    drop(guard);
+    };
 
     let mut stats_guard = stats.lock().await;
     stats_guard.ticks = stats_guard.ticks.saturating_add(1);
@@ -196,13 +189,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_op_when_slot_is_empty() {
+    async fn empty_slot_tick_is_tagged_no_agent() {
+        // Fix #78 — operator observability: the tick must still count
+        // even when no agent is configured, so "loop alive, no agent"
+        // is distinguishable from "loop stuck / panicked".
         let slot = make_slot(None);
         let stats = make_stats();
         run_tick_once(&slot, &stats, &AgentTickInput::default()).await;
         let s = stats.lock().await;
-        assert_eq!(s.ticks, 0);
-        assert!(s.last_action.is_none());
+        assert_eq!(s.ticks, 1);
+        assert_eq!(s.last_action, Some("no_agent"));
+        assert!(s.last_tick_ms > 0);
+    }
+
+    #[tokio::test]
+    async fn empty_slot_ticks_accumulate_across_calls() {
+        let slot = make_slot(None);
+        let stats = make_stats();
+        for _ in 0..4 {
+            run_tick_once(&slot, &stats, &AgentTickInput::default()).await;
+        }
+        let s = stats.lock().await;
+        assert_eq!(s.ticks, 4);
+        assert_eq!(s.last_action, Some("no_agent"));
     }
 
     #[tokio::test]

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -332,6 +332,11 @@ pub fn create_router_with_services(
         // Phase 10 P5 — Prometheus /metrics endpoint (no auth — Prometheus scrapes without tokens)
         .route("/metrics", get(crate::handlers::metrics::metrics_handler))
         .merge(protected)
+        // Phase 18.5-part-3e (fix #74) — normalise every non-JSON
+        // error body into a consistent `{ "error": { code, message } }`
+        // envelope. Applied as the outermost layer so it runs AFTER
+        // all other middleware and handler responses.
+        .layer(middleware::from_fn(json_error_envelope))
         .layer(DefaultBodyLimit::max(api_max_request_body_bytes))
         .with_state(state)
 }
@@ -581,6 +586,87 @@ pub struct TiramiPricingResponse {
 // ---------------------------------------------------------------------------
 // Auth middleware
 // ---------------------------------------------------------------------------
+
+/// Phase 18.5-part-3e (fix #74) — normalise non-JSON error bodies
+/// into a consistent envelope.
+///
+/// The axum router currently emits:
+///   - plain-text bodies from handlers returning `(StatusCode, String)`,
+///   - plain-text bodies from Axum's default `JsonRejection` for
+///     malformed request bodies,
+///   - JSON bodies from handlers that explicitly serialize one.
+///
+/// Clients can't reliably parse that mix. This middleware inspects
+/// every response; if its status is 4xx/5xx AND its `Content-Type`
+/// is not `application/json`, it rewrites the body into
+/// `{ "error": { "code": <u16>, "message": <body-as-string> } }`
+/// and flips the header to `application/json`. Success responses
+/// pass through untouched.
+async fn json_error_envelope(
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let response = next.run(request).await;
+    let status = response.status();
+    if !(status.is_client_error() || status.is_server_error()) {
+        return response;
+    }
+    let is_json = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.starts_with("application/json"))
+        .unwrap_or(false);
+    if is_json {
+        return response;
+    }
+
+    let (mut parts, body) = response.into_parts();
+    let bytes = match axum::body::to_bytes(body, 64 * 1024).await {
+        Ok(b) => b,
+        Err(_) => {
+            // Body read failed — synthesise a generic envelope so
+            // the client still gets JSON instead of a stalled stream.
+            let payload = serde_json::json!({
+                "error": {
+                    "code": status.as_u16(),
+                    "message": status.canonical_reason().unwrap_or("error"),
+                }
+            });
+            let body_bytes = serde_json::to_vec(&payload).unwrap_or_default();
+            parts
+                .headers
+                .insert(
+                    axum::http::header::CONTENT_TYPE,
+                    axum::http::HeaderValue::from_static("application/json"),
+                );
+            parts
+                .headers
+                .insert(
+                    axum::http::header::CONTENT_LENGTH,
+                    axum::http::HeaderValue::from(body_bytes.len()),
+                );
+            return Response::from_parts(parts, axum::body::Body::from(body_bytes));
+        }
+    };
+    let message = String::from_utf8_lossy(&bytes).to_string();
+    let payload = serde_json::json!({
+        "error": {
+            "code": status.as_u16(),
+            "message": message,
+        }
+    });
+    let body_bytes = serde_json::to_vec(&payload).unwrap_or_default();
+    parts.headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/json"),
+    );
+    parts.headers.insert(
+        axum::http::header::CONTENT_LENGTH,
+        axum::http::HeaderValue::from(body_bytes.len()),
+    );
+    Response::from_parts(parts, axum::body::Body::from(body_bytes))
+}
 
 async fn require_bearer_auth(
     State(state): State<AppState>,
@@ -4177,12 +4263,79 @@ mod tests {
     #[tokio::test]
     async fn agent_task_412_when_no_agent_configured() {
         let app = test_router_with_agent(Config::default(), None);
-        let (status, _body) = post_agent_task(
+        let (status, body) = post_agent_task(
             app,
             serde_json::json!({ "prompt": "hello", "max_tokens": 10 }),
         )
         .await;
         assert_eq!(status, StatusCode::PRECONDITION_FAILED);
+        // Fix #74 — now wrapped in the JSON error envelope.
+        assert_eq!(body["error"]["code"], 412);
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("no personal agent"));
+    }
+
+    // ------------------------------------------------------------------
+    // Fix #74 — JSON error envelope middleware
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn malformed_json_body_returns_json_error_envelope() {
+        let app = test_router_with_agent(
+            Config::default(),
+            Some(agent_at(NodeId([0xAAu8; 32]))),
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/agent/task")
+                    .header("content-type", "application/json")
+                    .body(Body::from("not json at all"))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert!(response.status().is_client_error());
+        let ct = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert!(
+            ct.starts_with("application/json"),
+            "expected application/json, got {ct}"
+        );
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert!(json["error"]["code"].is_number());
+        assert!(json["error"]["message"].is_string());
+    }
+
+    #[tokio::test]
+    async fn success_json_response_is_not_rewritten() {
+        // The middleware must only touch 4xx / 5xx — verify /health
+        // (2xx) still returns the original JSON body untouched.
+        let app = test_router_with_agent(Config::default(), None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(json["status"], "ok");
+        assert!(json.get("error").is_none());
     }
 
     #[tokio::test]

--- a/crates/tirami-node/src/handlers/metrics.rs
+++ b/crates/tirami-node/src/handlers/metrics.rs
@@ -74,8 +74,8 @@ mod tests {
         let text = String::from_utf8_lossy(&body);
         // Global counter always emits even when the ledger is empty (no nodes yet).
         assert!(
-            text.contains("forge_trade_count_total"),
-            "missing forge_trade_count_total in /metrics response:\n{text}"
+            text.contains("tirami_trade_count_total"),
+            "missing tirami_trade_count_total in /metrics response:\n{text}"
         );
         assert!(
             text.contains("# TYPE"),

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -332,11 +332,11 @@ impl TiramiNode {
 
         let addr = transport.endpoint_addr();
         let id = transport.endpoint_id();
-        tracing::info!("=== FORGE SEED NODE ===");
+        tracing::info!("=== TIRAMI SEED NODE ===");
         tracing::info!("Public key: {}", id);
         tracing::info!("Node ID: {}", transport.tirami_node_id());
         tracing::info!("Full address: {:?}", addr);
-        tracing::info!("Workers connect with: forge worker --seed {}", id);
+        tracing::info!("Workers connect with: tirami worker --seed {}", id);
 
         // Accept connections
         let _accept_handle = transport.start_accepting();
@@ -951,7 +951,7 @@ impl TiramiNode {
 
     /// Graceful shutdown: announce leaving, persist ledger, close transport.
     pub async fn shutdown(&self) {
-        tracing::info!("Shutting down Forge node...");
+        tracing::info!("Shutting down Tirami node...");
 
         // Announce leaving to all peers
         if let Some(cluster) = self.cluster.as_ref() {

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -273,6 +273,35 @@ impl TiramiNode {
         )
     }
 
+    /// Phase 18.5-part-3e — populate [`Self::personal_agent`] with a
+    /// default [`tirami_mind::PersonalAgent`] tied to the local node
+    /// identity, unless the operator disabled it via
+    /// `Config::personal_agent_enabled = false`.
+    ///
+    /// Idempotent: leaves the slot alone when something has already
+    /// populated it (e.g. a future state-snapshot reload). This is
+    /// the plumbing that makes `tirami start` yield a working agent
+    /// without a separate init call — the killer-app commitment
+    /// from `docs/killer-app.md`.
+    pub async fn ensure_personal_agent(&self, wallet: tirami_core::NodeId) {
+        if !self.config.personal_agent_enabled {
+            tracing::info!("personal agent disabled by config (personal_agent_enabled = false)");
+            return;
+        }
+        let mut guard = self.personal_agent.lock().await;
+        if guard.is_some() {
+            return;
+        }
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let agent =
+            tirami_mind::PersonalAgent::new(wallet.clone(), tirami_mind::TrmBudget::default(), now_ms);
+        tracing::info!("personal agent configured for {}", wallet.to_hex());
+        *guard = Some(agent);
+    }
+
     /// Initialize P2P transport.
     pub async fn init_transport(&mut self) -> Result<Arc<ForgeTransport>, tirami_core::TiramiError> {
         if let Some(transport) = self.transport.as_ref() {
@@ -339,6 +368,16 @@ impl TiramiNode {
         // Phase 14.3 — challenger-side audit loop: periodically picks peers
         // per their AuditTier probability and sends AuditChallenge messages.
         self.spawn_audit_challenger_loop(transport.clone());
+
+        // Phase 18.5-part-3e — auto-configure the user's PersonalAgent
+        // using the local node identity as the wallet, unless the
+        // operator opted out via `Config::personal_agent_enabled =
+        // false` (CLI: `tirami start --no-agent`). Done BEFORE the
+        // tick loop spawns so the very first tick sees a populated
+        // slot. Idempotent — if someone already pre-populated the
+        // slot (e.g. from a persisted state path in a future patch),
+        // we leave it alone.
+        self.ensure_personal_agent(transport.tirami_node_id()).await;
 
         // Phase 18.5-part-2 — PersonalAgent tick loop. Drives the
         // auto-earn / auto-spend heuristic when an agent is
@@ -936,6 +975,56 @@ impl TiramiNode {
             transport.close().await;
         }
 
-        tracing::info!("Forge node shut down");
+        tracing::info!("Tirami node shut down");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tirami_core::NodeId;
+
+    fn wallet() -> NodeId {
+        NodeId([0xAAu8; 32])
+    }
+
+    #[tokio::test]
+    async fn ensure_personal_agent_populates_slot_when_enabled() {
+        let config = Config {
+            personal_agent_enabled: true,
+            ..Config::default()
+        };
+        let node = TiramiNode::new(config);
+        assert!(node.personal_agent.lock().await.is_none());
+        node.ensure_personal_agent(wallet()).await;
+        let guard = node.personal_agent.lock().await;
+        let agent = guard.as_ref().expect("agent configured");
+        assert_eq!(agent.wallet, wallet());
+    }
+
+    #[tokio::test]
+    async fn ensure_personal_agent_skips_when_disabled() {
+        let config = Config {
+            personal_agent_enabled: false,
+            ..Config::default()
+        };
+        let node = TiramiNode::new(config);
+        node.ensure_personal_agent(wallet()).await;
+        assert!(node.personal_agent.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn ensure_personal_agent_is_idempotent() {
+        let config = Config::default();
+        let node = TiramiNode::new(config);
+        node.ensure_personal_agent(wallet()).await;
+        // Tamper so we can confirm a second call doesn't overwrite.
+        {
+            let mut guard = node.personal_agent.lock().await;
+            guard.as_mut().unwrap().record_earn(999);
+        }
+        node.ensure_personal_agent(wallet()).await;
+        let guard = node.personal_agent.lock().await;
+        assert_eq!(guard.as_ref().unwrap().earned_today_trm, 999);
     }
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -96,7 +96,7 @@ Two independent layers:
 - *Volume spike*: detects sudden anomalous increases in trade volume between specific pairs.
 - *Round-robin (Tarjan SCC)*: uses Tarjan's strongly-connected-components algorithm to find circular trade patterns that resemble wash trading.
 
-When a node scores above the detection threshold, a `trust_penalty` (up to 0.5) is subtracted from its effective reputation automatically. The penalty is visible in `/metrics` as `forge_collusion_trust_penalty`.
+When a node scores above the detection threshold, a `trust_penalty` (up to 0.5) is subtracted from its effective reputation automatically. The penalty is visible in `/metrics` as `tirami_collusion_trust_penalty`.
 
 ---
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -148,17 +148,17 @@ Prometheus metrics are exported at `/metrics` with no authentication required. T
 
 | Metric | Type | Description |
 |---|---|---|
-| `forge_cu_contributed_total` | Counter | Total TRM earned by this node across all trades |
-| `forge_cu_consumed_total` | Counter | Total TRM spent by this node |
-| `forge_reputation{node_id}` | Gauge | Current reputation score (0.0–1.0, default 0.5 per parameters.md §7) |
-| `forge_trade_count_total` | Counter | Total trades recorded on this node's ledger |
-| `forge_active_loan_count` | Gauge | Number of open loans (as lender or borrower) |
-| `forge_pool_total_cu` | Gauge | Total TRM in the lending pool |
-| `forge_pool_reserve_ratio` | Gauge | Current reserve ratio (must stay ≥ 30% per parameters.md §5) |
-| `forge_collusion_tight_cluster_score` | Gauge | Tight-cluster detection score for this node |
-| `forge_collusion_volume_spike_score` | Gauge | Volume-spike detection score |
-| `forge_collusion_round_robin_score` | Gauge | Round-robin (Tarjan SCC) detection score |
-| `forge_collusion_trust_penalty` | Gauge | Effective trust penalty subtracted from reputation |
+| `tirami_cu_contributed_total` | Counter | Total TRM earned by this node across all trades |
+| `tirami_cu_consumed_total` | Counter | Total TRM spent by this node |
+| `tirami_reputation{node_id}` | Gauge | Current reputation score (0.0–1.0, default 0.5 per parameters.md §7) |
+| `tirami_trade_count_total` | Counter | Total trades recorded on this node's ledger |
+| `tirami_active_loan_count` | Gauge | Number of open loans (as lender or borrower) |
+| `tirami_pool_total_trm` | Gauge | Total TRM in the lending pool |
+| `tirami_pool_reserve_ratio` | Gauge | Current reserve ratio (must stay ≥ 30% per parameters.md §5) |
+| `tirami_collusion_tight_cluster_score` | Gauge | Tight-cluster detection score for this node |
+| `tirami_collusion_volume_spike_score` | Gauge | Volume-spike detection score |
+| `tirami_collusion_round_robin_score` | Gauge | Round-robin (Tarjan SCC) detection score |
+| `tirami_collusion_trust_penalty` | Gauge | Effective trust penalty subtracted from reputation |
 
 Metrics that depend on trading activity (pool, loan counts, collusion scores) start at zero or their default and only update after the first trade. This is normal.
 
@@ -173,7 +173,7 @@ scrape_configs:
     scrape_interval: 15s
 ```
 
-**Grafana dashboard sketch**: create four panels — (1) TRM flow over time: `rate(forge_cu_contributed_total[5m])` vs `rate(forge_cu_consumed_total[5m])`; (2) reputation gauge 0–1 with threshold line at 0.5; (3) lending pool health: `forge_pool_reserve_ratio` with alert below 0.3; (4) collusion scores as a stacked bar, alert if `forge_collusion_trust_penalty > 0.1`.
+**Grafana dashboard sketch**: create four panels — (1) TRM flow over time: `rate(tirami_cu_contributed_total[5m])` vs `rate(tirami_cu_consumed_total[5m])`; (2) reputation gauge 0–1 with threshold line at 0.5; (3) lending pool health: `tirami_pool_reserve_ratio` with alert below 0.3; (4) collusion scores as a stacked bar, alert if `tirami_collusion_trust_penalty > 0.1`.
 
 ---
 


### PR DESCRIPTION
## Summary

Six issues surfaced on the 100.112.10.128 E2E run (Mac Studio over Tailscale) are fixed here in one PR so testnet-B can go live cleanly.

All verified by re-running the same E2E battery against a node built from this branch — see the **Verification** block at the bottom for actual results.

## Commits (one per issue)

| # | Commit | Change |
|---|---|---|
| #73 (P0) | `fix(#73): auto-configure PersonalAgent on \`tirami start\`` | \`TiramiNode::ensure_personal_agent\` populates the slot at \`run_seed\` using the local node id as the wallet. New \`--no-agent\` CLI flag opts out. +3 unit tests. |
| #74 (P1) | `fix(#74): normalise HTTP error bodies into a consistent JSON envelope` | Tower middleware wraps every non-JSON 4xx/5xx into \`{"error":{"code","message"}}\`. No handler signature churn. +2 unit tests. |
| #75 (P1) | `fix(#75): silence iroh/mDNS warn spam by default` | CLI default \`RUST_LOG\` now silences swarm_discovery/iroh::relay/noq_udp at error level; raw firehose still available with \`RUST_LOG=info\`. |
| #76 (P1) | `fix(#76): rename forge_* Prometheus metrics to tirami_*` | 11 metric identifiers renamed, plus rustdoc + operator-guide + FAQ. Regression-check that legacy \`forge_*\` names are gone. |
| #77 (P2) | `fix(#77): rename user-visible FORGE/forge_ strings to TIRAMI/tirami_` | Banner, Node ID display prefix, worker hint, chat/status/topology printlns, invoice default description, \`FORGE_LLAMA_CLI_PATH\`/\`FORGE_API_TOKEN\` env vars. Parser still accepts \`forge_\` prefix for backward compat. +4 unit tests. |
| #78 (P2) | `fix(#78): count empty-slot ticks so the loop no longer looks dead` | Stats counter always advances; empty slot tagged \`last_action = "no_agent"\`. +1 regression test (existing test renamed). |

## Closes

\`Closes #73\`, \`Closes #74\`, \`Closes #75\`, \`Closes #76\`, \`Closes #77\`, \`Closes #78\`.

## Explicitly **not** in this PR

- MCP tool names (\`forge_*\` in \`crates/tirami-mcp/src/main.rs\`, 40 tools). Separate issue to file after this merges.
- Internal type names like \`ForgeTransport\` and pre-1.0 Rust identifiers — none reach the user.
- Handler individual signature migration to an \`ApiError\` type — covered by the middleware at the edge, which is cheaper.
- \`forge-mesh\` external repo sync.

## Verification

All assertions run against a release binary deployed to 100.112.10.128 after this branch built:

| Issue | Check | Expected | Actual |
|---|---|---|---|
| #73 | \`GET /v1/tirami/agent/status\` | \`configured: true\` | \`configured: true\`, wallet set, preferences shown ✓ |
| #74 | \`POST /v1/chat/completions\` with malformed JSON | \`{"error":{"code":400, ...}}\` | exact match ✓ |
| #74 | \`POST\` without Content-Type | JSON envelope, code 415 | exact match ✓ |
| #75 | \`grep -c 'No route to host' tirami.log\` after startup | 0 | 0 ✓ |
| #76 | \`curl /metrics \| grep -c '^forge_'\` | 0 | 0 (and 13 \`tirami_*\` lines present) ✓ |
| #77 | startup banner | \`=== TIRAMI SEED NODE ===\` | exact match ✓ |
| #77 | worker hint | \`tirami worker --seed ...\` | exact match ✓ |
| #78 | \`GET /v1/tirami/agent/status\` 30s after start | \`loop.ticks >= 1, last_action = "idle"\` | \`ticks=1, last_action="idle", last_tick_ms set\` ✓ |
| sanity | real inference round-trip | response + \`x_tirami.trm_cost\` | \`content: "OK..."\`, \`trm_cost: 6\` ✓ |

## Tests

\`cargo test --workspace\` — **1 177 pass, 0 fail** (↑ 10 new unit tests vs \`main\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)