### PR TITLE
Fix #80–#85 — resolve all open E2E issues (incl. real TRM negotiation)

### DIFF
--- a/crates/tirami-ledger/src/metrics.rs
+++ b/crates/tirami-ledger/src/metrics.rs
@@ -31,6 +31,17 @@ pub(crate) fn is_anonymous_consumer(node_id: &tirami_core::NodeId) -> bool {
     node_id.0 == ANONYMOUS_CONSUMER_SENTINEL
 }
 
+/// Fix #85 — round a Prometheus gauge value to 9 decimal places so
+/// long-tail f64 drift (e.g. `0.9999999993809524` from `1.0 -
+/// minted/TOTAL_SUPPLY` with tens minted against 21 B) doesn't
+/// surface on operator dashboards.
+fn round_to_9dp(x: f64) -> f64 {
+    if !x.is_finite() {
+        return x;
+    }
+    (x * 1_000_000_000.0).round() / 1_000_000_000.0
+}
+
 pub struct TiramiMetrics {
     pub registry: Registry,
     pub cu_contributed: GaugeVec,
@@ -406,14 +417,18 @@ impl TiramiMetrics {
         }
 
         // Phase 13 tokenomics gauges — ledger-derived.
+        // Fix #85 — round supply_factor / yield_rate to 9 decimals
+        // (nano-unit precision, well below any operationally
+        // meaningful alert threshold) to silence f64 long-tail
+        // noise on dashboards.
         let minted = ledger.total_minted;
         self.total_minted.set(minted as i64);
         self.supply_factor
-            .set(crate::tokenomics::supply_factor(minted));
+            .set(round_to_9dp(crate::tokenomics::supply_factor(minted)));
         self.current_epoch
             .set(crate::tokenomics::current_epoch(minted) as i64);
         self.yield_rate
-            .set(crate::tokenomics::epoch_yield_rate(minted));
+            .set(round_to_9dp(crate::tokenomics::epoch_yield_rate(minted)));
 
         // Optional staking pool data.
         if let Some(pool) = staking_pool {

--- a/crates/tirami-ledger/src/metrics.rs
+++ b/crates/tirami-ledger/src/metrics.rs
@@ -20,6 +20,17 @@ use prometheus::{
 };
 
 /// Holds all Prometheus metrics for a Forge node.
+/// Placeholder NodeId used by HTTP `/v1/chat/completions` when the
+/// caller does not supply an `X-Tirami-Node-Id` header. Every byte
+/// is 0xFF so the sentinel is easy to spot in ledger dumps. The
+/// metrics layer filters this id out so it never appears as a
+/// node_id label on Prometheus dashboards (fix #83).
+const ANONYMOUS_CONSUMER_SENTINEL: [u8; 32] = [0xFFu8; 32];
+
+pub(crate) fn is_anonymous_consumer(node_id: &tirami_core::NodeId) -> bool {
+    node_id.0 == ANONYMOUS_CONSUMER_SENTINEL
+}
+
 pub struct TiramiMetrics {
     pub registry: Registry,
     pub cu_contributed: GaugeVec,
@@ -315,6 +326,15 @@ impl TiramiMetrics {
     ) {
         // Per-node balance and reputation metrics.
         for balance in ledger.balances.values() {
+            // Fix #83 — skip the anonymous-consumer sentinel. HTTP
+            // `record_api_trade` uses NodeId([255u8; 32]) as a
+            // placeholder consumer when the caller omits the
+            // `X-Tirami-Node-Id` header. That's an accounting
+            // bucket, not a real peer, so it shouldn't show up as
+            // a node_id label on Prometheus dashboards.
+            if is_anonymous_consumer(&balance.node_id) {
+                continue;
+            }
             let hex = balance.node_id.to_hex();
             let label = [hex.as_str()];
 
@@ -363,6 +383,9 @@ impl TiramiMetrics {
             }
 
             for node in &nodes {
+                if is_anonymous_consumer(node) {
+                    continue;
+                }
                 let report =
                     CollusionDetector::analyze_node(trades, node, now_ms);
                 let hex = node.to_hex();
@@ -509,6 +532,49 @@ mod tests {
             output.contains(&node.to_hex()),
             "node hex {} not in output",
             node.to_hex()
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Fix #83 — anonymous consumer sentinel must not leak to metrics
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn is_anonymous_consumer_recognises_sentinel() {
+        let sentinel = NodeId([0xFFu8; 32]);
+        assert!(super::is_anonymous_consumer(&sentinel));
+        let real = NodeId([0x42u8; 32]);
+        assert!(!super::is_anonymous_consumer(&real));
+    }
+
+    #[test]
+    fn test_observe_skips_anonymous_consumer_sentinel() {
+        // Simulate the state after a self-served HTTP chat: the
+        // ledger has a real node AND the anonymous sentinel in
+        // `balances`. Metrics must only expose the real node.
+        let mut ledger = ComputeLedger::new();
+        let real = NodeId([0x42u8; 32]);
+        let anon = NodeId([0xFFu8; 32]);
+        ledger.execute_trade(&TradeRecord {
+            provider: real.clone(),
+            consumer: anon.clone(),
+            trm_amount: 5,
+            tokens_processed: 5,
+            timestamp: 1_700_000_000_000,
+            model_id: "test".to_string(),
+            flops_estimated: 0,
+            nonce: [0u8; 16],
+        });
+        let metrics = TiramiMetrics::new();
+        metrics.observe(&ledger, 1_700_000_000_000);
+        let output = metrics.encode().unwrap();
+        assert!(
+            output.contains(&real.to_hex()),
+            "real node must appear in /metrics"
+        );
+        assert!(
+            !output.contains(&"ff".repeat(32)),
+            "anonymous sentinel must NOT appear in /metrics:\n{output}"
         );
     }
 

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -3171,8 +3171,12 @@ async fn forge_slash_events(
 
 #[derive(serde::Deserialize)]
 struct TokenIssueBody {
-    /// Hex-encoded 64-char NodeId for the token owner.
-    node_id: String,
+    /// Hex-encoded 64-char NodeId for the token owner. Optional:
+    /// when omitted, defaults to the local node's id so the common
+    /// "issue me a token" flow doesn't require extra plumbing
+    /// (fix #84).
+    #[serde(default)]
+    node_id: Option<String>,
     /// One of "read_only" | "inference" | "economy" | "admin".
     scope: String,
     /// Seconds until expiry. `0` means "never expires" (infra-only).
@@ -3206,8 +3210,14 @@ async fn forge_tokens_issue(
     require_admin_scope(&state, &headers).await?;
     check_forge_rate_limit(&state).await?;
 
-    let node_id = NodeId::from_hex(&body.node_id)
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid node_id: {e}")))?;
+    // Fix #84 — default the node_id to the local node's identity
+    // when the caller omits it. Matches the "issue me a token"
+    // mental model that originally tripped up integrators.
+    let node_id = match body.node_id.as_deref() {
+        Some(hex) if !hex.is_empty() => NodeId::from_hex(hex)
+            .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid node_id: {e}")))?,
+        _ => state.local_node_id.clone(),
+    };
     let scope = crate::api_tokens::ApiScope::parse(&body.scope).ok_or((
         StatusCode::BAD_REQUEST,
         format!(
@@ -4960,6 +4970,44 @@ mod tests {
         assert_eq!(json["scope"], "read_only");
         assert!(json["token"].as_str().unwrap().len() == 64);
         assert_eq!(json["label"], "ci-bot");
+    }
+
+    #[tokio::test]
+    async fn tokens_issue_defaults_node_id_to_local_node_when_omitted() {
+        // Fix #84 — integrators shouldn't need to know the local
+        // node_id to issue a token "for me". Omit the field and
+        // the server fills it in.
+        let mut config = Config::default();
+        config.api_bearer_token = Some("root".to_string());
+        let app = test_router(config);
+
+        let body = serde_json::json!({
+            "scope": "read_only",
+            "ttl_secs": 60,
+            "label": "auto-fill-test",
+            // no node_id
+        })
+        .to_string();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/tokens/issue")
+                    .header(AUTHORIZATION, "Bearer root")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = body_json(response).await;
+        // Expect a non-empty node_id — the local one the test router
+        // bound to. We don't pin the exact value (that's wiring
+        // detail), just that the handler resolved SOME node id.
+        let node_id = json["node_id"].as_str().unwrap_or("");
+        assert!(!node_id.is_empty(), "node_id auto-fill must not be empty");
+        assert_eq!(node_id.len(), 64, "hex NodeId must be 64 chars");
     }
 
     #[tokio::test]

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -928,14 +928,15 @@ fn gen_request_id() -> String {
 }
 
 /// Get model name from manifest or fallback.
-/// Returns the actual loaded model name, or "forge-no-model" if none is loaded.
+/// Returns the actual loaded model name, or "tirami-no-model" when
+/// running as a pure forwarder without a local model.
 async fn model_name(manifest: &ModelState) -> String {
     manifest
         .lock()
         .await
         .as_ref()
         .map(|m| m.id.0.clone())
-        .unwrap_or_else(|| "forge-no-model".to_string())
+        .unwrap_or_else(|| "tirami-no-model".to_string())
 }
 
 /// Parse an `X-Tirami-Node-Id` header (64-char hex → NodeId).
@@ -1295,13 +1296,20 @@ async fn openai_sync_response(
 ) -> Result<Json<OpenAIChatResponse>, (StatusCode, String)> {
     let mut engine = state.engine.lock().await;
     if !engine.is_loaded() {
-        return Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            serde_json::json!({
-                "error": {"message": "model not loaded", "type": "server_error"}
-            })
-            .to_string(),
-        ));
+        // Phase 18.5-part-4 (fix #80) — local engine has no model;
+        // try to forward the inference request to a connected peer
+        // over P2P. This is the only path that triggers a real
+        // dual-signed TRM negotiation from an HTTP client.
+        drop(engine);
+        return forward_chat_to_peer(
+            &state,
+            &prompt,
+            max_tokens,
+            temperature,
+            model,
+            has_tools,
+        )
+        .await;
     }
 
     // Use the engine's tokenizer for accurate prompt token count (#P11-prompt-tokens).
@@ -1418,6 +1426,223 @@ async fn openai_sync_response(
     }))
 }
 
+/// Phase 18.5-part-4 (fix #80) — forward a chat request to a
+/// connected peer via the P2P pipeline.
+///
+/// Invoked from `openai_sync_response` / `openai_stream_response`
+/// when the local engine isn't loaded. Picks the first connected
+/// peer (a smarter routing policy can slot into the same hook
+/// later) and drives `PipelineCoordinator::request_inference`,
+/// which:
+///   - Sends `Payload::InferenceRequest` to the peer.
+///   - Collects `Payload::TokenStream` chunks back.
+///   - On `Payload::TradeProposal`, counter-signs and returns
+///     `Payload::TradeAccept` so the peer records a dual-signed
+///     `SignedTradeRecord` and gossips it to the mesh.
+///
+/// Returns an OpenAI-shape response with the peer's tokens. The
+/// `x_tirami.effective_balance` reflects the local node's balance
+/// *after* the trade is gossiped back to us (which may not have
+/// happened yet by the time we respond — we report the pre-trade
+/// balance in that window).
+pub(crate) async fn forward_chat_to_peer(
+    state: &AppState,
+    prompt: &str,
+    max_tokens: u32,
+    temperature: f32,
+    model: String,
+    has_tools: bool,
+) -> Result<Json<OpenAIChatResponse>, (StatusCode, String)> {
+    let cluster = state.cluster.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "no connected peer cluster — model not loaded and transport inactive".to_string(),
+        )
+    })?;
+    let transport = cluster.transport_arc();
+    let peers = transport.connected_peers().await;
+    let peer_id = peers.first().cloned().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "model not loaded locally and no peers connected to forward to".to_string(),
+        )
+    })?;
+    let local_node_id = transport.tirami_node_id();
+
+    let text = crate::pipeline::PipelineCoordinator::request_inference(
+        &transport,
+        &peer_id,
+        &local_node_id,
+        prompt,
+        max_tokens,
+        temperature,
+    )
+    .await
+    .map_err(|e| (StatusCode::BAD_GATEWAY, format!("peer inference failed: {e}")))?;
+
+    // Count completion tokens using the local tokenizer if loaded
+    // (best effort — most workers won't have it). Fall back to a
+    // whitespace-split estimate so usage.completion_tokens is never 0.
+    let completion_tokens = {
+        let mut engine = state.engine.lock().await;
+        engine.tokenize(&text).ok().map(|t| t.len() as u32)
+    }
+    .unwrap_or_else(|| text.split_whitespace().count().max(1) as u32);
+
+    let effective_balance = state
+        .ledger
+        .lock()
+        .await
+        .effective_balance(&local_node_id);
+
+    let (message, finish_reason) = if has_tools {
+        let (content_before, maybe_tc) = extract_tool_call(&text);
+        if let Some(tc) = maybe_tc {
+            let tool_call = OpenAIToolCall {
+                id: tc.id,
+                call_type: "function".to_string(),
+                function: OpenAIFunctionCall {
+                    name: tc.name,
+                    arguments: tc.arguments,
+                },
+            };
+            (
+                OpenAIChatMessage {
+                    role: "assistant".to_string(),
+                    content: if content_before.is_empty() { None } else { Some(content_before) },
+                    tool_calls: Some(vec![tool_call]),
+                },
+                "tool_calls".to_string(),
+            )
+        } else {
+            (
+                OpenAIChatMessage {
+                    role: "assistant".to_string(),
+                    content: Some(text),
+                    tool_calls: None,
+                },
+                "stop".to_string(),
+            )
+        }
+    } else {
+        (
+            OpenAIChatMessage {
+                role: "assistant".to_string(),
+                content: Some(text),
+                tool_calls: None,
+            },
+            "stop".to_string(),
+        )
+    };
+
+    // The concrete trm_cost of the just-negotiated trade lives on
+    // the peer; until the signed trade lands locally via gossip we
+    // report 0 here. Clients relying on trm_cost should wait for
+    // the gossip round-trip (bounded by `state.config.anchor_interval_secs`).
+    Ok(Json(OpenAIChatResponse {
+        id: gen_request_id(),
+        object: "chat.completion".to_string(),
+        created: now_secs(),
+        model,
+        choices: vec![OpenAIChoice {
+            index: 0,
+            message,
+            finish_reason,
+        }],
+        usage: OpenAIUsage {
+            prompt_tokens: 0,
+            completion_tokens,
+            total_tokens: completion_tokens,
+        },
+        x_tirami: Some(TiramiUsageExt {
+            trm_cost: 0,
+            effective_balance,
+        }),
+    }))
+}
+
+/// Fix #80 — wrap a forwarded (non-stream) OpenAIChatResponse in a
+/// minimal SSE stream so streaming callers get the same shape they
+/// would from the local path: role chunk, one content chunk, stop
+/// chunk, [DONE] sentinel.
+fn forwarded_to_sse_stream(
+    resp: OpenAIChatResponse,
+    model: &str,
+) -> Sse<
+    impl tokio_stream::Stream<Item = Result<Event, std::convert::Infallible>> + Send + 'static,
+> {
+    let id = resp.id.clone();
+    let created = resp.created;
+    let choice = resp.choices.into_iter().next();
+    let (content, tool_calls, finish_reason) = match choice {
+        Some(c) => (
+            c.message.content.unwrap_or_default(),
+            c.message.tool_calls,
+            c.finish_reason,
+        ),
+        None => (String::new(), None, "stop".to_string()),
+    };
+
+    let role_chunk = serde_json::to_string(&OpenAIStreamChunk {
+        id: id.clone(),
+        object: "chat.completion.chunk".to_string(),
+        created,
+        model: model.to_string(),
+        choices: vec![OpenAIStreamChoice {
+            index: 0,
+            delta: OpenAIStreamDelta {
+                role: Some("assistant".to_string()),
+                content: None,
+                tool_calls: None,
+            },
+            finish_reason: None,
+        }],
+    })
+    .unwrap_or_default();
+
+    let content_chunk = serde_json::to_string(&OpenAIStreamChunk {
+        id: id.clone(),
+        object: "chat.completion.chunk".to_string(),
+        created,
+        model: model.to_string(),
+        choices: vec![OpenAIStreamChoice {
+            index: 0,
+            delta: OpenAIStreamDelta {
+                role: None,
+                content: Some(content),
+                tool_calls: None,
+            },
+            finish_reason: None,
+        }],
+    })
+    .unwrap_or_default();
+
+    let stop_chunk = serde_json::to_string(&OpenAIStreamChunk {
+        id,
+        object: "chat.completion.chunk".to_string(),
+        created,
+        model: model.to_string(),
+        choices: vec![OpenAIStreamChoice {
+            index: 0,
+            delta: OpenAIStreamDelta {
+                role: None,
+                content: None,
+                tool_calls,
+            },
+            finish_reason: Some(finish_reason),
+        }],
+    })
+    .unwrap_or_default();
+
+    let events: Vec<Result<Event, std::convert::Infallible>> = vec![
+        Ok(Event::default().data(role_chunk)),
+        Ok(Event::default().data(content_chunk)),
+        Ok(Event::default().data(stop_chunk)),
+        Ok(Event::default().data("[DONE]")),
+    ];
+    Sse::new(tokio_stream::iter(events))
+}
+
 /// Streaming SSE response in OpenAI format.
 ///
 /// Uses `InferenceEngine::generate_streaming` so tokens are emitted to the
@@ -1444,13 +1669,23 @@ async fn openai_stream_response(
     {
         let engine = state.engine.lock().await;
         if !engine.is_loaded() {
-            return Err((
-                StatusCode::SERVICE_UNAVAILABLE,
-                serde_json::json!({
-                    "error": {"message": "model not loaded", "type": "server_error"}
-                })
-                .to_string(),
-            ));
+            // Fix #80 — forward to a connected peer when no local
+            // model is loaded. The peer path returns the full text
+            // in one shot, so we emit it as a single SSE content
+            // chunk + stop + [DONE]. True chunked streaming across
+            // the P2P boundary is a follow-up (the pipeline already
+            // streams tokens, we just need a stream-forwarding hook).
+            drop(engine);
+            let json = forward_chat_to_peer(
+                &state,
+                &prompt,
+                max_tokens,
+                temperature,
+                model.clone(),
+                has_tools,
+            )
+            .await?;
+            return Ok(forwarded_to_sse_stream(json.0, &model).into_response());
         }
     } // release lock before blocking
 
@@ -3851,11 +4086,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_model_name_fallback_when_no_model_loaded() {
-        // When no manifest is set, model_name() should return "forge-no-model"
-        // (not the old "forge-model" hardcoded string).
+        // When no manifest is set, model_name() returns the "no model
+        // loaded" sentinel. Phase 17 rename: `forge-no-model` →
+        // `tirami-no-model`.
         let manifest_state: ModelState = Arc::new(Mutex::new(None));
         let name = model_name(&manifest_state).await;
-        assert_eq!(name, "forge-no-model");
+        assert_eq!(name, "tirami-no-model");
     }
 
     // -------------------------------------------------------------------------

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -1918,6 +1918,22 @@ async fn forge_balance(
     })
 }
 
+/// Fix #85 — round pricing floats to 6 decimal places before
+/// serializing.
+///
+/// The pricing engine uses EMA smoothing, which produces
+/// `1.0 ± tiny_epsilon` at the steady state. Operators reading
+/// `/v1/tirami/pricing` shouldn't see `0.9990014976703275` for a
+/// mostly-idle node. 6 decimals keeps enough precision for
+/// anything operationally meaningful (sub-cent on a $1 TRM) while
+/// silencing the f64 noise.
+fn round_price(x: f64) -> f64 {
+    if !x.is_finite() {
+        return x;
+    }
+    (x * 1_000_000.0).round() / 1_000_000.0
+}
+
 /// GET /v1/tirami/pricing — current market price and cost estimates.
 async fn forge_pricing(
     State(state): State<AppState>,
@@ -1928,11 +1944,11 @@ async fn forge_pricing(
     let trm_per_token = price.effective_trm_per_token();
 
     Ok(Json(TiramiPricingResponse {
-        trm_per_token,
-        supply_factor: price.supply_factor,
-        demand_factor: price.demand_factor,
-        cu_purchasing_power: price.cu_purchasing_power(),
-        deflation_factor: price.deflation_factor(),
+        trm_per_token: round_price(trm_per_token),
+        supply_factor: round_price(price.supply_factor),
+        demand_factor: round_price(price.demand_factor),
+        cu_purchasing_power: round_price(price.cu_purchasing_power()),
+        deflation_factor: round_price(price.deflation_factor()),
         total_trades_ever: price.total_trades_ever,
         estimated_cost_100_tokens: ledger.estimate_cost(100, 1, 1),
         estimated_cost_1000_tokens: ledger.estimate_cost(1000, 1, 1),
@@ -2040,9 +2056,11 @@ async fn forge_providers(
             serde_json::json!({
                 "node_id": n.node_id.to_hex(),
                 "contributed_cu": n.contributed,
-                "reputation": n.reputation,
+                "reputation": round_price(n.reputation),
                 "cu_per_100_tokens": rep_cost,
-                "base_trm_per_token": price,
+                // Fix #85 — snap to 6 decimals to hide EMA fp noise
+                // that otherwise renders as 0.9990014976703275.
+                "base_trm_per_token": round_price(price),
             })
         })
         .collect();
@@ -4970,6 +4988,22 @@ mod tests {
         assert_eq!(json["scope"], "read_only");
         assert!(json["token"].as_str().unwrap().len() == 64);
         assert_eq!(json["label"], "ci-bot");
+    }
+
+    // ------------------------------------------------------------------
+    // Fix #85 — round_price eliminates EMA f64 noise
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn round_price_snaps_noise_near_one() {
+        assert!((round_price(0.9990014976703275) - 0.999001).abs() < 1e-9);
+        // Exactly 1.0 stays 1.0.
+        assert_eq!(round_price(1.0), 1.0);
+        // Values already at 6-decimal precision are unchanged.
+        assert_eq!(round_price(0.5), 0.5);
+        // NaN / Inf are passed through.
+        assert!(round_price(f64::NAN).is_nan());
+        assert!(round_price(f64::INFINITY).is_infinite());
     }
 
     #[tokio::test]

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -3521,6 +3521,11 @@ async fn forge_agent_task(
             let output = tokens.join("");
             let flops_per_token = flops_per_token_from_manifest(&state).await;
             let model_id = req.model.as_deref().unwrap_or("active");
+            // Record the compute event on the ledger (accounting of
+            // FLOPs performed on the local engine). `record_api_trade`
+            // with consumer=None routes to the anonymous sentinel and
+            // still counts on `contributed` — this is the node's own
+            // internal accounting, not a wallet transfer.
             let trm_cost = record_api_trade(
                 &state.ledger,
                 &wallet,
@@ -3530,16 +3535,12 @@ async fn forge_agent_task(
                 flops_per_token,
             )
             .await;
-            // Self-originated by the local user: record as a spend
-            // on the agent (compute consumed, not earned).
-            {
-                let mut guard = state.personal_agent.lock().await;
-                if let Some(agent) = guard.as_mut() {
-                    if agent.wallet == wallet {
-                        agent.record_spend(trm_cost);
-                    }
-                }
-            }
+            // Fix #81 — self-served RunLocal tasks do NOT move TRM
+            // out of the user's wallet. The node paid itself in
+            // compute, so the PersonalAgent's spend tally must stay
+            // put. `maybe_record_agent_earn` already has the mirror
+            // invariant: earn only fires when the consumer is a
+            // peer, never when it's the anonymous-local sentinel.
             Ok(Json(serde_json::json!({
                 "task_id": task_id,
                 "status": "run_local",
@@ -4779,6 +4780,76 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    // -----------------------------------------------------------------
+    // Fix #81 regression: RunLocal must not touch the agent's spend tally.
+    // -----------------------------------------------------------------
+    #[tokio::test]
+    async fn agent_task_run_local_does_not_change_agent_spend_tally() {
+        // The RunLocal branch returns 503 when the model isn't
+        // loaded. Whether the branch succeeds or fails, the
+        // PersonalAgent's spend / earn tallies must not change
+        // because no TRM crosses wallet boundaries on a
+        // self-served task (the node pays itself in compute).
+        let app = test_router_with_agent(
+            Config::default(),
+            Some(agent_at(NodeId([0xAAu8; 32]))),
+        );
+
+        // Snapshot tallies via /v1/tirami/agent/status.
+        let before = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/tirami/agent/status")
+                    .body(Body::empty())
+                    .expect("before request"),
+            )
+            .await
+            .expect("before response");
+        let before_body = axum::body::to_bytes(before.into_body(), usize::MAX)
+            .await
+            .expect("before body");
+        let before_json: serde_json::Value =
+            serde_json::from_slice(&before_body).expect("before json");
+        let before_spent = before_json["spent_today_trm"].as_u64().unwrap_or_default();
+        let before_earned = before_json["earned_today_trm"].as_u64().unwrap_or_default();
+
+        // Drive the RunLocal path. It'll 503 on missing model, but the
+        // structural guarantee is: neither path touches the tally.
+        let _ = post_agent_task(
+            app.clone(),
+            serde_json::json!({
+                "prompt": "hi",
+                "max_tokens": 10,
+                "estimated_trm": 1,
+            }),
+        )
+        .await;
+
+        let after = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/tirami/agent/status")
+                    .body(Body::empty())
+                    .expect("after request"),
+            )
+            .await
+            .expect("after response");
+        let after_body = axum::body::to_bytes(after.into_body(), usize::MAX)
+            .await
+            .expect("after body");
+        let after_json: serde_json::Value =
+            serde_json::from_slice(&after_body).expect("after json");
+        let after_spent = after_json["spent_today_trm"].as_u64().unwrap_or_default();
+        let after_earned = after_json["earned_today_trm"].as_u64().unwrap_or_default();
+
+        assert_eq!(
+            (before_spent, before_earned),
+            (after_spent, after_earned),
+            "RunLocal path must not change spent/earned tallies on a self-served task"
+        );
     }
 
     #[tokio::test]

--- a/crates/tirami-node/src/pipeline.rs
+++ b/crates/tirami-node/src/pipeline.rs
@@ -655,16 +655,55 @@ impl PipelineCoordinator {
         transport.send_to(seed_peer_id, &envelope).await?;
         tracing::debug!("Sent inference request {} to {}", request_id, seed_peer_id);
 
-        // Collect streamed tokens
+        // Collect streamed tokens. Two completion signals:
+        //   (a) is_final=true TokenStream chunk arrives.
+        //   (b) TradeProposal counter-signed + TradeAccept sent.
+        //
+        // Fix #80-follow-up — previously this loop broke on (a)
+        // which abandoned the TradeProposal flight still in the
+        // wire buffer. The seed then timed out at 5s and fell
+        // back to the half-TRM penalty path. Now we wait for
+        // BOTH; if the TradeProposal doesn't arrive within
+        // `TRADE_PROPOSAL_WAIT`, we return the text anyway (the
+        // seed's timeout path will still record a trade).
+        const TRADE_PROPOSAL_WAIT: std::time::Duration =
+            std::time::Duration::from_secs(3);
         let mut result = String::new();
+        let mut seen_final = false;
+        let mut counter_signed = false;
+        let overall_deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(((max_tokens as u64) / 4).max(15));
         loop {
-            match transport.recv().await {
-                Some((peer_id, response)) => match response.payload {
+            if seen_final && counter_signed {
+                break;
+            }
+            let remaining = if seen_final {
+                TRADE_PROPOSAL_WAIT
+            } else {
+                overall_deadline.saturating_duration_since(tokio::time::Instant::now())
+            };
+            if remaining.is_zero() {
+                break;
+            }
+            let next = tokio::time::timeout(remaining, transport.recv()).await;
+            let envelope = match next {
+                Ok(Some((_peer_id, envelope))) => envelope,
+                Ok(None) => break,
+                Err(_) => {
+                    // Timeout: either waiting for tokens (unlikely to
+                    // have completed the HTTP response) or for the
+                    // trailing TradeProposal. In either case, exit.
+                    break;
+                }
+            };
+            let peer_id = &seed_peer_id;
+            let response = envelope;
+            match response.payload {
                     Payload::TokenStream(ts) => {
                         if ts.request_id == request_id {
                             result.push_str(&ts.text);
                             if ts.is_final {
-                                break;
+                                seen_final = true;
                             }
                         }
                     }
@@ -700,7 +739,7 @@ impl PipelineCoordinator {
                                     consumer_sig,
                                 }),
                             };
-                            if let Err(e) = transport.send_to(&peer_id, &accept).await {
+                            if let Err(e) = transport.send_to(peer_id, &accept).await {
                                 tracing::warn!("Failed to send TradeAccept: {}", e);
                             } else {
                                 tracing::debug!(
@@ -709,11 +748,10 @@ impl PipelineCoordinator {
                                     request_id
                                 );
                             }
+                            counter_signed = true;
                         }
                     }
                     _ => {}
-                },
-                None => break,
             }
         }
 

--- a/crates/tirami-node/src/pipeline.rs
+++ b/crates/tirami-node/src/pipeline.rs
@@ -6,8 +6,24 @@ use tirami_proto::{
     RpcServerFailed, RpcServerReady, TokenStreamMsg, TradeAccept, TradeProposal, Welcome,
 };
 use tirami_net::gossip::handle_reputation_gossip;
+use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::{oneshot, Mutex, Semaphore};
+
+/// Per-request TradeAccept dispatcher.
+///
+/// The seed's main recv loop is the single consumer of
+/// `transport.recv()`. When it pulls a `Payload::TradeAccept` off
+/// the wire, it must hand the consumer's signature back to the
+/// matching `handle_inference` task — otherwise that task times
+/// out at 5s and records a half-TRM penalized trade. This map
+/// keys per-request oneshot senders created by `handle_inference`
+/// and looked up by the main loop.
+///
+/// Same problem applies to the borrow flow (`LoanAccept`) — a
+/// follow-up can adopt the same pattern.
+pub(crate) type TradeAcceptDispatcher =
+    Arc<Mutex<HashMap<u64, oneshot::Sender<Vec<u8>>>>>;
 
 /// The role of a node in the inference pipeline.
 #[derive(Debug, Clone, PartialEq)]
@@ -51,6 +67,12 @@ impl PipelineCoordinator {
         let request_slots = Arc::new(Semaphore::new(
             config.max_concurrent_remote_inference_requests,
         ));
+        // Fix #80 — per-request TradeAccept dispatcher. Main recv
+        // loop routes incoming TradeAccept messages to the matching
+        // `handle_inference` task so the 5s timeout + penalty path
+        // only fires when the consumer is truly unresponsive.
+        let trade_accept_dispatcher: TradeAcceptDispatcher =
+            Arc::new(Mutex::new(HashMap::new()));
 
         loop {
             match self.transport.recv().await {
@@ -153,6 +175,7 @@ impl PipelineCoordinator {
                         let config = config.clone();
                         let ledger_path = ledger_path.clone();
                         let gossip = gossip.clone();
+                        let dispatcher = trade_accept_dispatcher.clone();
 
                         tokio::spawn(async move {
                             let _permit = permit;
@@ -167,6 +190,7 @@ impl PipelineCoordinator {
                                 &peer_id,
                                 req,
                                 gossip,
+                                dispatcher,
                             )
                             .await
                             {
@@ -241,9 +265,25 @@ impl PipelineCoordinator {
                             failed.reason
                         );
                     }
-                    Payload::TradeAccept(_) | Payload::TradeProposal(_) => {
-                        // Handled within handle_inference tasks via wait_for_trade_accept
-                        tracing::debug!("Trade message in main loop from {} (handled by task)", peer_id);
+                    Payload::TradeAccept(accept) => {
+                        // Fix #80 — route the consumer signature to
+                        // the matching handle_inference task.
+                        let mut dispatch = trade_accept_dispatcher.lock().await;
+                        if let Some(sender) = dispatch.remove(&accept.request_id) {
+                            let _ = sender.send(accept.consumer_sig);
+                        } else {
+                            tracing::debug!(
+                                "Orphan TradeAccept for request_id={} from {}",
+                                accept.request_id,
+                                peer_id
+                            );
+                        }
+                    }
+                    Payload::TradeProposal(_) => {
+                        tracing::debug!(
+                            "Unexpected TradeProposal in seed main loop from {}",
+                            peer_id
+                        );
                     }
                     Payload::LoanAccept(_) => {
                         // Handled by wait_for_loan_accept on the lender side.
@@ -719,6 +759,7 @@ async fn handle_inference(
     peer_id: &str,
     req: InferenceRequest,
     gossip: Arc<Mutex<GossipState>>,
+    trade_accept_dispatcher: TradeAcceptDispatcher,
 ) -> anyhow::Result<()> {
     use tirami_infer::InferenceEngine;
 
@@ -854,6 +895,14 @@ async fn handle_inference(
     let canonical = trade.canonical_bytes();
     let provider_sig = transport.sign(&canonical).to_vec();
 
+    // Fix #80 — register the dispatcher slot BEFORE sending the
+    // TradeProposal so we can't race a very-fast counter-sign.
+    let (accept_tx, accept_rx) = oneshot::channel::<Vec<u8>>();
+    {
+        let mut dispatch = trade_accept_dispatcher.lock().await;
+        dispatch.insert(req.request_id, accept_tx);
+    }
+
     // Send TradeProposal to consumer
     let proposal_msg = Envelope {
         msg_id: req.request_id * 10000 + 9999,
@@ -871,17 +920,31 @@ async fn handle_inference(
             nonce: trade.nonce,
         }),
     };
-    transport.send_to(peer_id, &proposal_msg).await?;
+    if let Err(e) = transport.send_to(peer_id, &proposal_msg).await {
+        // Cancel the dispatcher slot so stale entries don't
+        // accumulate when we can't even reach the peer.
+        let mut dispatch = trade_accept_dispatcher.lock().await;
+        dispatch.remove(&req.request_id);
+        drop(dispatch);
+        return Err(e.into());
+    }
 
-    // Wait for TradeAccept with timeout (5 seconds)
+    // Wait for TradeAccept with timeout (5 seconds). The
+    // dispatcher delivers the consumer signature through the
+    // oneshot channel when the main recv loop receives it.
     let accept_result = tokio::time::timeout(
         std::time::Duration::from_secs(5),
-        wait_for_trade_accept(&transport, req.request_id),
+        accept_rx,
     )
     .await;
+    // Remove any remaining slot on timeout so the map doesn't grow.
+    if accept_result.is_err() {
+        let mut dispatch = trade_accept_dispatcher.lock().await;
+        dispatch.remove(&req.request_id);
+    }
 
     match accept_result {
-        Ok(Some(consumer_sig)) => {
+        Ok(Ok(consumer_sig)) => {
             // Record dual-signed trade
             let signed = SignedTradeRecord {
                 trade: trade.clone(),
@@ -953,26 +1016,6 @@ async fn handle_inference(
     Ok(())
 }
 
-/// Wait for a TradeAccept message matching the given request_id.
-async fn wait_for_trade_accept(
-    transport: &ForgeTransport,
-    request_id: u64,
-) -> Option<Vec<u8>> {
-    loop {
-        match transport.recv().await {
-            Some((_peer_id, envelope)) => {
-                if let Payload::TradeAccept(accept) = envelope.payload {
-                    if accept.request_id == request_id {
-                        return Some(accept.consumer_sig);
-                    }
-                }
-                // Ignore other messages while waiting
-            }
-            None => return None,
-        }
-    }
-}
-
 /// Wait for a LoanAccept message matching the given request_id.
 ///
 /// Used by the lender-side `/v1/tirami/lend-to` flow after a `LoanProposal`
@@ -1033,6 +1076,58 @@ mod tests {
     use tirami_ledger::ComputeLedger;
     use tirami_net::ForgeTransport;
     use tokio::time::{Duration, timeout};
+
+    // ---------------------------------------------------------------------
+    // Fix #80 — TradeAcceptDispatcher
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn trade_accept_dispatcher_delivers_signature() {
+        let dispatcher: TradeAcceptDispatcher = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, rx) = oneshot::channel::<Vec<u8>>();
+        dispatcher.lock().await.insert(42, tx);
+
+        // Simulate the seed main loop receiving a TradeAccept for
+        // request_id=42 and routing the consumer_sig through the
+        // oneshot channel.
+        let sender = dispatcher
+            .lock()
+            .await
+            .remove(&42)
+            .expect("slot for 42 must exist");
+        sender
+            .send(vec![0xAAu8; 64])
+            .expect("oneshot::send must succeed");
+
+        let sig = rx.await.expect("handle_inference side must get the sig");
+        assert_eq!(sig.len(), 64);
+        assert!(dispatcher.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn trade_accept_dispatcher_orphan_request_is_noop() {
+        // When the main loop receives a TradeAccept for a request_id
+        // that has no registered waiter (e.g. the handle_inference
+        // task already timed out and cleaned up), remove returns
+        // None and the message is dropped without panic.
+        let dispatcher: TradeAcceptDispatcher = Arc::new(Mutex::new(HashMap::new()));
+        let slot = dispatcher.lock().await.remove(&99);
+        assert!(slot.is_none());
+    }
+
+    #[tokio::test]
+    async fn trade_accept_dispatcher_timeout_cleans_up_slot() {
+        // Simulate: handle_inference registers a slot, the consumer
+        // never sends TradeAccept, and the timeout branch removes
+        // the entry. The map must not grow unboundedly.
+        let dispatcher: TradeAcceptDispatcher = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _rx) = oneshot::channel::<Vec<u8>>();
+        dispatcher.lock().await.insert(7, tx);
+        assert_eq!(dispatcher.lock().await.len(), 1);
+        // Timeout branch in handle_inference removes the slot.
+        dispatcher.lock().await.remove(&7);
+        assert!(dispatcher.lock().await.is_empty());
+    }
 
     #[tokio::test]
     async fn worker_request_inference_surfaces_typed_error() {


### PR DESCRIPTION
## Summary

Resolves every open issue filed from the 100.112.10.128 E2E run (#80–#85). Includes a real 2-node verification that dual-signed TRM trades now land on the seed when a request comes in over HTTP.

## Commits (one per issue, plus one follow-up)

| # | Commit | Summary |
|---|---|---|
| #80 | \`fix(#80): wire HTTP /v1/chat/completions → P2P forward + dual-sign dispatcher\` | Non-stream + stream HTTP branches forward to a connected peer when the local engine has no model. New \`TradeAcceptDispatcher\` routes consumer signatures per-request_id so the seed's main recv loop stops eating them. |
| #80 fu | \`fix(#80-followup): worker keeps recv-loop open after final token to counter-sign\` | Worker's \`request_inference\` previously broke on the is_final TokenStream, missing the trailing TradeProposal. Split exit condition into \`seen_final && counter_signed\`. |
| #81 | \`fix(#81): RunLocal path no longer charges the agent's spend tally\` | Self-served tasks no longer move TRM out of the wallet. |
| #82 | — | Resolved implicitly by #80 (worker daemon now forwards via HTTP). |
| #83 | \`fix(#83): skip the anonymous-consumer sentinel in /metrics\` | \`ffff…ff\` no longer appears as a node_id label. |
| #84 | \`fix(#84): default node_id on POST /v1/tirami/tokens/issue to the local node\` | "Issue me a token" just works now. |
| #85 | \`fix(#85): round pricing f64s before serialisation to kill long-tail noise\` | \`0.9990014976703275\` → \`0.999001\` on the API, \`0.9999999993809524\` → rounded in metrics. |

## Closes
\`Closes #80, Closes #81, Closes #82, Closes #83, Closes #84, Closes #85\`.

## Verification — 2-node E2E against 100.112.10.128

Seed on Mac Studio (100.112.10.128:3000), worker as \`--daemon\` on localhost:3111.
POST \`Count to 5\` with max_tokens=20 to worker HTTP →

\`\`\`
Seed log:
  tirami_node::pipeline: Inference request from 95c22c69… 28 chars, max 20 tokens
  tirami_node::pipeline: Signed trade recorded: 32 CU for 21 tokens to 95c22c69…

Seed /v1/tirami/trades:
  count=1
    prov=df72ab499ba404dc.. cons=95c22c69ab93080e.. trm=32 tokens=21
\`\`\`

Consumer is a real NodeId (not \`ffff…\`), trm is full (not half/penalised) — **the dual-signed TRM negotiation flow is reachable from HTTP for the first time**.

Other checks against the same node:
- \`/metrics\` has 0 \`ffff…ff\` node_id labels (#83 ✓).
- \`/v1/tirami/pricing\` returns \`1.0\` across the board (not \`0.999…\`) (#85 ✓).
- \`POST /v1/tirami/tokens/issue\` with only \`{scope, label, ttl_secs}\` returns 200 with the local node's id auto-filled (#84 ✓).
- \`/v1/tirami/agent/task\` local branch leaves \`spent_today_trm\` unchanged (#81 ✓).

## Tests
\`cargo test --workspace\` — **1 185 passing, 0 failed** (↑ 8 new unit tests: dispatcher delivery/orphan/timeout cleanup, round_price, anonymous-sentinel filter, token auto-fill, RunLocal state invariance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)