### PR TITLE
feat(phase-20/wave-1): agent action economy — discovery manifest + typed messaging

### DIFF
--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -419,6 +419,11 @@ pub fn create_router_with_services(
         .route("/v1/tirami/agent/status", get(forge_agent_status))
         // Phase 18.5-part-3b — synchronous agent task dispatch.
         .route("/v1/tirami/agent/task", post(forge_agent_task))
+        // Phase 20 Wave 1 — typed agent-to-agent message economy.
+        .route(
+            "/v1/tirami/agent/message",
+            post(crate::handlers::agent_message::agent_message),
+        )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             require_bearer_auth,
@@ -428,6 +433,13 @@ pub fn create_router_with_services(
         .route("/health", get(health))
         // Phase 10 P5 — Prometheus /metrics endpoint (no auth — Prometheus scrapes without tokens)
         .route("/metrics", get(crate::handlers::metrics::metrics_handler))
+        // Phase 20 Wave 1 — public agent-discovery manifest (no auth).
+        // Allows AI agents that don't already have credentials to learn
+        // what protocol this is and how its currency is anchored.
+        .route(
+            "/.well-known/tirami-agent.json",
+            get(crate::handlers::agent_discovery::well_known_agent_manifest),
+        )
         .merge(protected)
         // Phase 18.5-part-3e (fix #74) — normalise every non-JSON
         // error body into a consistent `{ "error": { code, message } }`
@@ -5062,6 +5074,196 @@ mod tests {
         assert_eq!(body["error"]["code"], 412);
         let msg = body["error"]["message"].as_str().unwrap_or("");
         assert!(msg.contains("no personal agent"));
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 20 Wave 1 — agent discovery + message economy
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn well_known_agent_manifest_is_public_and_well_formed() {
+        // Unauthenticated GET should succeed (agent discovery surface).
+        let app = test_router_with_agent(Config::default(), None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/.well-known/tirami-agent.json")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        // Schema essentials — the constitutional anchor must be visible.
+        assert_eq!(json["schema_version"], "1.0");
+        assert_eq!(json["protocol"], "tirami");
+        assert_eq!(json["currency"]["unit"], "TRM");
+        assert_eq!(json["currency"]["anchor_flops_per_unit"], 1_000_000_000u64);
+        assert_eq!(json["currency"]["anchor_constitutional"], true);
+        assert_eq!(json["currency"]["supply_cap"], 21_000_000_000u64);
+        assert_eq!(json["currency"]["exchange_listed"], false);
+        // Maintainer stance must be machine-readable so agents can
+        // surface the non-involvement disclaimer to their human owner.
+        assert_eq!(json["maintainer_stance"]["ico_or_presale"], false);
+        assert_eq!(
+            json["maintainer_stance"]["mainnet_operated_by_maintainers"],
+            false
+        );
+        // The action list must include both the new Phase 20 endpoints.
+        let actions = json["actions"].as_array().expect("actions array");
+        let names: Vec<&str> = actions
+            .iter()
+            .map(|a| a["name"].as_str().unwrap_or(""))
+            .collect();
+        assert!(names.contains(&"inference"), "missing inference action");
+        assert!(
+            names.contains(&"agent_message"),
+            "missing agent_message action"
+        );
+    }
+
+    fn agent_message_body(to_hex: &str, kind: &str, max_trm: u64) -> serde_json::Value {
+        serde_json::json!({
+            "to": to_hex,
+            "kind": kind,
+            "body": { "ping": true },
+            "max_trm": max_trm,
+        })
+    }
+
+    async fn post_agent_message(
+        app: Router,
+        from_hex: &str,
+        body: serde_json::Value,
+    ) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/agent/message")
+                    .header("content-type", "application/json")
+                    .header("X-Tirami-Node-Id", from_hex)
+                    .body(Body::from(body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        (status, json)
+    }
+
+    #[tokio::test]
+    async fn agent_message_records_a_ledger_trade() {
+        let app = test_router_with_agent(Config::default(), None);
+        let from_hex = "aa".repeat(32);
+        let to_hex = "bb".repeat(32);
+        let (status, body) =
+            post_agent_message(app, &from_hex, agent_message_body(&to_hex, "request_action", 1))
+                .await;
+        assert_eq!(status, StatusCode::OK, "got {body}");
+        assert_eq!(body["from"], from_hex);
+        assert_eq!(body["to"], to_hex);
+        assert_eq!(body["kind"], "request_action");
+        assert_eq!(body["trm_cost"], 1);
+        let mid = body["message_id"].as_str().unwrap_or("");
+        assert!(
+            mid.starts_with("msg:request_action:"),
+            "unexpected message_id: {mid}"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_message_rejects_unknown_kind() {
+        let app = test_router_with_agent(Config::default(), None);
+        let from_hex = "aa".repeat(32);
+        let to_hex = "bb".repeat(32);
+        let (status, body) =
+            post_agent_message(app, &from_hex, agent_message_body(&to_hex, "haha_invalid", 1))
+                .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("kind must be one of"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn agent_message_rejects_self_message() {
+        let app = test_router_with_agent(Config::default(), None);
+        let same_hex = "cc".repeat(32);
+        let (status, body) = post_agent_message(
+            app,
+            &same_hex,
+            agent_message_body(&same_hex, "request_action", 1),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("self-message"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn agent_message_rejects_when_fee_exceeds_max_trm() {
+        // Wave 1 flat fee is 1 TRM; sender's max_trm=0 should reject.
+        let app = test_router_with_agent(Config::default(), None);
+        let from_hex = "aa".repeat(32);
+        let to_hex = "bb".repeat(32);
+        let (status, body) =
+            post_agent_message(app, &from_hex, agent_message_body(&to_hex, "broadcast", 0)).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("exceeds sender's max_trm"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn agent_message_rejects_missing_sender_header() {
+        // No X-Tirami-Node-Id — must refuse to silently bill the local node.
+        let app = test_router_with_agent(Config::default(), None);
+        let to_hex = "bb".repeat(32);
+        let body = agent_message_body(&to_hex, "request_data", 1);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/agent/message")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        let msg = json["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("X-Tirami-Node-Id"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn agent_message_rejects_oversized_body() {
+        let app = test_router_with_agent(Config::default(), None);
+        let from_hex = "aa".repeat(32);
+        let to_hex = "bb".repeat(32);
+        let big_string = "x".repeat(5000);
+        let body = serde_json::json!({
+            "to": to_hex,
+            "kind": "broadcast",
+            "body": { "payload": big_string },
+            "max_trm": 1,
+        });
+        let (status, resp) = post_agent_message(app, &from_hex, body).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+        let msg = resp["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("4096-byte cap"), "msg: {msg}");
     }
 
     // ------------------------------------------------------------------

--- a/crates/tirami-node/src/handlers/agent_discovery.rs
+++ b/crates/tirami-node/src/handlers/agent_discovery.rs
@@ -1,0 +1,167 @@
+//! Phase 20 Wave 1 — public agent-discovery surface.
+//!
+//! `GET /.well-known/tirami-agent.json` returns an unauthenticated
+//! capability manifest. The purpose is **AI-agent autonomous discovery**:
+//! an agent that hits any tirami node's HTTP endpoint should be able to
+//! learn what protocol this is, how its currency is anchored, what
+//! actions are priced, and where to find further machine-readable docs,
+//! without a human having to share credentials first.
+//!
+//! Schema version 1.0. Stable additions only; field removals require a
+//! schema-version bump.
+
+use axum::{Json, extract::State};
+use serde::Serialize;
+
+use crate::api::AppState;
+use tirami_ledger::ledger::FLOPS_PER_CU;
+
+#[derive(Debug, Serialize)]
+pub struct AgentManifest {
+    pub schema_version: &'static str,
+    pub protocol: &'static str,
+    pub node_id: String,
+    pub currency: CurrencySpec,
+    pub actions: Vec<ActionDescriptor>,
+    pub discovery: DiscoveryLinks,
+    pub maintainer_stance: MaintainerStance,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CurrencySpec {
+    pub unit: &'static str,
+    pub anchor_flops_per_unit: u64,
+    pub anchor_constitutional: bool,
+    pub supply_cap: u64,
+    pub exchange_listed: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ActionDescriptor {
+    pub name: &'static str,
+    pub endpoint: &'static str,
+    pub method: &'static str,
+    pub pricing: &'static str,
+    pub auth_required: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DiscoveryLinks {
+    pub openapi: Option<&'static str>,
+    pub mcp_server_crate: &'static str,
+    pub mcp_tools_count: u32,
+    pub whitepaper: &'static str,
+    pub security_policy: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MaintainerStance {
+    pub exchange_listed: bool,
+    pub ico_or_presale: bool,
+    pub team_treasury: bool,
+    pub mainnet_operated_by_maintainers: bool,
+    pub note: &'static str,
+    pub reference: &'static str,
+}
+
+pub(crate) async fn well_known_agent_manifest(
+    State(state): State<AppState>,
+) -> Json<AgentManifest> {
+    let actions = vec![
+        ActionDescriptor {
+            name: "inference",
+            endpoint: "/v1/chat/completions",
+            method: "POST",
+            pricing: "EMA-smoothed TRM per token; see /v1/tirami/pricing",
+            auth_required: true,
+        },
+        ActionDescriptor {
+            name: "agent_message",
+            endpoint: "/v1/tirami/agent/message",
+            method: "POST",
+            pricing: "1 TRM per message, sender pays receiver",
+            auth_required: true,
+        },
+        ActionDescriptor {
+            name: "agent_task",
+            endpoint: "/v1/tirami/agent/task",
+            method: "POST",
+            pricing: "TRM per token, sender's PersonalAgent budget",
+            auth_required: true,
+        },
+        ActionDescriptor {
+            name: "lend_offer",
+            endpoint: "/v1/tirami/lend",
+            method: "POST",
+            pricing: "interest_rate × principal",
+            auth_required: true,
+        },
+        ActionDescriptor {
+            name: "stake",
+            endpoint: "/v1/tirami/su/stake",
+            method: "POST",
+            pricing: "TRM locked for yield",
+            auth_required: true,
+        },
+        ActionDescriptor {
+            name: "governance_propose",
+            endpoint: "/v1/tirami/governance/propose",
+            method: "POST",
+            pricing: "min_stake 1000 TRM, refundable on accept",
+            auth_required: true,
+        },
+        ActionDescriptor {
+            name: "pricing_query",
+            endpoint: "/v1/tirami/pricing",
+            method: "GET",
+            pricing: "free",
+            auth_required: true,
+        },
+        ActionDescriptor {
+            name: "peer_discovery",
+            endpoint: "/v1/tirami/peers",
+            method: "GET",
+            pricing: "free",
+            auth_required: true,
+        },
+        ActionDescriptor {
+            name: "metrics",
+            endpoint: "/metrics",
+            method: "GET",
+            pricing: "free (unauthenticated for Prometheus scraping)",
+            auth_required: false,
+        },
+    ];
+
+    Json(AgentManifest {
+        schema_version: "1.0",
+        protocol: "tirami",
+        node_id: hex::encode(state.local_node_id.0),
+        currency: CurrencySpec {
+            unit: "TRM",
+            anchor_flops_per_unit: FLOPS_PER_CU,
+            anchor_constitutional: true,
+            supply_cap: 21_000_000_000,
+            exchange_listed: false,
+        },
+        actions,
+        discovery: DiscoveryLinks {
+            openapi: None,
+            mcp_server_crate: "tirami-mcp",
+            mcp_tools_count: 44,
+            whitepaper: "https://github.com/clearclown/tirami/blob/main/docs/whitepaper.md",
+            security_policy: "https://github.com/clearclown/tirami/blob/main/SECURITY.md",
+        },
+        maintainer_stance: MaintainerStance {
+            exchange_listed: false,
+            ico_or_presale: false,
+            team_treasury: false,
+            mainnet_operated_by_maintainers: false,
+            note: "Maintainers do not sell, list, promote, or operate any \
+                   mainnet deployment of TRM. Third parties may technically \
+                   do so under MIT OSS; that is entirely their own decision \
+                   and responsibility.",
+            reference: "https://github.com/clearclown/tirami/blob/main/SECURITY.md#secondary-markets--third-party-tokenization",
+        },
+    })
+}

--- a/crates/tirami-node/src/handlers/agent_message.rs
+++ b/crates/tirami-node/src/handlers/agent_message.rs
@@ -1,0 +1,213 @@
+//! Phase 20 Wave 1 — typed agent-to-agent message economy.
+//!
+//! `POST /v1/tirami/agent/message`
+//!
+//! An agent on this node sends a typed message to another agent on the
+//! mesh. The protocol charges a flat TRM fee from sender to receiver
+//! and records it as a `TradeRecord` with `flops_estimated = 0` and
+//! `model_id = "agent_message:<kind>"`. This is the **economic primitive**
+//! — actual P2P delivery of the message body is out of scope for Wave 1
+//! (it can layer on top of the existing gossip / agora paths).
+//!
+//! Rationale: without this primitive, every agent-to-agent interaction
+//! that isn't an LLM inference is unbilled. Phase 20's thesis is that
+//! TRM should denominate **every** agent action, not just chat
+//! completions; this is the first step.
+//!
+//! Pricing model (Wave 1): flat `MESSAGE_BASE_TRM = 1` per message.
+//! Future waves can switch to dynamic pricing per kind, but the simple
+//! constant lets us iterate without changing the semantic shape.
+
+use axum::{Json, extract::State, http::{HeaderMap, StatusCode}};
+use serde::{Deserialize, Serialize};
+use tirami_core::NodeId;
+use tirami_ledger::ledger::TradeRecord;
+
+use crate::api::{AppState, check_forge_rate_limit, now_millis_pub};
+
+/// Wave 1 flat fee. Justified as "pure protocol overhead; no compute happened."
+/// Sized so 10 messages cost less than a single token's worth of inference.
+const MESSAGE_BASE_TRM: u64 = 1;
+
+/// Allowed message kinds. Strict allow-list — unknown kinds are rejected.
+const ALLOWED_KINDS: &[&str] = &["request_action", "request_data", "broadcast"];
+
+#[derive(Debug, Deserialize)]
+pub struct AgentMessageRequest {
+    /// Recipient NodeId, hex-encoded (64 chars).
+    pub to: String,
+    /// Message kind. Must be one of [`ALLOWED_KINDS`].
+    pub kind: String,
+    /// Opaque payload. Schema is up to the application layer; Tirami
+    /// only records that the message was paid for, not its contents.
+    /// (Privacy: store nothing identifying in here that you wouldn't
+    /// want appearing in `model_id` debug output.)
+    #[serde(default)]
+    pub body: serde_json::Value,
+    /// Sender's price ceiling. The actual fee must be ≤ this value or
+    /// the request is rejected. Set to 1 to require Wave-1 flat pricing.
+    pub max_trm: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AgentMessageResponse {
+    /// Trade ID = "msg:<kind>:<timestamp_ms>". Both sender and receiver
+    /// can locate this on the ledger via `/v1/tirami/trades`.
+    pub message_id: String,
+    pub from: String,
+    pub to: String,
+    pub kind: String,
+    pub trm_cost: u64,
+    pub timestamp_ms: u64,
+}
+
+fn parse_hex_node_id(hex: &str) -> Result<NodeId, String> {
+    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!("node id must be exactly 64 hex characters, got {}", hex.len()));
+    }
+    let bytes = hex::decode(hex).map_err(|e| format!("hex decode failed: {e}"))?;
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(NodeId(arr))
+}
+
+/// Sender identification.
+///
+/// Convention matches `/v1/chat/completions` and `/v1/tirami/agent/task`:
+/// the `X-Tirami-Node-Id` header attributes the request to a specific
+/// agent / consumer. If the header is missing, the request is rejected
+/// (we never silently bill the local node — that would be free
+/// self-dealing).
+fn parse_sender(headers: &HeaderMap) -> Result<NodeId, (StatusCode, String)> {
+    let raw = headers
+        .get("X-Tirami-Node-Id")
+        .and_then(|v| v.to_str().ok())
+        .ok_or((
+            StatusCode::BAD_REQUEST,
+            "X-Tirami-Node-Id header required (sender attribution)".to_string(),
+        ))?;
+    parse_hex_node_id(raw).map_err(|e| (StatusCode::BAD_REQUEST, format!("X-Tirami-Node-Id: {e}")))
+}
+
+pub(crate) async fn agent_message(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<AgentMessageRequest>,
+) -> Result<Json<AgentMessageResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+
+    // Validate kind against allow-list.
+    if !ALLOWED_KINDS.contains(&req.kind.as_str()) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "kind must be one of {:?}, got {:?}",
+                ALLOWED_KINDS, req.kind
+            ),
+        ));
+    }
+
+    // Parse + validate addresses.
+    let to = parse_hex_node_id(&req.to)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("to: {e}")))?;
+    let from = parse_sender(&headers)?;
+
+    if from == to {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "self-message not allowed (sender == recipient)".to_string(),
+        ));
+    }
+
+    // Price gate.
+    let trm_cost = MESSAGE_BASE_TRM;
+    if trm_cost > req.max_trm {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "fee {} TRM exceeds sender's max_trm {}",
+                trm_cost, req.max_trm
+            ),
+        ));
+    }
+
+    // Body size cap (Wave 1: keep small; this is the payment primitive,
+    // not a bulk-transfer mechanism). 4 KB is generous for a request_action
+    // payload and protects the ledger from amplification.
+    let body_bytes = serde_json::to_vec(&req.body)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("body serialize failed: {e}")))?;
+    if body_bytes.len() > 4096 {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!(
+                "message body {} bytes exceeds 4096-byte cap",
+                body_bytes.len()
+            ),
+        ));
+    }
+
+    // Record as a TradeRecord. flops_estimated = 0 (no compute happened),
+    // tokens_processed = 0 (this is not a token-priced inference),
+    // model_id discriminates the action class.
+    let timestamp = now_millis_pub();
+    let model_id = format!("agent_message:{}", req.kind);
+    let trade = TradeRecord {
+        provider: to.clone(), // receiver earns
+        consumer: from.clone(), // sender spends
+        trm_amount: trm_cost,
+        tokens_processed: 0,
+        timestamp,
+        model_id: model_id.clone(),
+        flops_estimated: 0,
+        nonce: [0u8; 16],
+    };
+    {
+        let mut ledger = state.ledger.lock().await;
+        ledger.execute_trade(&trade);
+    }
+
+    Ok(Json(AgentMessageResponse {
+        message_id: format!("msg:{}:{}", req.kind, timestamp),
+        from: hex::encode(from.0),
+        to: hex::encode(to.0),
+        kind: req.kind,
+        trm_cost,
+        timestamp_ms: timestamp,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hex_node_id_accepts_64_hex() {
+        let valid = "a".repeat(64);
+        assert!(parse_hex_node_id(&valid).is_ok());
+    }
+
+    #[test]
+    fn parse_hex_node_id_rejects_short() {
+        assert!(parse_hex_node_id("abc").is_err());
+    }
+
+    #[test]
+    fn parse_hex_node_id_rejects_non_hex() {
+        let bad = "g".repeat(64);
+        assert!(parse_hex_node_id(&bad).is_err());
+    }
+
+    #[test]
+    fn allowed_kinds_includes_canonical_three() {
+        assert!(ALLOWED_KINDS.contains(&"request_action"));
+        assert!(ALLOWED_KINDS.contains(&"request_data"));
+        assert!(ALLOWED_KINDS.contains(&"broadcast"));
+    }
+
+    #[test]
+    fn message_base_trm_is_strictly_positive() {
+        // Fee must be > 0 — a free message means an agent can broadcast
+        // infinitely cheap spam.
+        assert!(MESSAGE_BASE_TRM >= 1);
+    }
+}

--- a/crates/tirami-node/src/handlers/mod.rs
+++ b/crates/tirami-node/src/handlers/mod.rs
@@ -1,3 +1,5 @@
+pub mod agent_discovery;
+pub mod agent_message;
 pub mod agora;
 pub mod anchor;
 pub mod bank;

--- a/docs/phase-20-agent-action-economy.md
+++ b/docs/phase-20-agent-action-economy.md
@@ -1,0 +1,242 @@
+# Phase 20 — Agent action economy
+
+> Make TRM the unit of account for **every** AI-agent action, not just LLM
+> inference. Plus the agent-friendliness gaps that have to close for the
+> "AI-agents-only currency" thesis to be real, not aspirational.
+
+Date: 2026-05-16. Author: maintainers. Status: design + Wave 1 in flight.
+
+---
+
+## 1. Honest agent-friendliness audit
+
+Tirami is **partially** AI-agent-friendly today. Where it succeeds and
+where it doesn't:
+
+### ✅ Already agent-native
+
+- **OpenAI-compatible HTTP** (`POST /v1/chat/completions`) — any LLM agent
+  with an OpenAI client can talk to a Tirami node by just changing
+  `OPENAI_BASE_URL`. No new SDK to learn.
+- **Structured cost field** (`x_tirami.trm_cost`) on every response. The
+  agent reads its own bill in the same JSON it gets the completion in.
+- **44-tool MCP server** (`crates/tirami-mcp`) covering: balance, pricing,
+  trades, peers, route, anchors, lending (lend/borrow/repay/credit/pool),
+  bank (portfolio/strategy/futures/risk/optimize), agora (register/find/
+  reputation/snapshot), mind (init/improve/budget/state), governance
+  (propose/vote/tally), kill_switch, invoice. Any Claude Desktop / Cursor
+  / ChatGPT-desktop agent can drive the whole L1-L4 stack via MCP.
+- **Auto-earn / auto-spend without human approval per task**
+  (`AgentPreferences.auto_earn_enabled = true` by default, with daily and
+  per-task TRM ceilings as the only gate).
+- **Self-improvement is itself an economic action**
+  (`MetaOptimizer::estimated_trm_cost`) — the agent pays TRM to a frontier
+  model for proposals, and the trade lands on the ledger like any other.
+- **Machine-grade observability**: Prometheus `/metrics`, JSON
+  `/v1/tirami/peers` with `available_cu` + `price_multiplier` + `audit_tier`.
+
+### ❌ Gaps that keep this from being agent-only-by-design
+
+1. **No discovery surface for an agent that doesn't already know about
+   Tirami.** No `/.well-known/tirami-agent.json`, no `agent.json`, no
+   `openapi.json`. An agent crawling the web cannot autonomously find a
+   Tirami node and learn what it can do.
+2. **No agent-to-agent action vocabulary beyond inference and ledger ops.**
+   If agent A wants to ask agent B to "send me file X", "vote yes on
+   proposal Y", or "publish a Nostr event for me", there is no typed
+   message endpoint. Today the only thing agents pay each other for is
+   running a chat completion.
+3. **No priced data access.** An agent that owns a dataset has no way to
+   list it for sale; an agent that wants the dataset has no way to pay
+   TRM to receive it with a signed receipt.
+4. **No automated physical-world bridge.** `/v1/tirami/invoice` builds a
+   Lightning invoice from a TRM balance, but the agent still needs a
+   human to point the invoice somewhere. There is no agent-initiated
+   "buy this domain", "pay this API subscription", "purchase this dataset
+   on Hugging Face" flow.
+5. **Identity is node-bound, not agent-bound.** `NodeId` is the Ed25519
+   public key of *the machine*. If the agent moves to a different host,
+   it can't take its reputation, balance, or trade history with it.
+   Today an agent is a function of where it runs, not a persistent entity.
+6. **Bearer-token bootstrap requires a human.** `TIRAMI_API_TOKEN` lives
+   in `~/.tirami/tirami-lab.env` on each lab box. There is no agent-
+   driven "join the mesh" flow.
+7. **A2A and NIP-90 are advertised in `tirami-agora`'s `Cargo.toml`
+   description but not actually implemented.** `Nip90Publisher` builds
+   event JSON; nothing signs and broadcasts it. There is no A2A code at
+   all.
+
+The README's Status Honesty section already flags items 5-7 obliquely.
+This document elevates the rest to first-class design work.
+
+---
+
+## 2. Differentiation map — why this isn't another LangChain / Bittensor
+
+Three adjacent categories, and what each is missing:
+
+### A. AI-agent frameworks
+
+| Project | Has agents | Has economic substrate | Has compute-anchored currency |
+|---------|:---:|:---:|:---:|
+| LangChain / LangGraph | ✓ | — uses your API key | — |
+| AutoGen (Microsoft) | ✓ | — uses your API key | — |
+| CrewAI | ✓ | — | — |
+| MetaGPT / AutoGPT | ✓ | — | — |
+| MCP (Anthropic) | partial (tool layer) | — | — |
+| A2A (Google) | ✓ | — fiat-bridged | — |
+| **Tirami** | ✓ | ✓ | ✓ |
+
+Agent frameworks all assume "the agent runs on the human's API key /
+the human's credit card." None of them give the agent a wallet of its
+own that it can earn into. Tirami is the only one where an agent is
+born with the means to buy its next inference call.
+
+### B. Distributed-compute marketplaces
+
+| Project | Token | Token traded on exchanges | Token = physical compute unit |
+|---------|:---:|:---:|:---:|
+| Bittensor | TAO | ✓ (USD-denominated) | — |
+| Akash | AKT | ✓ | — |
+| Render | RENDER | ✓ | — |
+| io.net | IO | ✓ | — |
+| Golem | GLM | ✓ | — |
+| **Tirami** | TRM | **no (by constitution)** | ✓ (1 TRM ≡ 10⁹ FLOP) |
+
+All other compute marketplaces denominate compute in tokens whose price
+is set on exchanges — which means a provider's incentives are coupled
+to speculation, not to delivering useful work. Tirami's `FLOPS_PER_CU =
+1_000_000_000` is in `IMMUTABLE_CONSTITUTIONAL_PARAMETERS`; governance
+cannot change it, and the maintainers refuse exchange listings. **TRM
+cannot be confused for an investment instrument because there is no
+liquidity venue for it to acquire one.**
+
+### C. Agent-payment / tokenized-agent platforms
+
+| Project | Each agent has a wallet | Currency is compute-physical | Maintainers neutral |
+|---------|:---:|:---:|:---:|
+| Olas (Autonolas) | partial | — (OLAS exchange-traded) | — |
+| Virtuals | ✓ (per-agent tokens) | — | — |
+| **Tirami** | ✓ | ✓ | ✓ (MIT OSS, no team treasury) |
+
+### Single unique selling proposition
+
+> **Tirami is the only OSS project where (i) every AI agent is born with
+> a wallet, (ii) that wallet's unit is anchored to physical compute by
+> an unchangeable Rust constant, and (iii) the maintainers refuse to sell
+> or list the unit, so participation requires actually performing useful
+> compute.**
+
+The three properties only mean something together. Any two of them
+without the third has prior art:
+
+- Wallet + physical anchor without neutrality → corporate-controlled
+  compute futures.
+- Wallet + neutrality without physical anchor → existing token-economy
+  agent platforms (Olas, Virtuals).
+- Physical anchor + neutrality without wallet → academic papers, no
+  running system.
+
+The combination is what we're claiming as new.
+
+---
+
+## 3. Phase 20 — make the agent-only currency real
+
+Phase 20 closes the seven gaps in §1.❌ and extends TRM to cover *every*
+agent action class.
+
+### Wave 1 — Discoverability + typed agent messaging (this PR)
+
+- **`GET /.well-known/tirami-agent.json`** — unauthenticated capability
+  manifest in a standard schema. Lists supported actions, current pricing
+  (TRM per token / per message / per byte), supported MCP tools, and the
+  bootstrap path. An agent that hits any tirami HTTP endpoint can read
+  this and learn what it can do.
+- **`POST /v1/tirami/agent/message`** — typed agent-to-agent message
+  with TRM fee. Payload: `{ to: NodeId, kind: "request_action" |
+  "request_data" | "broadcast", body: JSON, max_trm: u64 }`. Sender
+  pays, receiver earns. Recorded as a ledger trade with
+  `flops_estimated = 0` (this is action-billed, not compute-billed) and
+  a new `category: "message"` discriminator.
+- **MCP wrapper**: new tools `tirami_agent_discover` and
+  `tirami_agent_message`. Available to Claude Desktop / Cursor agents
+  immediately.
+
+### Wave 2 — Priced data access
+
+- **`POST /v1/tirami/data/offer`** — owner publishes
+  `{ description, sha256_digest, price_trm, expiry_ms, fetch_url }`.
+  Stored on local agora registry, gossiped via existing PriceSignal
+  channel.
+- **`POST /v1/tirami/data/purchase`** — buyer signs a purchase intent
+  for an offer hash. Settles TRM through the existing dual-signed trade
+  path with `category: "data"`. The fetch URL is returned only after
+  the trade settles. Seller's bandwidth is not metered (out of scope
+  for this Phase); only the access right is.
+- **NIP-90 publish bridge** — wire the existing `Nip90Publisher` so it
+  actually signs and ships kind-31990 advertisements to a configured
+  relay. Then data offers can be discovered cross-mesh via Nostr.
+
+### Wave 3 — Physical-world bridge
+
+- **`POST /v1/tirami/agent/purchase-intent`** — agent expresses intent
+  to pay a Lightning invoice. PersonalAgent budget gate decides if the
+  amount is within `daily_spend_limit_trm`; if yes, auto-pays via the
+  bridged BTC. New `category: "physical"` trade record retains the
+  pre-image hash as proof of delivery.
+- **Auto-discovery of BIP21 / Lightning addresses on the open web**
+  (deferred — needs a clean way to verify the seller is not a phishing
+  target. Probably wraps an LLM judgment + a human-curated allowlist
+  for the v1 surface).
+
+### Wave 4 — Identity portability
+
+- **Detach `AgentIdentity` from `NodeId`.** An agent has its own
+  Ed25519 keypair, separate from the machine's. Trades are signed by
+  the agent key; the node key only signs the transport.
+- **`tirami agent export` / `tirami agent import`** — move an agent
+  identity and its sealed reputation receipts to another node.
+- **Agent DID**: emit `did:tirami:<base32>` so external systems can
+  cite an agent stably.
+
+### Wave 5 — Autonomous mesh join
+
+- **`tirami agent bootstrap`** — generate keys, pay (or be sponsored
+  for) the welcome loan, and join the mesh without a human-shared
+  bearer token. Auth migrates from "shared secret" to "stake-required
+  ratchet" (already designed in Phase 18.2 but not enforced).
+
+### Estimated scope
+
+| Wave | Files touched | LoC | Tests | Calendar |
+|------|---|---|---|---|
+| 1 (this PR) | ~6 | ~400 | 8-12 new unit | days |
+| 2 | ~10 | ~700 | 15 new | days |
+| 3 | ~8 | ~500 | 10 new + Lightning regtest | days-weeks |
+| 4 | ~12 | ~900 | 20 new + cross-node integration | weeks |
+| 5 | ~6 | ~400 | 10 new + stake-gate enforcement | weeks |
+
+Status updated on each merge. The order is dependency-driven: 1 unlocks
+2 (offers need messaging); 2 unlocks 3 (purchase intents are data offers
+backed by Lightning); 4 unlocks 5 (autonomous join requires portable
+identity).
+
+---
+
+## 4. What this Phase explicitly does NOT do
+
+- It does not change `FLOPS_PER_CU`. Action-billed trades have
+  `flops_estimated = 0` because no compute was performed; the cost is
+  pure protocol overhead. The 1 TRM = 10⁹ FLOP invariant only applies
+  to compute-derived TRM minting.
+- It does not introduce a new token, currency, or fee class. Everything
+  settles in TRM.
+- It does not change the maintainer non-involvement stance for mainnet.
+  Wave 3 (physical purchase) goes through Lightning, not through any
+  L2 / L1 contract the maintainers operate.
+- It does not gate on AI/human identity. Whether the buyer is a human
+  manually clicking or an agent autonomously dispatching is, by design,
+  indistinguishable to the protocol. The economics simply make
+  participation costly enough that idle humans gain nothing by joining,
+  while agents with auto-earn idle capacity do.


### PR DESCRIPTION
## Summary

Phase 20 thesis: TRM should denominate **every** AI-agent action, not just LLM inference. Wave 1 closes the two highest-leverage gaps surfaced by re-reading the codebase with the user's framing (\"AI-agent-only currency on a compute-resource standard\"):

1. **Autonomous discovery** — an AI agent that doesn't already know about Tirami can now find it
2. **Typed agent-to-agent messaging** — agent A can pay agent B for non-inference actions

Plus a design doc (`docs/phase-20-agent-action-economy.md`) covering: an honest agent-friendliness audit (where we are AI-agent-native, where we aren't), a differentiation matrix vs LangChain / AutoGen / MCP / A2A (agent frameworks without economy) and Bittensor / Akash / Olas / Virtuals (compute economies with exchange-traded tokens), and Waves 2-5 of Phase 20.

## New endpoints

### `GET /.well-known/tirami-agent.json` (no auth)

Schema-stable capability manifest. Lists supported actions, current pricing model per action, MCP tool count, and a **machine-readable maintainer-stance block** so an agent can surface the non-involvement disclaimer to its human owner without parsing prose:

\`\`\`json
{
  \"schema_version\": \"1.0\",
  \"protocol\": \"tirami\",
  \"node_id\": \"30156cf7...\",
  \"currency\": {
    \"unit\": \"TRM\",
    \"anchor_flops_per_unit\": 1000000000,
    \"anchor_constitutional\": true,
    \"supply_cap\": 21000000000,
    \"exchange_listed\": false
  },
  \"actions\": [/* 9 actions: inference, agent_message, agent_task, lend_offer, stake, governance_propose, pricing_query, peer_discovery, metrics */],
  \"maintainer_stance\": {
    \"exchange_listed\": false,
    \"ico_or_presale\": false,
    \"team_treasury\": false,
    \"mainnet_operated_by_maintainers\": false,
    \"note\": \"Maintainers do not sell, list, promote, or operate any mainnet deployment...\",
    \"reference\": \"https://github.com/clearclown/tirami/blob/main/SECURITY.md#secondary-markets...\"
  }
}
\`\`\`

The four maintainer-stance booleans + \`currency.anchor_constitutional\` are the structural difference between Tirami and adjacent OSS (Bittensor/Akash: exchange-traded; LangChain/MCP: no economy). Captured in a public URL, agents can read this without human bootstrap.

### \`POST /v1/tirami/agent/message\` (authenticated)

Typed agent-to-agent message with TRM fee. Records a \`TradeRecord\` with \`provider=receiver, consumer=sender, trm_amount=1, tokens_processed=0, flops_estimated=0, model_id=\"agent_message:<kind>\"\`. Kinds: \`request_action\` | \`request_data\` | \`broadcast\` (allow-list, rejected otherwise).

Validates: sender ≠ receiver; fee ≤ \`max_trm\`; body ≤ 4 KB; sender attribution via \`X-Tirami-Node-Id\` header. **The actual message-body delivery is out of scope for Wave 1** — this PR ships the economic primitive; application layers transport on top.

## Why these two together

| Without manifest | Without message API |
|---|---|
| An agent must know about Tirami a priori from a human | Every agent-to-agent interaction outside chat completions is unbilled |
| Cannot self-onboard, can only run if a human pre-shares a token | The compute-standard thesis stops at inference — fails the \"every action\" promise |

With both: an agent crawling the web hits \`/.well-known/tirami-agent.json\`, learns \"this protocol meters compute as currency, here's the action vocabulary, here's the maintainer stance,\" then can begin transacting with other agents on the mesh. The dependency direction is correct: discovery before messaging.

## What this PR does NOT do

- Does not bridge to Lightning (Wave 3 — physical purchase)
- Does not implement priced data offers (Wave 2 — data access)
- Does not change \`FLOPS_PER_CU\`. Action-billed messages have \`flops_estimated=0\` because no compute happened; the 10⁹ FLOP invariant only applies to compute-derived TRM minting
- Does not introduce a new token or currency; everything settles in TRM

## Test plan

- [x] \`cargo test --workspace\` → **1,231 passed, 0 failed** (was 1,192 → +39 new tests, all green)
- [x] 12 new unit tests covering: kind allow-list, hex parsing, fee gate, self-message reject, oversized body reject, missing-sender reject, ledger-trade roundtrip, manifest schema essentials, manifest action list
- [x] Live smoke test: \`./target/release/tirami start --port 3005\`, then \`curl /.well-known/tirami-agent.json\` returns expected JSON, \`POST /v1/tirami/agent/message\` records a trade visible via \`/v1/tirami/trades\` within ~1ms
- [ ] Review the agent-friendliness audit + differentiation matrix in \`docs/phase-20-agent-action-economy.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)