### PR TITLE
feat(phase-20/wave-5): DID-auth challenge/verify (autonomous mesh join)

### DIFF
--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -88,6 +88,9 @@ pub(crate) struct AppState {
     /// `POST /v1/tirami/agent/identity/init` or `/import` is called.
     /// In-memory only; persistence is a follow-up.
     pub agent_identity: crate::handlers::agent_identity::AgentIdentityState,
+    /// Phase 20 Wave 5 — pending DID-auth challenges. Each entry is
+    /// single-use and short-lived (5 min default).
+    pub auth_challenges: crate::handlers::auth_did::ChallengeState,
 }
 
 /// Simple rate limiter for authentication failures.
@@ -247,6 +250,9 @@ pub fn create_router_with_services(
             crate::handlers::purchase_intent::PurchaseIntentRegistry::new(),
         )),
         agent_identity: Arc::new(Mutex::new(None)),
+        auth_challenges: Arc::new(Mutex::new(
+            crate::handlers::auth_did::ChallengeStore::new(),
+        )),
     };
     let api_max_request_body_bytes = state.config.api_max_request_body_bytes;
 
@@ -501,6 +507,18 @@ pub fn create_router_with_services(
         .route(
             "/.well-known/tirami-agent.json",
             get(crate::handlers::agent_discovery::well_known_agent_manifest),
+        )
+        // Phase 20 Wave 5 — DID-auth challenge/verify. Both endpoints
+        // are public (no bearer required) because the whole point is
+        // that an autonomous agent can sign in without a pre-shared
+        // human token.
+        .route(
+            "/v1/tirami/auth/challenge",
+            get(crate::handlers::auth_did::issue_challenge),
+        )
+        .route(
+            "/v1/tirami/auth/verify",
+            post(crate::handlers::auth_did::verify_did_signature),
         )
         .merge(protected)
         // Phase 18.5-part-3e (fix #74) — normalise every non-JSON
@@ -6116,6 +6134,321 @@ mod tests {
             assert!(
                 names.iter().any(|n| n == expected),
                 "manifest missing {expected}, actions={names:?}"
+            );
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 20 Wave 5 — DID-auth challenge / verify (autonomous join)
+    // ------------------------------------------------------------------
+
+    async fn get_auth_challenge(app: Router) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/auth/challenge")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        (status, serde_json::from_slice(&bytes).unwrap_or_default())
+    }
+
+    async fn post_auth_verify(
+        app: Router,
+        body: serde_json::Value,
+    ) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/auth/verify")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        (status, serde_json::from_slice(&bytes).unwrap_or_default())
+    }
+
+    /// End-to-end happy path: challenge → DID-sign → verify → token.
+    #[tokio::test]
+    async fn auth_did_full_handshake_yields_session_token() {
+        let app = test_router_with_agent(Config::default(), None);
+
+        // 1. Public challenge endpoint.
+        let (status, ch) = get_auth_challenge(app.clone()).await;
+        assert_eq!(status, StatusCode::OK, "challenge: {ch}");
+        let challenge_hex = ch["challenge_hex"]
+            .as_str()
+            .expect("challenge_hex")
+            .to_string();
+        assert_eq!(challenge_hex.len(), 64);
+        assert_eq!(ch["ttl_secs"], 300);
+
+        // 2. Agent generates its own AgentIdentity (Wave 4 primitive)
+        //    and signs the challenge bytes.
+        let agent = tirami_mind::AgentIdentity::generate(0, Some("autonomous".into()));
+        let challenge_bytes = hex::decode(&challenge_hex).expect("hex");
+        let sig = agent.sign(&challenge_bytes);
+        let sig_hex = hex::encode(sig.to_bytes());
+        let did = agent.did();
+
+        // 3. Verify.
+        let (status, resp) = post_auth_verify(
+            app.clone(),
+            serde_json::json!({
+                "did": did,
+                "challenge_hex": challenge_hex,
+                "signature_hex": sig_hex,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "verify: {resp}");
+        assert_eq!(resp["did"], did);
+        let token = resp["session_token"].as_str().expect("token").to_string();
+        assert_eq!(token.len(), 64); // 32 random bytes → 64 hex chars
+        assert!(resp["expires_at_ms"].as_u64().unwrap_or(0) > 0);
+    }
+
+    #[tokio::test]
+    async fn auth_did_rejects_replay_of_same_challenge() {
+        let app = test_router_with_agent(Config::default(), None);
+        let (_, ch) = get_auth_challenge(app.clone()).await;
+        let challenge_hex = ch["challenge_hex"].as_str().expect("ok").to_string();
+        let agent = tirami_mind::AgentIdentity::generate(0, None);
+        let sig_hex = hex::encode(
+            agent
+                .sign(&hex::decode(&challenge_hex).expect("hex"))
+                .to_bytes(),
+        );
+        // First verify succeeds.
+        let (status, _) = post_auth_verify(
+            app.clone(),
+            serde_json::json!({
+                "did": agent.did(),
+                "challenge_hex": challenge_hex,
+                "signature_hex": sig_hex,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        // Second verify with the same challenge MUST fail — single-use.
+        let (status, body) = post_auth_verify(
+            app,
+            serde_json::json!({
+                "did": agent.did(),
+                "challenge_hex": challenge_hex,
+                "signature_hex": sig_hex,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(
+            msg.contains("unknown challenge_hex"),
+            "msg: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_did_rejects_signature_from_different_key() {
+        let app = test_router_with_agent(Config::default(), None);
+        let (_, ch) = get_auth_challenge(app.clone()).await;
+        let challenge_hex = ch["challenge_hex"].as_str().expect("ok").to_string();
+        // Sign with one key but claim a different DID.
+        let signer = tirami_mind::AgentIdentity::generate(0, None);
+        let imposter = tirami_mind::AgentIdentity::generate(0, None);
+        let sig_hex = hex::encode(
+            signer
+                .sign(&hex::decode(&challenge_hex).expect("hex"))
+                .to_bytes(),
+        );
+        let (status, body) = post_auth_verify(
+            app,
+            serde_json::json!({
+                "did": imposter.did(),
+                "challenge_hex": challenge_hex,
+                "signature_hex": sig_hex,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("signature invalid"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn auth_did_rejects_malformed_did_prefix() {
+        let app = test_router_with_agent(Config::default(), None);
+        let (_, ch) = get_auth_challenge(app.clone()).await;
+        let challenge_hex = ch["challenge_hex"].as_str().expect("ok").to_string();
+        let agent = tirami_mind::AgentIdentity::generate(0, None);
+        let sig_hex = hex::encode(
+            agent
+                .sign(&hex::decode(&challenge_hex).expect("hex"))
+                .to_bytes(),
+        );
+        let (status, body) = post_auth_verify(
+            app,
+            serde_json::json!({
+                "did": format!("did:other:{}", agent.public_key_hex()),
+                "challenge_hex": challenge_hex,
+                "signature_hex": sig_hex,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("did must start with"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn auth_did_rejects_wrong_length_signature() {
+        let app = test_router_with_agent(Config::default(), None);
+        let (_, ch) = get_auth_challenge(app.clone()).await;
+        let challenge_hex = ch["challenge_hex"].as_str().expect("ok").to_string();
+        let agent = tirami_mind::AgentIdentity::generate(0, None);
+        let (status, body) = post_auth_verify(
+            app,
+            serde_json::json!({
+                "did": agent.did(),
+                "challenge_hex": challenge_hex,
+                "signature_hex": "ab".repeat(16),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("signature_hex must be 128"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn auth_did_rejects_unknown_challenge() {
+        let app = test_router_with_agent(Config::default(), None);
+        let agent = tirami_mind::AgentIdentity::generate(0, None);
+        let fake_challenge = "00".repeat(32);
+        let sig_hex = hex::encode(
+            agent
+                .sign(&hex::decode(&fake_challenge).expect("hex"))
+                .to_bytes(),
+        );
+        let (status, body) = post_auth_verify(
+            app,
+            serde_json::json!({
+                "did": agent.did(),
+                "challenge_hex": fake_challenge,
+                "signature_hex": sig_hex,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let msg = body["error"]["message"].as_str().unwrap_or("");
+        assert!(msg.contains("unknown challenge_hex"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn auth_did_issued_token_unlocks_authenticated_endpoints() {
+        // The whole point of Wave 5: after a successful DID handshake,
+        // the returned bearer token must let the agent hit normally-
+        // protected endpoints without a human-shared API token.
+        let mut config = Config::default();
+        // Disable the legacy implicit-admin token so the test exercises
+        // the issued-session-token path only.
+        config.api_bearer_token = None;
+        let app = test_router_with_agent(config, None);
+
+        let (_, ch) = get_auth_challenge(app.clone()).await;
+        let challenge_hex = ch["challenge_hex"].as_str().expect("ok").to_string();
+        let agent = tirami_mind::AgentIdentity::generate(0, Some("autoclient".into()));
+        let sig_hex = hex::encode(
+            agent
+                .sign(&hex::decode(&challenge_hex).expect("hex"))
+                .to_bytes(),
+        );
+        let (_, resp) = post_auth_verify(
+            app.clone(),
+            serde_json::json!({
+                "did": agent.did(),
+                "challenge_hex": challenge_hex,
+                "signature_hex": sig_hex,
+            }),
+        )
+        .await;
+        let token = resp["session_token"].as_str().expect("token").to_string();
+
+        // Hit a protected endpoint with the issued token.
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/balance")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "DID-issued token should unlock /v1/tirami/balance"
+        );
+    }
+
+    #[tokio::test]
+    async fn well_known_manifest_lists_wave_5_auth_actions() {
+        let app = test_router_with_agent(Config::default(), None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/.well-known/tirami-agent.json")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        let names: Vec<String> = json["actions"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .map(|a| a["name"].as_str().unwrap_or("").to_string())
+            .collect();
+        for expected in &["auth_challenge", "auth_verify"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "manifest missing {expected}, actions={names:?}"
+            );
+        }
+        // Both new auth endpoints must advertise auth_required = false
+        // (that is literally what makes autonomous join possible).
+        let actions = json["actions"].as_array().expect("array");
+        for name in &["auth_challenge", "auth_verify"] {
+            let a = actions
+                .iter()
+                .find(|a| a["name"] == *name)
+                .expect("found");
+            assert_eq!(
+                a["auth_required"], false,
+                "{} must advertise auth_required=false",
+                name
             );
         }
     }

--- a/crates/tirami-node/src/handlers/agent_discovery.rs
+++ b/crates/tirami-node/src/handlers/agent_discovery.rs
@@ -164,6 +164,21 @@ pub(crate) async fn well_known_agent_manifest(
             pricing: "free; replaces this node's loaded identity",
             auth_required: true,
         },
+        // Phase 20 Wave 5 — DID-auth (autonomous mesh join).
+        ActionDescriptor {
+            name: "auth_challenge",
+            endpoint: "/v1/tirami/auth/challenge",
+            method: "GET",
+            pricing: "free; public — issues a single-use 32-byte nonce",
+            auth_required: false,
+        },
+        ActionDescriptor {
+            name: "auth_verify",
+            endpoint: "/v1/tirami/auth/verify",
+            method: "POST",
+            pricing: "free; public — DID-signed challenge → short-lived bearer token",
+            auth_required: false,
+        },
         ActionDescriptor {
             name: "agent_task",
             endpoint: "/v1/tirami/agent/task",

--- a/crates/tirami-node/src/handlers/auth_did.rs
+++ b/crates/tirami-node/src/handlers/auth_did.rs
@@ -1,0 +1,333 @@
+//! Phase 20 Wave 5 — DID-based authentication for autonomous mesh join.
+//!
+//! Until Wave 5, a human had to pre-share `TIRAMI_API_TOKEN` with
+//! every node an agent wanted to use. That made fully-autonomous AI
+//! agents structurally impossible — a human bottleneck sat between
+//! the agent and the mesh on day one.
+//!
+//! Wave 5 swaps that for a Sign-In-With-Ed25519 challenge protocol:
+//!
+//!   1. Agent calls `GET /v1/tirami/auth/challenge` (public, no auth).
+//!      Server returns a 32-byte random nonce + an expiry timestamp.
+//!   2. Agent signs the raw nonce bytes with its `AgentIdentity`
+//!      Ed25519 key (the same key behind its `did:tirami:<hex>`).
+//!   3. Agent calls `POST /v1/tirami/auth/verify` (public, no auth)
+//!      with `{ did, challenge_hex, signature_hex }`.
+//!   4. Server verifies the signature against the DID's embedded
+//!      public key, marks the challenge consumed, and issues a
+//!      short-lived bearer token via the existing
+//!      `Phase 17 Wave 1.5` `TokenStore`.
+//!   5. Agent uses that bearer token for all subsequent calls.
+//!
+//! Properties this primitive guarantees:
+//!
+//! - **No human-shared secret** is required to join. The agent
+//!   onboards purely with cryptographic material it generated
+//!   itself in Wave 4.
+//! - **Each challenge is single-use** and expires within
+//!   `CHALLENGE_TTL_SECS` (default 5 min). A leaked challenge can't
+//!   be replayed.
+//! - **The issued bearer token's `node_id` is the DID's public key**,
+//!   so all `/v1/tirami/trades` / Prometheus metrics that key on
+//!   `NodeId` attribute usage to the right agent — not to whatever
+//!   shared admin secret the operator happened to issue.
+//! - **No new transport** — the existing `Authorization: Bearer
+//!   <token>` middleware accepts these tokens unchanged because
+//!   they go through the same `TokenStore`.
+//!
+//! Out of scope for Wave 5 (deferred):
+//!
+//! - Stake-required mining enforcement. The `can_provide_inference`
+//!   function already exists in `tirami-ledger` from Phase 18.2;
+//!   Wave 5.5 turns it on in trade paths.
+//! - Welcome-loan auto-claim. New agents can today receive a welcome
+//!   loan via `POST /v1/tirami/lend`, but the call still requires
+//!   admin scope. Wave 5.5 lets a `Bearer` session token issued
+//!   under a fresh DID claim its own welcome loan.
+
+use axum::{Json, extract::State, http::StatusCode};
+use ed25519_dalek::Signature;
+use rand::RngCore;
+use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use tirami_core::NodeId;
+use tirami_mind::{AgentIdentity, DID_PREFIX};
+
+use crate::api::{AppState, check_forge_rate_limit, now_millis_pub};
+use crate::api_tokens::ApiScope;
+
+/// How long an issued challenge remains valid before it must be
+/// re-fetched. 5 minutes is generous enough for a paused-then-resumed
+/// agent loop while still small enough that a leaked challenge isn't
+/// useful for very long.
+pub const CHALLENGE_TTL_SECS: u64 = 300;
+
+/// Session-token lifetime after a successful DID verify. 1 hour —
+/// long enough that an agent doesn't have to re-handshake constantly,
+/// short enough that revocation propagates quickly.
+pub const SESSION_TTL_SECS: u64 = 3_600;
+
+#[derive(Debug, Clone)]
+struct ChallengeRecord {
+    /// `challenge_hex` doubles as the map key; the raw bytes are kept
+    /// alongside to avoid re-decoding on verify.
+    challenge_bytes: [u8; 32],
+    expires_at_ms: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct ChallengeStore {
+    /// `challenge_hex` → record. Single-use: removing the entry on
+    /// verify implements replay protection.
+    by_hex: HashMap<String, ChallengeRecord>,
+}
+
+impl ChallengeStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mint a fresh challenge. Returns `(challenge_hex, expires_at_ms)`.
+    pub fn mint(&mut self, now_ms: u64) -> (String, u64) {
+        // Lazy GC: drop anything already past expiry. Bounded work
+        // because `by_hex.len()` is at most O(concurrent fresh agents)
+        // and old entries leave at the same rate they enter.
+        self.by_hex.retain(|_, r| r.expires_at_ms > now_ms);
+
+        let mut buf = [0u8; 32];
+        OsRng.fill_bytes(&mut buf);
+        let hex = hex::encode(buf);
+        let expires_at_ms = now_ms.saturating_add(CHALLENGE_TTL_SECS.saturating_mul(1_000));
+        self.by_hex.insert(
+            hex.clone(),
+            ChallengeRecord {
+                challenge_bytes: buf,
+                expires_at_ms,
+            },
+        );
+        (hex, expires_at_ms)
+    }
+
+    /// Consume a challenge by its hex value. Returns the raw bytes
+    /// on success, or an error if the challenge is unknown / expired.
+    /// The entry is removed before return so a successful consume
+    /// cannot be replayed.
+    pub fn consume(&mut self, challenge_hex: &str, now_ms: u64) -> Result<[u8; 32], String> {
+        let record = self
+            .by_hex
+            .remove(challenge_hex)
+            .ok_or_else(|| "unknown challenge_hex (expired, already-consumed, or never issued)".to_string())?;
+        if record.expires_at_ms <= now_ms {
+            return Err("challenge expired".into());
+        }
+        Ok(record.challenge_bytes)
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_hex.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_hex.is_empty()
+    }
+}
+
+pub type ChallengeState = Arc<Mutex<ChallengeStore>>;
+
+// ---------------------------------------------------------------------------
+// Request / response shapes
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct ChallengeResponse {
+    pub challenge_hex: String,
+    pub expires_at_ms: u64,
+    pub server_node_id: String,
+    pub ttl_secs: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VerifyRequest {
+    pub did: String,
+    pub challenge_hex: String,
+    pub signature_hex: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VerifyResponse {
+    pub did: String,
+    pub session_token: String,
+    pub expires_at_ms: u64,
+    pub scope: String,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /v1/tirami/auth/challenge` — public, no auth.
+pub(crate) async fn issue_challenge(
+    State(state): State<AppState>,
+) -> Result<Json<ChallengeResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+    let now = now_millis_pub();
+    let mut store = state.auth_challenges.lock().await;
+    let (challenge_hex, expires_at_ms) = store.mint(now);
+    Ok(Json(ChallengeResponse {
+        challenge_hex,
+        expires_at_ms,
+        server_node_id: hex::encode(state.local_node_id.0),
+        ttl_secs: CHALLENGE_TTL_SECS,
+    }))
+}
+
+/// `POST /v1/tirami/auth/verify` — public, no auth. Body:
+/// `{ did, challenge_hex, signature_hex }`. On success returns a
+/// short-lived bearer token.
+pub(crate) async fn verify_did_signature(
+    State(state): State<AppState>,
+    Json(req): Json<VerifyRequest>,
+) -> Result<Json<VerifyResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+
+    // 1. Sanity-check the DID format up front so a malformed input
+    //    is rejected before we burn the challenge.
+    if !req.did.starts_with(DID_PREFIX) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("did must start with {DID_PREFIX}"),
+        ));
+    }
+    let pk_hex = &req.did[DID_PREFIX.len()..];
+    if pk_hex.len() != 64 || !pk_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "did suffix must be 64 hex characters".into(),
+        ));
+    }
+
+    // 2. Parse the signature hex into an Ed25519 Signature object.
+    if req.signature_hex.len() != 128 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "signature_hex must be 128 hex characters (64-byte Ed25519 sig)".into(),
+        ));
+    }
+    let sig_bytes = hex::decode(&req.signature_hex)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("signature_hex decode: {e}")))?;
+    let mut sig_arr = [0u8; 64];
+    sig_arr.copy_from_slice(&sig_bytes);
+    let sig = Signature::from_bytes(&sig_arr);
+
+    // 3. Consume the challenge (single-use). Doing this BEFORE
+    //    verifying the signature is intentional: a replay attempt
+    //    with a valid but already-consumed challenge fails here,
+    //    and an attacker who guesses challenges burns valid ones
+    //    one at a time rather than reusing one indefinitely.
+    let now = now_millis_pub();
+    let challenge_bytes = {
+        let mut store = state.auth_challenges.lock().await;
+        store
+            .consume(&req.challenge_hex, now)
+            .map_err(|e| (StatusCode::UNAUTHORIZED, e))?
+    };
+
+    // 4. Verify the signature against the DID's pubkey + the
+    //    server-issued challenge bytes.
+    AgentIdentity::verify_with_did(&req.did, &challenge_bytes, &sig)
+        .map_err(|e| (StatusCode::UNAUTHORIZED, format!("signature invalid: {e}")))?;
+
+    // 5. Issue a short-lived session token. The token's `node_id`
+    //    is the DID's public key, so every authenticated trade or
+    //    metric this session produces attributes to the right
+    //    economic actor.
+    let mut pk_bytes = [0u8; 32];
+    pk_bytes.copy_from_slice(
+        &hex::decode(pk_hex)
+            .map_err(|e| (StatusCode::BAD_REQUEST, format!("did suffix decode: {e}")))?,
+    );
+    let did_node_id = NodeId(pk_bytes);
+    let scope = ApiScope::Economy;
+    let (raw_token, token_record) = {
+        let mut store = state.api_tokens.lock().await;
+        store.issue(
+            did_node_id,
+            scope,
+            SESSION_TTL_SECS,
+            format!("did-auth:{}", &req.did[DID_PREFIX.len()..DID_PREFIX.len() + 12]),
+            now,
+        )
+    };
+
+    Ok(Json(VerifyResponse {
+        did: req.did,
+        session_token: raw_token,
+        expires_at_ms: token_record.expires_at_ms,
+        scope: format!("{:?}", scope),
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests on the challenge store
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mint_then_consume_round_trip() {
+        let mut store = ChallengeStore::new();
+        let (hex_a, exp_a) = store.mint(1_000);
+        assert!(exp_a > 1_000);
+        let bytes = store.consume(&hex_a, 1_001).expect("consume ok");
+        assert_eq!(hex::encode(bytes), hex_a);
+    }
+
+    #[test]
+    fn consume_is_single_use() {
+        let mut store = ChallengeStore::new();
+        let (hex_a, _) = store.mint(1_000);
+        store.consume(&hex_a, 1_001).expect("first consume ok");
+        let err = store.consume(&hex_a, 1_002);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn consume_rejects_expired() {
+        let mut store = ChallengeStore::new();
+        let (hex_a, exp) = store.mint(1_000);
+        // Try to consume just after expiry.
+        let err = store.consume(&hex_a, exp + 1);
+        assert!(err.is_err(), "expired challenge should be rejected");
+    }
+
+    #[test]
+    fn consume_rejects_unknown() {
+        let mut store = ChallengeStore::new();
+        let err = store.consume("00".repeat(32).as_str(), 1_000);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn mint_gcs_old_entries() {
+        let mut store = ChallengeStore::new();
+        // Mint at t=0, then mint again well past TTL — old one is GC'd.
+        store.mint(0);
+        assert_eq!(store.len(), 1);
+        store.mint(CHALLENGE_TTL_SECS * 1_000 + 1);
+        assert_eq!(store.len(), 1, "old expired entry should have been GC'd");
+    }
+
+    #[test]
+    fn mint_yields_unique_challenges() {
+        let mut store = ChallengeStore::new();
+        let (a, _) = store.mint(0);
+        let (b, _) = store.mint(0);
+        assert_ne!(a, b);
+    }
+}

--- a/crates/tirami-node/src/handlers/mod.rs
+++ b/crates/tirami-node/src/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod agent_identity;
 pub mod agent_message;
 pub mod agora;
 pub mod anchor;
+pub mod auth_did;
 pub mod bank;
 pub mod data_offer;
 pub mod governance;

--- a/docs/phase-20-agent-action-economy.md
+++ b/docs/phase-20-agent-action-economy.md
@@ -307,12 +307,64 @@ import on node B, same DID continues to refer to the same actor.
   AgentIdentity when one is loaded. Deferred to keep Wave 4 strictly
   additive.
 
-### Wave 5 — Autonomous mesh join
+### Wave 5 — Autonomous mesh join ✅ shipped
 
-- **`tirami agent bootstrap`** — generate keys, pay (or be sponsored
-  for) the welcome loan, and join the mesh without a human-shared
-  bearer token. Auth migrates from "shared secret" to "stake-required
-  ratchet" (already designed in Phase 18.2 but not enforced).
+The blocker for fully-autonomous AI agents on Tirami used to be:
+a human had to pre-share `TIRAMI_API_TOKEN` with every node the
+agent wanted to use. Wave 5 swaps that for a Sign-In-With-Ed25519
+challenge protocol:
+
+- **`GET /v1/tirami/auth/challenge`** — public, no auth. Server
+  returns `{ challenge_hex, expires_at_ms, server_node_id, ttl_secs }`
+  where `challenge_hex` is a fresh 32-byte random nonce. TTL: 300 s.
+- **`POST /v1/tirami/auth/verify`** — public, no auth. Body:
+  `{ did, challenge_hex, signature_hex }`. Server (i) consumes the
+  challenge — single-use, so a replay can never succeed —
+  (ii) parses the DID's embedded Ed25519 public key,
+  (iii) verifies the signature against that pubkey + the
+  challenge bytes, then issues a short-lived bearer token via
+  the existing `Phase 17 Wave 1.5` `TokenStore`. The token's
+  `node_id` is the DID's public key, so trades + metrics attribute
+  to the right agent rather than to whatever shared admin secret
+  the operator happened to issue.
+- **Session lifetime**: 3600 s by default. Long enough that a
+  paused-then-resumed agent loop doesn't have to re-handshake on
+  every step; short enough that revocation propagates quickly.
+- **No new transport** — the existing
+  `Authorization: Bearer <token>` middleware accepts these tokens
+  unchanged because they go through the same `TokenStore`.
+- **Discovery manifest** advertises both endpoints with
+  `auth_required: false`; an agent discovering Tirami for the first
+  time learns from one unauthenticated GET that it can sign in via
+  its DID.
+
+Properties guaranteed:
+
+- **No human-shared secret** is required for an agent to join. The
+  agent onboards purely with cryptographic material it generated
+  itself in Wave 4.
+- **Replay protection** is structural: the challenge entry is
+  removed from the store before the signature is even verified, so
+  even a valid challenge cannot be reused.
+- **DID-keyed audit trail**: every API call made under a DID-issued
+  token attributes to the DID's pubkey on the ledger and Prometheus.
+
+**Wave 5 follow-ups**:
+
+- **Stake-required mining enforcement**. The `can_provide_inference`
+  function exists in `tirami-ledger` from Phase 18.2; it is not yet
+  consulted in the trade-recording path. Wave 5.5 turns it on so
+  that "joined the mesh" is a real economic step (must hold ≥
+  `MIN_PROVIDER_STAKE` either by self-stake or via the welcome loan),
+  not just a cryptographic step.
+- **Welcome-loan auto-claim**. A fresh DID that has just verified
+  should be able to claim a welcome loan directly via its session
+  token rather than requiring an admin to grant one out of band.
+- **Persistence of the issued challenge store**. Today the store is
+  in-memory, which is fine because challenges are 5-min ephemeral.
+  If we ever extend the protocol to support delayed signatures
+  (e.g. signed-offline-then-submitted-later), the store will need
+  to survive restart.
 
 ### Estimated scope
 


### PR DESCRIPTION
## Summary

Phase 20 Wave 5 — final wave. Removes the human-shared-token bottleneck that until now made fully-autonomous AI agents impossible on Tirami. An agent holding a Wave-4 \`AgentIdentity\` can now sign in to **any** Tirami node by signing a server-issued nonce, with zero pre-shared secrets.

## New endpoints (both public, no auth)

| Method | Path | Purpose |
|---|---|---|
| GET | \`/v1/tirami/auth/challenge\` | Issue a single-use 32-byte nonce; 5-min TTL |
| POST | \`/v1/tirami/auth/verify\` | Verify Ed25519 signature over the nonce → short-lived bearer token |

The flow is Sign-In-With-Ed25519:

1. Agent: \`GET /v1/tirami/auth/challenge\` → \`{ challenge_hex, expires_at_ms, server_node_id }\`
2. Agent signs the raw challenge bytes with its \`AgentIdentity\` Ed25519 key (the same key behind its \`did:tirami:<hex>\`)
3. Agent: \`POST /v1/tirami/auth/verify { did, challenge_hex, signature_hex }\` → \`{ session_token, expires_at_ms, scope }\`
4. Agent uses \`Authorization: Bearer <session_token>\` on every subsequent call

## Design properties

- **No human-shared secret** is required to join. Agent onboards purely with cryptographic material it generated itself in Wave 4.
- **Replay protection is structural** — the challenge entry is removed from the store **before** the signature is verified, so even a valid challenge cannot be reused.
- **DID-keyed audit trail** — the issued session token's \`node_id\` is the DID's pubkey, so ledger entries + Prometheus metrics attribute to the right agent, not to a shared admin token.
- **No new transport** — existing \`Authorization: Bearer <token>\` middleware accepts these tokens unchanged because they go through the same Phase-17 W1.5 \`TokenStore\`.
- **Discovery manifest** now advertises both endpoints with \`auth_required: false\`, so an autonomous agent learns from one unauthenticated \`GET /.well-known/tirami-agent.json\` that it can sign in via DID.

## Stacked on Wave 4

Base: \`phase-20/wave-4-agent-identity\` (PR #95). Merge order: #92 → #93 → #94 → #95 → this PR.

## What this PR does NOT do (intentional Wave 5.5+ deferrals)

- **Stake-required mining enforcement** — \`can_provide_inference\` exists in tirami-ledger from Phase 18.2 but is not yet consulted in the trade-recording path. Wave 5.5 turns it on so \"joined the mesh\" is a real economic step (must hold ≥ \`MIN_PROVIDER_STAKE\`), not just a cryptographic one.
- **Welcome-loan auto-claim** — a fresh DID that has just verified should be able to claim a welcome loan via its session token; today that still requires admin scope.
- **Persistence of the issued challenge store** — currently in-memory. Fine for 5-min ephemeral challenges; if the protocol ever supports delayed signatures, the store will need to survive restart.

## Test plan

- [x] \`cargo test --workspace\` → **1,289 passed, 0 failed** (was 1,275 → +14 new)
- [x] 6 unit tests on \`ChallengeStore\` (mint+consume / single-use / expired-rejection / unknown-rejection / lazy GC of expired / nonce uniqueness)
- [x] 8 integration tests on the HTTP layer (full handshake yields token / replay rejected / wrong-key signature rejected / malformed DID prefix rejected / wrong-length signature rejected / unknown challenge rejected / DID-issued token unlocks /v1/tirami/balance / manifest exposes Wave-5 actions with \`auth_required=false\`)
- [x] **Live cross-process smoke**:
  - \`tirami node --api-token \"operator-secret-not-shared\"\`
  - \`/v1/tirami/balance\` (no auth) → 401
  - \`GET /v1/tirami/auth/challenge\` (no auth) → 200, fresh 64-char hex nonce
  - Python+cryptography generates a brand-new Ed25519 keypair OFFLINE (no server contact for keygen)
  - \`POST /v1/tirami/auth/verify\` with the agent's DID + signature → 200, \`session_token\`, \`scope: \"Economy\"\`
  - \`/v1/tirami/balance\` with \`Bearer <session_token>\` → **200** (same endpoint that was 401 in step 1)
  - Replay the same challenge → **401** \"unknown challenge_hex (expired, already-consumed, or never issued)\"

## Phase 20 complete

| Wave | PR | Subject |
|---|---|---|
| 1 | #92 | discovery manifest + typed agent messaging |
| 2 | #93 | priced data offer marketplace |
| 3 | #94 | physical-world purchase intent + Lightning bridge |
| 4 | #95 | portable agent identity (did:tirami) + encrypted export |
| 5 | this | autonomous mesh join via DID-auth |

🤖 Generated with [Claude Code](https://claude.com/claude-code)