### PR TITLE
fix(phase19): ProofPolicy::default() = Optional (sync with Config string)

### DIFF
--- a/crates/tirami-ledger/src/zk.rs
+++ b/crates/tirami-ledger/src/zk.rs
@@ -83,7 +83,13 @@ pub enum ProofPolicy {
 
 impl Default for ProofPolicy {
     fn default() -> Self {
-        Self::Disabled
+        // Phase 19 Tier C — default promoted from `Disabled` to
+        // `Optional` to match `Config::default_proof_policy()`.
+        // Optional means "proofs are accepted and rewarded when
+        // provided, but trades without proofs are still valid".
+        // Constitutional ratchet (`try_ratchet_proof_policy`)
+        // prevents downgrade; governance can only move UP from here.
+        Self::Optional
     }
 }
 
@@ -501,8 +507,12 @@ mod tests {
     // -------------------------------------------------------------
 
     #[test]
-    fn proof_policy_default_is_disabled() {
-        assert_eq!(ProofPolicy::default(), ProofPolicy::Disabled);
+    fn proof_policy_default_is_optional() {
+        // Phase 19 Tier C — the enum default must match the
+        // `Config::default_proof_policy()` string default so that
+        // consumers using `ProofPolicy::default()` and consumers
+        // reading from the config see the same value.
+        assert_eq!(ProofPolicy::default(), ProofPolicy::Optional);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

Phase 18.3 で `Config::proof_policy` の string default は `\"disabled\"` から `\"optional\"` に昇格済みだったが、`ProofPolicy::default()` (enum) は依然 `Disabled` を返していた。

この差が **documentation vs implementation の乖離** を生む。Reddit 公開前の独立 cross-check (tirami-economics の Reddit readiness audit) で発見された。

## 修正

- `ProofPolicy::default()` → `Optional` を返す。
- Constitutional ratchet (`try_ratchet_proof_policy`) は不変 — governance で UP はできるが DOWN はできない。
- unit test `proof_policy_default_is_disabled` → `proof_policy_default_is_optional` に改名 + コメントで Config 同期の意図を明示。

## 検証

- `cargo test --workspace` — **1 192 passing, 0 failed**。
- `grep -rn ProofPolicy::Disabled crates/ | grep -v tests` — tests / doc-strings 以外で Disabled を hardcode している箇所なし。

## 関連

- tirami-economics PR #50 (Reddit readiness audit) と併せて mergeされるべき。
- `docs/release-readiness.md` Tier C の ProofPolicy 状態記述と整合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)