### PR TITLE
Phase 19 — Tier C/D enablers (peer discovery, ProofPolicy=Optional, Sepolia deploy, disclaimer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,27 @@ Companion: clearclown/tirami-contracts — Solidity/Foundry TRM ERC-20 + Bridge
 
 ## License
 
-MIT
+MIT. See [`LICENSE`](LICENSE).
+
+## Not an investment — secondary-market disclaimer
+
+TRM is **compute accounting**, not a financial product. The
+protocol maintainers do not sell, promote, or speculate on TRM.
+Because the code is MIT-licensed open source, anyone anywhere may
+— without the maintainers' knowledge, consent, or endorsement —
+bridge, list, trade, or derive TRM on secondary markets. If you
+choose to hold or trade TRM as a store of value, you take on all
+associated risk yourself.
+
+- No ICO, no pre-sale, no airdrop, no private round.
+- No revenue share from third-party markets.
+- Base mainnet deploy is **audit-gated** (see
+  [`docs/release-readiness.md`](docs/release-readiness.md) Tier D
+  and the `deploy-base-mainnet` target in
+  [`repos/tirami-contracts/Makefile`](repos/tirami-contracts/Makefile)).
+
+Full text of the disclaimer is in
+[`SECURITY.md`](SECURITY.md#secondary-markets--third-party-tokenization).
 
 ## Acknowledgements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-**Last reviewed:** 2026-04-18 (Phase 17 Wave 3.6).
+**Last reviewed:** 2026-04-19 (Phase 19 Tier C/D enablers).
 
 Tirami is a protocol for buying and selling compute as a currency on
 an adversarial public network. Security is not optional. If you find
@@ -9,6 +9,66 @@ below. If you're here to exploit one, please also consider reporting:
 the bounty program framework in the "Bug bounty" section pays out
 competitively with market prices and reporting keeps you in
 good-faith territory (see "Rules of engagement").
+
+## Secondary markets & third-party tokenization
+
+Tirami is **MIT-licensed open-source software**. TRM is the unit
+the ledger uses to account for compute. TRM is not a financial
+product, an investment contract, a security, or a commodity
+offered for sale by the protocol maintainers.
+
+Because the software is open source, anyone in the world — with or
+without the maintainers' knowledge, consent, or endorsement — may:
+
+- bridge the on-chain ERC-20 to other networks,
+- list TRM on a secondary exchange,
+- speculate on its future value,
+- build derivatives (futures, options, structured products),
+- fork the code and run a competing network.
+
+The protocol maintainers:
+
+- **do not** solicit investment in TRM.
+- **do not** promise any return, appreciation, or yield beyond the
+  mechanical "TRM ↔ compute" accounting relationship.
+- **do not** sell TRM on a pre-sale, ICO, airdrop, or private round.
+- **do not** receive equity, tokens, or revenue share from any
+  third-party market that lists TRM.
+- **cannot prevent** third parties from creating such markets
+  after the open-source release.
+- **explicitly disclaim** any warranty of merchantability or
+  fitness for a particular purpose (see `LICENSE`, the MIT clause
+  at the end).
+
+If you are considering holding or trading TRM as a store of value,
+you are making that judgement yourself and accepting all associated
+risk — legal, regulatory, counterparty, and technical.
+
+The protocol works without any external market. `1 TRM = 10⁹ FLOP`
+is the definitional anchor (docs/whitepaper.md §3). The compute is
+the value. Everything else is emergent.
+
+## Mainnet deployment gate
+
+`make deploy-base-mainnet` in `repos/tirami-contracts/Makefile`
+refuses to run unless the operator has:
+
+1. An external security audit report signed off (env var
+   `AUDIT_CLEARANCE=yes`).
+2. A multi-sig address configured to receive `Ownable::owner`
+   (env var `MULTISIG_OWNER`).
+3. Typed `i-accept-responsibility` at an interactive prompt.
+
+An operator who bypasses these gates — for instance by patching
+the Makefile, calling `forge script` directly, or deploying from
+another tool — is solely responsible for the deployment. The MIT
+license explicitly permits such forks and redeploys but does
+**not** transfer any liability from the patcher to the original
+maintainers.
+
+See `docs/release-readiness.md` for the full Tier A–D rollout
+criteria, and `docs/deployments/README.md` for the live deploy
+record.
 
 ## Supported versions
 

--- a/crates/tirami-cli/src/main.rs
+++ b/crates/tirami-cli/src/main.rs
@@ -564,6 +564,16 @@ async fn main() -> anyhow::Result<()> {
             let transport = node.connect_to_seed(seed_addr).await?;
             tracing::info!("Connected to seed. Ready for inference.");
 
+            // Phase 19 / Tier C — auto-configure the PersonalAgent
+            // on the worker too. Without this `/v1/tirami/agent/*`
+            // returns 412 on worker nodes, breaking the
+            // killer-app story for users who run a worker
+            // (HTTP → P2P forward) instead of a full seed. Also
+            // spawn the background tick loop so the agent observes
+            // activity.
+            node.ensure_personal_agent(transport.tirami_node_id()).await;
+            node.spawn_agent_loop();
+
             // Spawn HTTP API server in background (same pattern as Seed)
             node.spawn_api();
 

--- a/crates/tirami-core/src/config.rs
+++ b/crates/tirami-core/src/config.rs
@@ -131,8 +131,8 @@ pub struct Config {
     /// Phase 18.3 — zkML rollout gate. See
     /// `tirami_ledger::zk::ProofPolicy`. Stored as a string here
     /// to avoid circular dependencies between tirami-core and
-    /// tirami-ledger. Valid values: "disabled" (default),
-    /// "optional", "recommended", "required".
+    /// tirami-ledger. Valid values: `"disabled"`, `"optional"`
+    /// (Phase 19 default), `"recommended"`, `"required"`.
     ///
     /// The network-wide value is Constitutionally ratcheted: once
     /// set to "required", it cannot be downgraded by governance.
@@ -181,7 +181,14 @@ fn default_checkpoint_retain_secs() -> u64 {
 }
 
 fn default_proof_policy() -> String {
-    "disabled".to_string()
+    // Phase 19 / Tier C — promoted from "disabled" to "optional".
+    // Nodes trade without proofs by default but proof-verified
+    // trades get a reputation boost once an ezkl/risc0 backend is
+    // wired in. Constitutional ratchet in
+    // `tirami_ledger::zk::try_ratchet_proof_policy` prevents
+    // downgrade, so future governance can only move UP to
+    // `recommended` / `required` (the latter irreversibly).
+    "optional".to_string()
 }
 
 fn default_agent_tick_interval_secs() -> u64 {
@@ -272,7 +279,7 @@ impl Default for Config {
             checkpoint_interval_secs: 3_600,
             checkpoint_retain_secs: 24 * 3_600,
             archive_path: None,
-            proof_policy: "disabled".to_string(),
+            proof_policy: "optional".to_string(),
             agent_tick_interval_secs: 30,
             personal_agent_enabled: true,
         }

--- a/crates/tirami-core/src/types.rs
+++ b/crates/tirami-core/src/types.rs
@@ -254,6 +254,26 @@ pub struct PriceSignal {
     pub latency_hint_ms: u32,
     /// Unix timestamp (ms) when this signal was created.
     pub timestamp: u64,
+    /// Phase 19 / Tier-C enabler (fix for #80 scope-extension).
+    ///
+    /// Optional HTTP endpoint the provider advertises for callers
+    /// that want to drive inference over the OpenAI-compatible REST
+    /// surface rather than iroh P2P. When present, consumers can
+    /// resolve `NodeId → URL` locally from the peer registry
+    /// instead of requiring the user to hand-wire `peer.url` on
+    /// every request.
+    ///
+    /// `None` is the pre-Phase-19 wire shape and parses cleanly
+    /// (via `#[serde(default)]`) — operators who don't want to
+    /// advertise HTTP simply leave the config field empty.
+    ///
+    /// SECURITY: the advertised URL is self-attested. Consumers
+    /// MUST still verify trades are dual-signed (which already
+    /// happens). An attacker advertising an HTTP endpoint they
+    /// don't control at most wastes the consumer's request; they
+    /// cannot forge a signed trade.
+    #[serde(default)]
+    pub http_endpoint: Option<String>,
 }
 
 impl PriceSignal {
@@ -391,6 +411,7 @@ mod tests {
             model_capabilities: vec![],
             latency_hint_ms: 50,
             timestamp: 0,
+            http_endpoint: None,
         };
         assert!(!sig.is_valid());
     }
@@ -404,6 +425,7 @@ mod tests {
             model_capabilities: vec![],
             latency_hint_ms: 50,
             timestamp: 0,
+            http_endpoint: None,
         };
         assert!(!sig.is_valid());
     }
@@ -417,6 +439,7 @@ mod tests {
             model_capabilities: vec![],
             latency_hint_ms: 50,
             timestamp: 0,
+            http_endpoint: None,
         };
         assert!(!sig.is_valid());
     }
@@ -430,6 +453,7 @@ mod tests {
             model_capabilities: vec![],
             latency_hint_ms: 50,
             timestamp: 0,
+            http_endpoint: None,
         };
         assert!(!sig.is_valid());
     }
@@ -443,6 +467,7 @@ mod tests {
             model_capabilities: vec![],
             latency_hint_ms: 50,
             timestamp: 0,
+            http_endpoint: None,
         };
         assert!(!sig.is_valid());
     }
@@ -456,6 +481,7 @@ mod tests {
             model_capabilities: vec![],
             latency_hint_ms: 50,
             timestamp: 0,
+            http_endpoint: None,
         };
         assert!(sig.is_valid());
     }
@@ -469,6 +495,7 @@ mod tests {
             model_capabilities: vec![],
             latency_hint_ms: 50,
             timestamp: 0,
+            http_endpoint: None,
         };
         assert!(sig.is_valid());
     }

--- a/crates/tirami-ledger/src/ledger.rs
+++ b/crates/tirami-ledger/src/ledger.rs
@@ -805,6 +805,26 @@ impl ComputeLedger {
         &self.price
     }
 
+    /// Phase 19 / Tier C — resolve a peer's advertised HTTP
+    /// endpoint from the most recent PriceSignal in the registry.
+    /// Returns `None` when the peer is unknown or didn't advertise
+    /// an endpoint (i.e. it's iroh-P2P only).
+    ///
+    /// Used by `forge_agent_task` to auto-pick a peer URL after
+    /// `select_provider` without requiring the caller to supply
+    /// `peer.url` on every request.
+    ///
+    /// SECURITY: the value is self-attested by the advertising
+    /// peer. Callers MUST still verify trades are dual-signed
+    /// (`execute_signed_trade` already enforces this). A peer that
+    /// lies about its URL at most wastes the consumer's request.
+    pub fn peer_http_endpoint(&self, node_id: &NodeId) -> Option<String> {
+        self.peer_registry
+            .get(node_id)
+            .and_then(|s| s.price_signal.as_ref())
+            .and_then(|sig| sig.http_endpoint.clone())
+    }
+
     /// Return the most recent trades, newest first.
     pub fn recent_trades(&self, limit: usize) -> Vec<TradeRecord> {
         self.trade_log.iter().rev().take(limit).cloned().collect()
@@ -5879,7 +5899,41 @@ mod tests {
             model_capabilities: vec![ModelId(model.to_string())],
             latency_hint_ms: 50,
             timestamp: now_millis(),
+            http_endpoint: None,
         }
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 19 / Tier C — peer_http_endpoint auto-resolution
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn peer_http_endpoint_returns_none_when_peer_unknown() {
+        let ledger = ComputeLedger::new();
+        assert!(ledger.peer_http_endpoint(&NodeId([42u8; 32])).is_none());
+    }
+
+    #[test]
+    fn peer_http_endpoint_returns_none_when_peer_advertises_nothing() {
+        let mut ledger = ComputeLedger::new();
+        let node = NodeId([42u8; 32]);
+        let mut sig = price_signal_for(node.clone(), "qwen", 1.0, 1000);
+        sig.http_endpoint = None;
+        ledger.peer_registry.ingest_price_signal(&sig);
+        assert!(ledger.peer_http_endpoint(&node).is_none());
+    }
+
+    #[test]
+    fn peer_http_endpoint_surfaces_advertised_url() {
+        let mut ledger = ComputeLedger::new();
+        let node = NodeId([42u8; 32]);
+        let mut sig = price_signal_for(node.clone(), "qwen", 1.0, 1000);
+        sig.http_endpoint = Some("http://100.64.1.1:3000".to_string());
+        ledger.peer_registry.ingest_price_signal(&sig);
+        assert_eq!(
+            ledger.peer_http_endpoint(&node).as_deref(),
+            Some("http://100.64.1.1:3000"),
+        );
     }
 
     #[test]

--- a/crates/tirami-ledger/src/peer_registry.rs
+++ b/crates/tirami-ledger/src/peer_registry.rs
@@ -384,6 +384,7 @@ mod tests {
             model_capabilities: vec![ModelId("qwen2.5-0.5b".into())],
             latency_hint_ms: 50,
             timestamp,
+            http_endpoint: None,
         }
     }
 

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -2088,7 +2088,7 @@ async fn forge_peers(
         .peers()
         .iter()
         .map(|(node_id, state)| {
-            let (price_multiplier, available_cu, models, latency_hint_ms, timestamp) =
+            let (price_multiplier, available_cu, models, latency_hint_ms, timestamp, http_endpoint) =
                 match &state.price_signal {
                     Some(sig) => (
                         sig.price_multiplier,
@@ -2099,8 +2099,9 @@ async fn forge_peers(
                             .collect::<Vec<_>>(),
                         sig.latency_hint_ms,
                         sig.timestamp,
+                        sig.http_endpoint.clone(),
                     ),
-                    None => (1.0, 0, vec![], 0, 0),
+                    None => (1.0, 0, vec![], 0, 0, None),
                 };
             serde_json::json!({
                 "node_id": node_id.to_hex(),
@@ -2112,6 +2113,9 @@ async fn forge_peers(
                 "last_seen": timestamp,
                 "audit_tier": format!("{:?}", state.audit_tier),
                 "verified_trades": state.verified_trade_count,
+                // Phase 19 / Tier C — peer's self-advertised HTTP
+                // endpoint (None if iroh-P2P only).
+                "http_endpoint": http_endpoint,
             })
         })
         .collect();
@@ -3479,10 +3483,8 @@ async fn forge_agent_task(
         .estimated_trm
         .unwrap_or_else(|| ((req.max_tokens as u64).saturating_add(99) / 100).max(1));
 
-    // Phase 18.5-part-3c — parse the peer hint (if any) so we can
-    // populate `preferred_provider` and have `tick` return
-    // `RunRemote` instead of bailing to `AskUser`.
-    let peer_hint_parsed: Option<(NodeId, String)> = match &req.peer {
+    // Phase 18.5-part-3c — parse the explicit peer hint (if any).
+    let explicit_peer: Option<(NodeId, String)> = match &req.peer {
         Some(hint) => match NodeId::from_hex(&hint.node_id) {
             Ok(id) => Some((id, hint.url.trim_end_matches('/').to_string())),
             Err(_) => {
@@ -3494,6 +3496,35 @@ async fn forge_agent_task(
         },
         None => None,
     };
+
+    // Phase 19 / Tier C — when no explicit peer is supplied, try to
+    // auto-resolve via select_provider + peer_http_endpoint. This
+    // closes the "RunRemote always bails to ask_user" scaffold from
+    // #80 so remote routing works without the caller needing to
+    // know peer URLs.
+    let auto_peer: Option<(NodeId, String)> = if explicit_peer.is_none()
+        && size == tirami_mind::TaskSize::Remote
+    {
+        let ledger = state.ledger.lock().await;
+        let model_id = tirami_core::ModelId(
+            req.model.as_deref().unwrap_or("").to_string(),
+        );
+        match ledger.select_provider(
+            &model_id,
+            req.max_tokens as u64,
+            &state.local_node_id,
+        ) {
+            Some((provider_id, _cost)) => match ledger.peer_http_endpoint(&provider_id) {
+                Some(url) => Some((provider_id, url.trim_end_matches('/').to_string())),
+                None => None,
+            },
+            None => None,
+        }
+    } else {
+        None
+    };
+
+    let peer_hint_parsed = explicit_peer.clone().or(auto_peer);
 
     let estimate = tirami_mind::TaskCostEstimate {
         size,

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -422,6 +422,19 @@ impl TiramiNode {
             bal.max(0) as u64
         };
 
+        // Phase 19 / Tier C — advertise HTTP endpoint so consumers
+        // can auto-resolve NodeId → URL. Only emit when the API is
+        // bound to a non-loopback address (otherwise the URL is
+        // useless to peers). `0.0.0.0` is treated as "listen on all"
+        // but we need a caller-reachable address, so we surface it
+        // only if the operator explicitly set the bind to a public
+        // interface name. Callers can always override with a
+        // `peer.url` override on the HTTP request.
+        let http_endpoint = derive_public_http_endpoint(
+            &self.config.api_bind_addr,
+            self.config.api_port,
+        );
+
         tirami_core::PriceSignal {
             node_id,
             // Phase 14.1: static 1.0 multiplier. Dynamic pricing policy
@@ -435,6 +448,7 @@ impl TiramiNode {
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_millis() as u64)
                 .unwrap_or(0),
+            http_endpoint,
         }
     }
 
@@ -760,6 +774,12 @@ impl TiramiNode {
         let model_manifest = self.model_manifest.clone();
         // Build a lightweight closure that re-creates the signal each tick.
         let node_id = transport.tirami_node_id();
+        // Phase 19 / Tier C — advertise HTTP endpoint so peers can
+        // auto-resolve NodeId → URL for forwarded chat requests.
+        let http_endpoint = derive_public_http_endpoint(
+            &self.config.api_bind_addr,
+            self.config.api_port,
+        );
 
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(std::time::Duration::from_secs(30));
@@ -791,6 +811,7 @@ impl TiramiNode {
                         .duration_since(std::time::UNIX_EPOCH)
                         .map(|d| d.as_millis() as u64)
                         .unwrap_or(0),
+                    http_endpoint: http_endpoint.clone(),
                 };
 
                 // Update own PeerRegistry entry.
@@ -1026,5 +1047,71 @@ mod tests {
         node.ensure_personal_agent(wallet()).await;
         let guard = node.personal_agent.lock().await;
         assert_eq!(guard.as_ref().unwrap().earned_today_trm, 999);
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 19 / Tier C — derive_public_http_endpoint
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn loopback_bind_returns_none() {
+        assert!(super::derive_public_http_endpoint("127.0.0.1", 3000).is_none());
+        assert!(super::derive_public_http_endpoint("localhost", 3000).is_none());
+        assert!(super::derive_public_http_endpoint("::1", 3000).is_none());
+    }
+
+    #[test]
+    fn zero_bind_is_suppressed() {
+        // 0.0.0.0 is a "listen on all" sentinel; peers can't reach
+        // it as a URL. Suppress rather than advertise garbage.
+        assert!(super::derive_public_http_endpoint("0.0.0.0", 3000).is_none());
+        assert!(super::derive_public_http_endpoint("::", 3000).is_none());
+    }
+
+    #[test]
+    fn public_bind_produces_http_url() {
+        let url = super::derive_public_http_endpoint("100.64.1.1", 3000)
+            .expect("non-loopback bind should advertise");
+        assert_eq!(url, "http://100.64.1.1:3000");
+    }
+
+    #[test]
+    fn ipv6_public_bind_is_bracketed() {
+        let url = super::derive_public_http_endpoint("2001:db8::1", 3000)
+            .expect("v6 public bind should advertise");
+        assert_eq!(url, "http://[2001:db8::1]:3000");
+    }
+}
+
+/// Phase 19 / Tier C — derive the HTTP endpoint this node should
+/// advertise on its PriceSignal so peers can resolve `NodeId → URL`.
+///
+/// Rules:
+/// - Loopback addresses (`127.0.0.1`, `::1`, `localhost`) → `None`
+///   because no peer can reach them.
+/// - Wildcard binds (`0.0.0.0`, `::`) → `None` because the value
+///   isn't a valid URL host.
+/// - Anything else → `Some("http://<host>:<port>")` with v6
+///   addresses bracketed per RFC 3986.
+///
+/// Operators who want TLS or a reverse-proxy URL can extend this
+/// helper by reading a config override (future `config.public_http_url`).
+pub(crate) fn derive_public_http_endpoint(bind: &str, port: u16) -> Option<String> {
+    let b = bind.trim();
+    if b.is_empty() {
+        return None;
+    }
+    let lower = b.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "127.0.0.1" | "::1" | "localhost" | "0.0.0.0" | "::"
+    ) {
+        return None;
+    }
+    if b.contains(':') && !b.starts_with('[') {
+        // Raw IPv6 literal — bracket for URL form.
+        Some(format!("http://[{b}]:{port}"))
+    } else {
+        Some(format!("http://{b}:{port}"))
     }
 }

--- a/crates/tirami-proto/src/messages.rs
+++ b/crates/tirami-proto/src/messages.rs
@@ -1308,6 +1308,7 @@ mod tests {
             model_capabilities: vec![ModelId("qwen2.5-0.5b".into())],
             latency_hint_ms: 50,
             timestamp: 1_000,
+            http_endpoint: None,
         }
     }
 

--- a/docs/deployments/README.md
+++ b/docs/deployments/README.md
@@ -1,0 +1,100 @@
+# Tirami On-Chain Deployments
+
+Phase 19 / Tier C–D. This directory records every on-chain deploy
+of the Tirami contracts so operators, auditors, and the community
+can independently verify what's live.
+
+## Current status
+
+| Network | Chain ID | TRM ERC-20 | TiramiBridge | Deployed at |
+|---|---|---|---|---|
+| Base Sepolia (testnet) | 84532 | — (not yet) | — | — |
+| Base mainnet | 8453 | **audit-gated** | **audit-gated** | **not deployed** |
+
+The Base mainnet deploy is blocked on:
+1. External security audit (Phase 17 Wave 3.3) — not started.
+2. Multi-sig configured for `Ownable::owner` transfer.
+3. ≥30-day clean operation on Base Sepolia.
+4. Active bug bounty for ≥30 days (SECURITY.md).
+
+See `docs/release-readiness.md` for the full tiered rollout plan.
+
+## Reproducing a deploy
+
+All deploys must go through `repos/tirami-contracts/Makefile`:
+
+```bash
+# one-time environment
+export DEPLOYER_ADDRESS=0x...     # the EOA that broadcasts the tx
+export PRIVATE_KEY=0x...          # OR use `--ledger` for HW signer
+export BASESCAN_KEY=...           # from https://basescan.org/myapikey
+
+cd repos/tirami-contracts
+make preflight                    # fail-fast env check
+make test                         # 15/15 forge tests GREEN
+make deploy-base-sepolia          # free testnet ETH
+```
+
+Record the resulting addresses and the broadcast artifact
+(`broadcast/Deploy.s.sol/84532/run-latest.json`) as
+`docs/deployments/base-sepolia-<YYYY-MM-DD>.md` using the template
+below. The record is what lets any third party audit the
+deployment path without reading the Foundry internals.
+
+### Deployment record template
+
+```markdown
+# Base Sepolia deploy — YYYY-MM-DD
+
+**Deployer:** 0x...
+**Tx (TRM):** https://sepolia.basescan.org/tx/0x...
+**Tx (Bridge):** https://sepolia.basescan.org/tx/0x...
+
+**TRM ERC-20:** 0x...
+**TiramiBridge:** 0x...
+
+**Bytecode hash (TRM):** 0x... (from `forge inspect src/TRM.sol:TRM bytecode`)
+**Bytecode hash (Bridge):** 0x...
+
+**Source verified:** yes (BaseScan link)
+**Constructor args:** DEPLOYER_ADDRESS = 0x...
+
+**Follow-up:** owner transfer to <TEAM_OR_MULTISIG>.
+```
+
+## Mainnet deploy — gated
+
+`make deploy-base-mainnet` is wired but refuses to run unless:
+
+- `AUDIT_CLEARANCE=yes` environment variable is set (operator
+  attestation that an external audit signed off).
+- `MULTISIG_OWNER` environment variable contains the multi-sig
+  address that will receive `Ownable::owner`.
+- The operator types the phrase `i-accept-responsibility` at an
+  interactive prompt.
+
+Any operator who bypasses these gates (e.g. by patching the
+Makefile) is solely responsible for the deployment. The protocol
+maintainers explicitly decline any warranty on unaudited mainnet
+contracts — see `SECURITY.md` and `LICENSE` (MIT).
+
+## Secondary-market disclaimer
+
+TRM is **compute accounting**, not a financial product. Anyone in
+the world may — without the protocol maintainers' knowledge or
+endorsement — create a secondary market, bridge the ERC-20 to
+other chains, or speculate on its value. The maintainers:
+
+- **do not** market TRM as an investment.
+- **do not** receive, sell, or speculate on TRM on behalf of the
+  project.
+- **cannot control** third-party tokenization or resale after
+  the OSS release (MIT license explicitly permits this).
+
+If you are considering holding TRM as a store of value, you are
+making that judgement yourself. The protocol works without any
+external market — `1 TRM ↔ 10⁹ FLOP` is the definitional anchor,
+and the compute is the value. Everything else is emergent.
+
+See `SECURITY.md` ("Secondary markets & third-party tokenization")
+for the full text of the disclaimer the repo commits to.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -1,10 +1,25 @@
-# Tirami — Release Readiness (2026-04-19)
+# Tirami — Release Readiness (2026-04-19, Tier C/D enablers)
 
 A concise, honest assessment of "can we publish this now?"
-Updated after the Phase 18.5-part-3 E2E fix wave closed all
-open issues (#73–#85) and a live 2-node verification on
-`100.112.10.128` confirmed end-to-end dual-signed TRM
-negotiation for the first time via HTTP.
+Updated after Phase 19 landed the Tier C/D enablers:
+
+- Peer auto-discovery via `PriceSignal.http_endpoint` (#114).
+- `ProofPolicy` default promoted `Disabled → Optional` (#115).
+- Base Sepolia deployment Makefile + gated mainnet target (#116).
+- Secondary-market + audit-gated disclaimer in `SECURITY.md`
+  and `README.md` (#117).
+
+Follow-up known gap — filed as #88 (P2, not a blocker): worker
+`--daemon` has no gossip recv loop, so peer auto-discovery needs
+either an explicit `peer.url` hint or a full seed (which DOES
+receive + ingest gossip). Tier C shipping is fine with that
+caveat — operators can drive via explicit URLs.
+
+The 2026-04-18 live 2-node E2E on `100.112.10.128` already
+confirmed dual-signed TRM negotiation lands on the seed
+(`Signed trade recorded: 32 CU for 21 tokens…`). This wave
+adds the peer-discovery plumbing and the on-chain deployment
+infrastructure on top.
 
 ## Verdict by scale tier
 
@@ -12,8 +27,8 @@ negotiation for the first time via HTTP.
 |---|---|---|---|
 | **A — OSS public preview** | Repo public, tweet, blog, Hacker News; devs run `tirami start` locally | ✅ **READY** | MIT licensed, no real money, 1 185 passing tests, transparent SECURITY.md, placeholder PGP marked as such. |
 | **B — Invited testnet** | ≤100 node operators, TRM stays virtual (no external value), you track uptime | ✅ **READY** with caveats below | Phase 18.5-part-3 closed every blocker identified on the 2026-04-18 E2E run. |
-| **C — Open public testnet** | 1 000+ nodes, open registration, still virtual TRM | ⚠️ **NOT YET** | Needs (1) peer auto-discovery so callers don't hand-wire `peer.url`, (2) `ProofPolicy` raised to `Optional` at minimum, (3) ≥ 7-day stress test at 10+ nodes, (4) bug-bounty live with real PGP. |
-| **D — Mainnet with real value** | Base L2 TRM ERC-20, real capital | ❌ **FORBIDDEN by own plan** | Phase 17 Wave 3.3 explicitly gates this on external security audit completion. |
+| **C — Open public testnet** | 1 000+ nodes, open registration, still virtual TRM | 🟡 **Infrastructure READY, operational blockers remain** | (1) Peer auto-discovery wire shape in place (`PriceSignal.http_endpoint`, Phase 19). (2) `ProofPolicy` default promoted to `Optional` (Phase 19). Still pending: (3) ≥ 7-day stress at 10+ nodes, (4) bug bounty live with real PGP, (5) worker daemon gossip loop (see #88 — explicit `peer.url` workaround works). |
+| **D — Mainnet with real value** | Base L2 TRM ERC-20, real capital | 🟡 **Infrastructure READY, audit gate active** | Sepolia deploy Makefile + mainnet target gated on `AUDIT_CLEARANCE=yes` + `MULTISIG_OWNER` + interactive confirmation (Phase 19). Mainnet deploy still blocked on external audit. Secondary-market disclaimer landed in SECURITY.md / README / deployments/README. |
 
 ## What's ready now (Tier A + B)
 


### PR DESCRIPTION
## Summary

Build the infrastructure pieces needed to move past Tier A+B (OSS preview + invited testnet) to Tier C (open public testnet) and Tier D (mainnet — **infrastructure only; no real deploy**, per user directive "実資金はいらない"). Also adds a comprehensive secondary-market disclaimer so the project position on third-party tokenization is unambiguous.

## Commits

| Commit | Summary |
|---|---|
| `feat(tier-c-1): PriceSignal.http_endpoint` | Auto peer URL discovery. `PriceSignal` gains `Option<String>` with `#[serde(default)]`. Seed advertises its API URL (suppresses loopback / wildcard binds). `peer_http_endpoint` resolver on `ComputeLedger`. `forge_agent_task` auto-picks a peer when `size=remote` and no explicit `peer.url` is given. `/v1/tirami/peers` exposes the field. +7 tests. |
| `feat(tier-c-2): ProofPolicy default → Optional` | Default zkML policy promoted from `Disabled` to `Optional`. Constitutional ratchet semantics unchanged — governance can move UP but never back. |
| `feat(tier-c-d): worker auto-agent + Sepolia + disclaimer` | (a) `tirami worker` now auto-configures `PersonalAgent` like `tirami start`. (b) `repos/tirami-contracts/Makefile` with Sepolia + gated mainnet targets. `deploy-base-mainnet` refuses to run without `AUDIT_CLEARANCE=yes` + `MULTISIG_OWNER` + typed `i-accept-responsibility`. (c) `SECURITY.md` + `README.md` carry an explicit secondary-market / third-party-tokenization disclaimer. (d) `docs/deployments/README.md` deployment record template. |

## Verdict changes

Before this PR:
- Tier A/B — READY.
- Tier C — NOT YET (peer discovery wiring + ProofPolicy activation needed).
- Tier D — FORBIDDEN (audit-gated).

After this PR:
- Tier A/B — READY (unchanged).
- Tier C — **Infrastructure READY**, operational blockers remain (≥ 7-day stress, bug bounty live, worker daemon gossip loop per #88 — manual `peer.url` workaround works today).
- Tier D — **Infrastructure READY**, audit gate active. Deploy target refuses to run without the 3-way interlock. Secondary-market position documented.

## Tests

- \`cargo test --workspace\` — **1 192 passing, 0 failed** (↑ 7 new).
- 15/15 Foundry tests on `repos/tirami-contracts` (unchanged, verified before this PR).
- 2-node E2E on 100.112.10.128 — explicit `peer.url` round-trip confirmed (`count=1 trm=11 tokens=11`, full price, not penalised).

## Secondary-market position (as committed in SECURITY.md)

> TRM is **compute accounting**, not a financial product. The
> protocol maintainers do not sell, promote, or speculate on TRM.
> Because the code is MIT-licensed open source, anyone anywhere may
> — without the maintainers' knowledge, consent, or endorsement —
> bridge, list, trade, or derive TRM on secondary markets. If you
> choose to hold or trade TRM as a store of value, you take on all
> associated risk yourself.

## Follow-up

- #88 filed: daemon-mode worker lacks gossip recv loop. Not a Tier C blocker (explicit `peer.url` works), but needed before a clean "just run `tirami worker`" UX.
- Tier D mainnet deploy still gated on external audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)