### PR TITLE
feat(phase-21/wave-2): welcome-loan as effective stake + claim endpoint + flip default

### DIFF
--- a/crates/tirami-core/src/config.rs
+++ b/crates/tirami-core/src/config.rs
@@ -47,14 +47,16 @@ pub struct Config {
     /// Maximum accepted HTTP request body size for the local API.
     pub api_max_request_body_bytes: usize,
 
-    /// Phase 21 Wave 1 — when `true`, refuse `/v1/chat/completions`
+    /// Phase 21 Wave 1+2 — when `true`, refuse `/v1/chat/completions`
     /// requests unless the local node passes
-    /// [`tirami_ledger::ComputeLedger::can_provide_inference`].
-    /// Default `false` for backwards-compat with existing deploys
-    /// that have no stake configured. Wave 2 of Phase 21 adds
-    /// welcome-loan-counts-as-stake semantics and flips this default
-    /// to `true`.
-    #[serde(default)]
+    /// [`tirami_ledger::ComputeLedger::inference_eligibility`].
+    /// Default **`true`** as of Wave 2: a fresh node can pass via
+    /// the bootstrap window (≤ 10 TRM cumulative) or by claiming a
+    /// welcome loan (`POST /v1/tirami/agent/claim-welcome`,
+    /// 1 000 TRM × 72 h). Operators with custom flows that pre-
+    /// inflate contribution past the cap without staking can set
+    /// this to `false` explicitly.
+    #[serde(default = "default_stake_gate_enabled")]
     pub stake_gate_enabled: bool,
 
     /// Bootstrap relay addresses for WAN discovery.
@@ -195,6 +197,15 @@ pub struct Config {
     pub personal_agent_enabled: bool,
 }
 
+/// Phase 21 Wave 2 — stake gate is **on by default** so that fresh
+/// deploys start enforcing Sybil resistance immediately. Operators
+/// who want the pre-Wave-1 permissive behaviour can opt out by
+/// setting `stake_gate_enabled = false`. See
+/// `docs/phase-21-stake-enforcement.md` for the rationale.
+fn default_stake_gate_enabled() -> bool {
+    true
+}
+
 fn default_anchor_interval_secs() -> u64 {
     3600
 }
@@ -325,7 +336,7 @@ impl Default for Config {
             api_bind_addr: "127.0.0.1".to_string(),
             api_bearer_token: None,
             api_max_request_body_bytes: 64 * 1024,
-            stake_gate_enabled: false,
+            stake_gate_enabled: default_stake_gate_enabled(),
             bootstrap_relays: vec![],
             p2p_bind_addr: None,
             bootstrap_peers: vec![],

--- a/crates/tirami-ledger/src/ledger.rs
+++ b/crates/tirami-ledger/src/ledger.rs
@@ -102,6 +102,17 @@ pub struct ComputeLedger {
     /// even if the global Sybil ceiling hasn't been hit.
     #[serde(default, skip_serializing)]
     pub sybil_limiter: crate::sybil::WelcomeLoanLimiter,
+    /// Phase 21 Wave 2 — record of welcome-loan grants the local
+    /// node has issued (or that arrived via gossip). Keyed by
+    /// borrower NodeId; single-grant-per-node enforced by the
+    /// `can_issue_welcome_loan` "no existing balance" rule.
+    ///
+    /// Used by [`Self::inference_eligibility`] to recognise an
+    /// unrepaid, unexpired welcome loan as effective stake — the
+    /// missing link between Wave 1's opt-in gate and Wave 2's
+    /// default-on enforcement.
+    #[serde(default)]
+    pub welcome_loans: HashMap<NodeId, WelcomeLoanGrant>,
 }
 
 /// Audit trail entry written each time [`ComputeLedger::update_trust_penalties`]
@@ -128,12 +139,66 @@ pub struct SlashEvent {
 pub enum InferenceEligibility {
     /// Node has posted ≥ `MIN_PROVIDER_STAKE_TRM` of locked stake.
     Staked { staked_amount: u64 },
+    /// Phase 21 Wave 2 — node has an active, unrepaid welcome loan.
+    /// Treated as effective stake until repayment or expiry.
+    WelcomeLoan {
+        principal_trm: u64,
+        expires_at_ms: u64,
+    },
     /// Node has not yet hit its stakeless earn cap. After
     /// `contributed_so_far` ≥ `cap_trm` the node must stake.
     BootstrapWindow {
         contributed_so_far: u64,
         cap_trm: u64,
     },
+}
+
+/// Phase 21 Wave 2 — a single welcome-loan grant.
+///
+/// Recorded by [`ComputeLedger::grant_welcome_loan`]. While `repaid =
+/// false` and `expires_at_ms > now`, the borrower passes the
+/// stake-gate via the `WelcomeLoan` variant of
+/// [`InferenceEligibility`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WelcomeLoanGrant {
+    pub node_id: NodeId,
+    pub principal_trm: u64,
+    pub granted_at_ms: u64,
+    pub expires_at_ms: u64,
+    pub repaid: bool,
+}
+
+/// Phase 21 Wave 2 — error variants from
+/// [`ComputeLedger::grant_welcome_loan`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WelcomeLoanError {
+    /// Node already has a balance (welcome loans are one-shot).
+    AlreadyHasBalance,
+    /// Network has reached the sunset epoch — welcome-loan bootstrap
+    /// path is permanently closed (constitutional).
+    SunsetReached,
+    /// Sybil ceiling (per-bucket or global) reached. Caller may
+    /// retry later when the rolling window decays.
+    SybilCeiling,
+}
+
+impl std::fmt::Display for WelcomeLoanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyHasBalance => write!(
+                f,
+                "node already has a ledger balance; welcome loans are one-shot per node"
+            ),
+            Self::SunsetReached => write!(
+                f,
+                "welcome-loan sunset epoch reached; constitutional bootstrap window closed"
+            ),
+            Self::SybilCeiling => write!(
+                f,
+                "Sybil rate limiter denied this grant; retry after the rolling window decays"
+            ),
+        }
+    }
 }
 
 /// Phase 21 Wave 1 — denial reason from
@@ -627,6 +692,7 @@ impl ComputeLedger {
             slash_events: Vec::new(),
             checkpoints: Vec::new(),
             sybil_limiter: crate::sybil::WelcomeLoanLimiter::new(),
+            welcome_loans: HashMap::new(),
         }
     }
 
@@ -987,6 +1053,7 @@ impl ComputeLedger {
             slash_events: snapshot.slash_events,
             checkpoints: snapshot.checkpoints,
             sybil_limiter: crate::sybil::WelcomeLoanLimiter::new(),
+            welcome_loans: HashMap::new(),
         };
         // Phase 17 Wave 1.2 — replay defense must survive a restart.
         ledger.rebuild_nonce_cache();
@@ -2229,21 +2296,20 @@ impl ComputeLedger {
     /// but returns a structured reason on denial, suitable for
     /// surfacing in HTTP 403 responses.
     ///
-    /// Discriminates three deny cases:
-    ///
-    /// - The node has been slashed at least once; staking does not
-    ///   restore eligibility (constitutional).
-    /// - The node has consumed its stakeless earn cap and has not
-    ///   yet posted ≥ `MIN_PROVIDER_STAKE_TRM` of stake.
-    /// - Both — slashed AND past the cap. The slash check fires
-    ///   first.
+    /// Phase 21 Wave 2 extended this to recognise an active,
+    /// unrepaid welcome loan as effective stake. Precedence:
+    ///   1. Real locked stake ≥ MIN_PROVIDER_STAKE_TRM → Staked.
+    ///   2. Previously slashed → PreviouslySlashed (constitutional).
+    ///   3. Active unrepaid welcome loan → WelcomeLoan.
+    ///   4. Cumulative contributed < cap → BootstrapWindow.
+    ///   5. Else → StakeRequired.
     pub fn inference_eligibility(
         &self,
         node_id: &NodeId,
         staking: &crate::StakingPool,
         now_ms: u64,
     ) -> Result<InferenceEligibility, InferenceIneligible> {
-        // Primary path: real stake meets the floor.
+        // 1. Primary path: real stake meets the floor.
         let staked_amount = staking
             .stakes_for(node_id)
             .filter(|s| s.is_locked(now_ms))
@@ -2253,7 +2319,7 @@ impl ComputeLedger {
             return Ok(InferenceEligibility::Staked { staked_amount });
         }
 
-        // Constitutional permanent ban for previously-slashed nodes.
+        // 2. Constitutional permanent ban for previously-slashed nodes.
         let slashed_before = self
             .slash_events
             .iter()
@@ -2262,7 +2328,19 @@ impl ComputeLedger {
             return Err(InferenceIneligible::PreviouslySlashed);
         }
 
-        // Bootstrap window: under the stakeless cap.
+        // 3. Phase 21 Wave 2 — active welcome loan counts as effective
+        //    stake. The grant is "active" iff not yet repaid AND not
+        //    yet expired.
+        if let Some(grant) = self.welcome_loans.get(node_id) {
+            if !grant.repaid && grant.expires_at_ms > now_ms {
+                return Ok(InferenceEligibility::WelcomeLoan {
+                    principal_trm: grant.principal_trm,
+                    expires_at_ms: grant.expires_at_ms,
+                });
+            }
+        }
+
+        // 4. Bootstrap window: under the stakeless cap.
         let total_earned = self
             .balances
             .get(node_id)
@@ -2280,6 +2358,66 @@ impl ComputeLedger {
             cumulative_contributed: total_earned,
             cap_trm: crate::lending::STAKELESS_EARN_CAP_TRM,
         })
+    }
+
+    /// Phase 21 Wave 2 — grant a welcome loan to `node_id`.
+    ///
+    /// On success:
+    /// 1. A [`WelcomeLoanGrant`] is recorded in `welcome_loans` so
+    ///    [`Self::inference_eligibility`] sees it.
+    /// 2. A zero-balance [`NodeBalance`] is inserted so subsequent
+    ///    [`Self::can_issue_welcome_loan`] calls return false
+    ///    (one-shot per node).
+    /// 3. The Sybil rate limiter is updated for the supplied bucket
+    ///    (use `""` for "no bucketing").
+    ///
+    /// The loan principal is **not** added to the balance's
+    /// `contributed` field — Phase 21 treats the welcome loan as a
+    /// stake-equivalent right, not an inflation of the borrower's
+    /// earnings. Repayment after the 72 h term is the borrower's
+    /// responsibility (Phase 21 Wave 3+ may automate this).
+    pub fn grant_welcome_loan(
+        &mut self,
+        node_id: NodeId,
+        bucket: &str,
+        now_ms: u64,
+    ) -> Result<WelcomeLoanGrant, WelcomeLoanError> {
+        // Sunset check (constitutional).
+        if (self.current_epoch() as u64) >= crate::lending::WELCOME_LOAN_SUNSET_EPOCH {
+            return Err(WelcomeLoanError::SunsetReached);
+        }
+        // Single-grant rule: must not already have a balance.
+        if self.balances.contains_key(&node_id) {
+            return Err(WelcomeLoanError::AlreadyHasBalance);
+        }
+
+        let principal_trm = crate::lending::WELCOME_LOAN_AMOUNT;
+        let term_ms = crate::lending::WELCOME_LOAN_TERM_HOURS.saturating_mul(3_600_000);
+        let grant = WelcomeLoanGrant {
+            node_id: node_id.clone(),
+            principal_trm,
+            granted_at_ms: now_ms,
+            expires_at_ms: now_ms.saturating_add(term_ms),
+            repaid: false,
+        };
+
+        self.balances.insert(
+            node_id.clone(),
+            NodeBalance {
+                node_id: node_id.clone(),
+                contributed: 0,
+                consumed: 0,
+                reserved: 0,
+                reputation: crate::lending::DEFAULT_REPUTATION,
+            },
+        );
+        self.welcome_loans.insert(node_id, grant.clone());
+        // Record for the rolling Sybil window — keeps the bucket
+        // counters honest even when callers pass empty buckets.
+        if !bucket.is_empty() {
+            self.sybil_limiter.record(bucket, now_ms);
+        }
+        Ok(grant)
     }
 
     /// Phase 17 Wave 4.1 — per-bucket welcome-loan eligibility.

--- a/crates/tirami-ledger/src/lib.rs
+++ b/crates/tirami-ledger/src/lib.rs
@@ -26,6 +26,7 @@ pub use collusion::{CollusionDetector, CollusionReport};
 pub use ledger::{
     ComputeLedger, InferenceEligibility, InferenceIneligible, MarketPrice, NetworkStats,
     SettlementNode, SettlementStatement, SignatureError, SignedTradeRecord, TradeRecord,
+    WelcomeLoanError, WelcomeLoanGrant,
 };
 pub use lending::{
     LoanRecord, LoanSignatureError, LoanStatus, ModelTier, SignedLoanRecord,

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -492,6 +492,11 @@ pub fn create_router_with_services(
             "/v1/tirami/agent/identity/import",
             post(crate::handlers::agent_identity::import_identity),
         )
+        // Phase 21 Wave 2 — autonomous welcome-loan claim.
+        .route(
+            "/v1/tirami/agent/claim-welcome",
+            post(crate::handlers::welcome_claim::claim_welcome_loan),
+        )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             require_bearer_auth,
@@ -6616,6 +6621,158 @@ mod tests {
         assert!(
             msg.contains("stakeless earn cap"),
             "unexpected inner message: {msg}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 21 Wave 2 — welcome-loan claim + welcome-loan-as-stake
+    // ------------------------------------------------------------------
+
+    async fn post_claim_welcome(
+        app: Router,
+        node_id_hex: &str,
+        bucket: Option<&str>,
+    ) -> (StatusCode, serde_json::Value) {
+        let body = serde_json::json!({ "bucket": bucket.unwrap_or("") });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/agent/claim-welcome")
+                    .header("content-type", "application/json")
+                    .header("X-Tirami-Node-Id", node_id_hex)
+                    .body(Body::from(body.to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        (status, serde_json::from_slice(&bytes).unwrap_or_default())
+    }
+
+    /// Happy path: a fresh node claims its welcome loan and the
+    /// response carries the principal + 72-hour expiry.
+    #[tokio::test]
+    async fn welcome_loan_claim_returns_grant_for_fresh_node() {
+        let app = test_router_with_agent(Config::default(), None);
+        let claimant = "aa".repeat(32);
+        let (status, body) = post_claim_welcome(app, &claimant, Some("AS-test")).await;
+        assert_eq!(status, StatusCode::OK, "claim failed: {body}");
+        assert_eq!(body["node_id"], claimant);
+        assert_eq!(body["principal_trm"], tirami_ledger::lending::WELCOME_LOAN_AMOUNT);
+        let granted = body["granted_at_ms"].as_u64().expect("granted_at_ms");
+        let expires = body["expires_at_ms"].as_u64().expect("expires_at_ms");
+        assert!(expires > granted, "expires must be after granted");
+        // Term should be 72 h.
+        let term_ms = (expires - granted) as i64;
+        let expected_term_ms =
+            (tirami_ledger::lending::WELCOME_LOAN_TERM_HOURS * 3_600_000) as i64;
+        assert_eq!(term_ms, expected_term_ms);
+    }
+
+    /// A second claim from the same node must fail because the
+    /// grant left a balance entry that flips `can_issue_welcome_loan`
+    /// to `false`.
+    #[tokio::test]
+    async fn welcome_loan_claim_is_one_shot_per_node() {
+        let app = test_router_with_agent(Config::default(), None);
+        let claimant = "bb".repeat(32);
+        let (status, _) = post_claim_welcome(app.clone(), &claimant, None).await;
+        assert_eq!(status, StatusCode::OK);
+        let (status, body) = post_claim_welcome(app, &claimant, None).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        // Body is wrapped by the envelope middleware (handler returned a
+        // JSON string under (StatusCode, String)).
+        let outer = body;
+        let inner_str = outer["error"]["message"].as_str().expect("inner");
+        let inner: serde_json::Value =
+            serde_json::from_str(inner_str).expect("inner json");
+        assert_eq!(inner["error"]["code"], "already_has_balance");
+    }
+
+    /// With the stake gate enabled and the local node well past the
+    /// stakeless cap, a freshly-granted welcome loan must flip
+    /// eligibility back to "allowed" via the `WelcomeLoan` verdict.
+    #[tokio::test]
+    async fn stake_gate_with_welcome_loan_passes_inference() {
+        use tirami_ledger::{ComputeLedger, TradeRecord};
+        let mut ledger = ComputeLedger::new();
+        let local = tirami_core::NodeId([0u8; 32]);
+        // Trick: grant the welcome loan first (creates the balance
+        // entry), then push contributions past the cap on the same
+        // entry — eligibility should still report `WelcomeLoan`.
+        // Use the current wall-clock so the 72-hour expiry is in
+        // the future relative to `now_millis()` inside the gate.
+        let now = now_millis();
+        let grant = ledger
+            .grant_welcome_loan(local.clone(), "", now)
+            .expect("grant ok");
+        assert!(grant.principal_trm > 0);
+        let trade = TradeRecord {
+            provider: local.clone(),
+            consumer: tirami_core::NodeId([0x99u8; 32]),
+            trm_amount: tirami_ledger::lending::STAKELESS_EARN_CAP_TRM + 1,
+            tokens_processed: 1,
+            timestamp: 0,
+            model_id: "phase21-w2-prep".into(),
+            flops_estimated: 0,
+            nonce: [0u8; 16],
+        };
+        ledger.execute_trade(&trade);
+
+        let mut config = Config::default();
+        config.stake_gate_enabled = true;
+        let app = test_router_with_agent_and_ledger(config, None, ledger, None);
+        let status = post_chat(app, chat_body_minimum()).await;
+        assert_ne!(
+            status,
+            StatusCode::FORBIDDEN,
+            "active welcome loan should pass the stake gate"
+        );
+    }
+
+    /// The discovery manifest must surface the welcome-loan policy
+    /// (amount, term, availability) AND the new action so an
+    /// autonomous agent can plan its bootstrap before its first call.
+    #[tokio::test]
+    async fn manifest_exposes_wave_2_welcome_loan_policy_and_action() {
+        let app = test_router_with_agent(Config::default(), None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/.well-known/tirami-agent.json")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(
+            json["policy"]["welcome_loan_amount_trm"],
+            tirami_ledger::lending::WELCOME_LOAN_AMOUNT
+        );
+        assert_eq!(
+            json["policy"]["welcome_loan_term_hours"],
+            tirami_ledger::lending::WELCOME_LOAN_TERM_HOURS
+        );
+        assert_eq!(json["policy"]["welcome_loan_available"], true);
+        let names: Vec<String> = json["actions"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .map(|a| a["name"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "claim_welcome_loan"),
+            "manifest missing claim_welcome_loan, actions={names:?}"
         );
     }
 

--- a/crates/tirami-node/src/handlers/agent_discovery.rs
+++ b/crates/tirami-node/src/handlers/agent_discovery.rs
@@ -52,6 +52,18 @@ pub struct PolicySpec {
     /// to a different provider, post stake, or claim a welcome loan
     /// based on this flag rather than discovering it via a 403.
     pub stake_gate_enabled: bool,
+    /// Phase 21 Wave 2 — welcome-loan principal an agent can claim
+    /// via `POST /v1/tirami/agent/claim-welcome`. Lets the agent
+    /// budget around the 72-hour term before deciding to call.
+    pub welcome_loan_amount_trm: u64,
+    /// Phase 21 Wave 2 — welcome-loan term in hours. Fixed at
+    /// `WELCOME_LOAN_TERM_HOURS = 72`.
+    pub welcome_loan_term_hours: u64,
+    /// Phase 21 Wave 2 — `true` while the network's epoch is below
+    /// `WELCOME_LOAN_SUNSET_EPOCH` (constitutional). `false` means
+    /// the bootstrap window has closed permanently and claims will
+    /// 410.
+    pub welcome_loan_available: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -192,6 +204,14 @@ pub(crate) async fn well_known_agent_manifest(
             pricing: "free; public — DID-signed challenge → short-lived bearer token",
             auth_required: false,
         },
+        // Phase 21 Wave 2 — autonomous welcome-loan claim.
+        ActionDescriptor {
+            name: "claim_welcome_loan",
+            endpoint: "/v1/tirami/agent/claim-welcome",
+            method: "POST",
+            pricing: "free; grants WELCOME_LOAN_AMOUNT TRM for 72 h (one-shot per node)",
+            auth_required: true,
+        },
         ActionDescriptor {
             name: "agent_task",
             endpoint: "/v1/tirami/agent/task",
@@ -250,6 +270,16 @@ pub(crate) async fn well_known_agent_manifest(
         agent_did,
         policy: PolicySpec {
             stake_gate_enabled: state.config.stake_gate_enabled,
+            welcome_loan_amount_trm: tirami_ledger::lending::WELCOME_LOAN_AMOUNT,
+            welcome_loan_term_hours: tirami_ledger::lending::WELCOME_LOAN_TERM_HOURS,
+            // Best-effort: try a non-blocking read of the ledger. If
+            // contended, advertise `true` (the default for a fresh
+            // network) rather than blocking the manifest GET.
+            welcome_loan_available: match state.ledger.try_lock() {
+                Ok(l) => (l.current_epoch() as u64)
+                    < tirami_ledger::lending::WELCOME_LOAN_SUNSET_EPOCH,
+                Err(_) => true,
+            },
         },
         currency: CurrencySpec {
             unit: "TRM",

--- a/crates/tirami-node/src/handlers/mod.rs
+++ b/crates/tirami-node/src/handlers/mod.rs
@@ -11,3 +11,4 @@ pub mod metrics;
 pub mod mind;
 pub mod purchase_intent;
 pub mod tokenomics;
+pub mod welcome_claim;

--- a/crates/tirami-node/src/handlers/welcome_claim.rs
+++ b/crates/tirami-node/src/handlers/welcome_claim.rs
@@ -1,0 +1,116 @@
+//! Phase 21 Wave 2 — autonomous welcome-loan claim.
+//!
+//! `POST /v1/tirami/agent/claim-welcome`
+//!
+//! An autonomous agent that has just authenticated via Phase 20 Wave 5
+//! (DID-signed challenge → bearer token) can claim its own welcome
+//! loan with this endpoint — no admin scope required, no human in
+//! the loop. The handler trusts the `X-Tirami-Node-Id` header for
+//! the borrower identity (same convention as `agent_message` /
+//! `data_offer` / `purchase_intent`); a stake-required mining gate
+//! could later be wired to require the header to match the bearer
+//! token's `node_id`, but Wave 2 keeps it as a discoverable surface
+//! consistent with the rest of the API.
+//!
+//! On success the response carries the full [`WelcomeLoanGrant`] so
+//! the agent can plan around the 72-hour expiry.
+
+use axum::{Json, extract::State, http::{HeaderMap, StatusCode}};
+use serde::{Deserialize, Serialize};
+
+use tirami_core::NodeId;
+use tirami_ledger::{WelcomeLoanError, WelcomeLoanGrant};
+
+use crate::api::{AppState, check_forge_rate_limit, now_millis_pub};
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ClaimWelcomeRequest {
+    /// Operator-supplied bucket key (typically the requester's ASN
+    /// string, e.g. `"AS16509"` for AWS). Required for Phase 17
+    /// Wave 4.1 per-bucket rate limiting. Empty string disables
+    /// bucket-level rate limiting for this request.
+    #[serde(default)]
+    pub bucket: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClaimWelcomeResponse {
+    pub node_id: String,
+    pub principal_trm: u64,
+    pub granted_at_ms: u64,
+    pub expires_at_ms: u64,
+}
+
+impl From<WelcomeLoanGrant> for ClaimWelcomeResponse {
+    fn from(grant: WelcomeLoanGrant) -> Self {
+        Self {
+            node_id: hex::encode(grant.node_id.0),
+            principal_trm: grant.principal_trm,
+            granted_at_ms: grant.granted_at_ms,
+            expires_at_ms: grant.expires_at_ms,
+        }
+    }
+}
+
+fn parse_hex_node_id(hex: &str) -> Result<NodeId, String> {
+    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!(
+            "node id must be exactly 64 hex characters, got {}",
+            hex.len()
+        ));
+    }
+    let bytes = hex::decode(hex).map_err(|e| format!("hex decode failed: {e}"))?;
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(NodeId(arr))
+}
+
+fn parse_sender(headers: &HeaderMap) -> Result<NodeId, (StatusCode, String)> {
+    let raw = headers
+        .get("X-Tirami-Node-Id")
+        .and_then(|v| v.to_str().ok())
+        .ok_or((
+            StatusCode::BAD_REQUEST,
+            "X-Tirami-Node-Id header required (claimant node id)".into(),
+        ))?;
+    parse_hex_node_id(raw)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("X-Tirami-Node-Id: {e}")))
+}
+
+/// `POST /v1/tirami/agent/claim-welcome`
+pub(crate) async fn claim_welcome_loan(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<ClaimWelcomeRequest>,
+) -> Result<Json<ClaimWelcomeResponse>, (StatusCode, String)> {
+    check_forge_rate_limit(&state).await?;
+    let node_id = parse_sender(&headers)?;
+    let now = now_millis_pub();
+    let mut ledger = state.ledger.lock().await;
+    let grant = ledger
+        .grant_welcome_loan(node_id, &req.bucket, now)
+        .map_err(|e| {
+            let status = match e {
+                WelcomeLoanError::AlreadyHasBalance => StatusCode::CONFLICT,
+                WelcomeLoanError::SunsetReached => StatusCode::GONE,
+                WelcomeLoanError::SybilCeiling => StatusCode::TOO_MANY_REQUESTS,
+            };
+            let code = match e {
+                WelcomeLoanError::AlreadyHasBalance => "already_has_balance",
+                WelcomeLoanError::SunsetReached => "sunset_reached",
+                WelcomeLoanError::SybilCeiling => "sybil_ceiling",
+            };
+            (
+                status,
+                serde_json::json!({
+                    "error": {
+                        "type": "welcome_loan_denied",
+                        "code": code,
+                        "message": e.to_string(),
+                    }
+                })
+                .to_string(),
+            )
+        })?;
+    Ok(Json(ClaimWelcomeResponse::from(grant)))
+}

--- a/docs/phase-21-stake-enforcement.md
+++ b/docs/phase-21-stake-enforcement.md
@@ -60,25 +60,54 @@ Three waves:
 This wave is strictly additive. Existing nodes upgrade with zero
 behavioural change (gate stays off) until the operator opts in.
 
-### Wave 2 — Welcome-loan counts as effective stake; flip the default
+### Wave 2 — Welcome-loan counts as effective stake; flip the default ✅ shipped
 
-Today, a fresh node with no stake hits the `BootstrapWindow` (10 TRM
-stakeless earn cap) and then must post real stake. A welcome loan
-(1,000 TRM at 0% for 72 h) exists separately and is intended to be
-the bootstrap path *after* the cap, but `can_provide_inference`
-doesn't currently consult loan state.
+Until Wave 2, a fresh node with no stake had only a 10 TRM stakeless
+window before the gate would refuse to serve. A welcome loan
+(1 000 TRM at 0 % for 72 h) was advertised in `lending.rs` constants
+but never materialised on the ledger — `can_provide_inference` did
+not consult any loan state. Wave 2 closes the gap end-to-end:
 
-Wave 2:
+- **New `WelcomeLoanGrant` type** + new
+  `ComputeLedger.welcome_loans: HashMap<NodeId, WelcomeLoanGrant>`
+  field. Tracks granted, expires-at-ms, repaid flag.
+- **New `ComputeLedger::grant_welcome_loan(node_id, bucket, now_ms)`**
+  performs the eligibility check (sunset epoch, no existing balance),
+  records the grant, inserts a zero-balance entry so the single-
+  grant-per-node rule fires for any retry, and bumps the Sybil
+  rate-limit window for the supplied bucket.
+- **`InferenceEligibility` gains a `WelcomeLoan` variant**. The
+  verdict order is now: real stake → previously-slashed →
+  **welcome loan (unrepaid, unexpired)** → bootstrap window → deny.
+- **`POST /v1/tirami/agent/claim-welcome`** (new endpoint). Body
+  carries an optional `bucket` for the Sybil window. Returns the
+  `WelcomeLoanGrant` (principal, granted_at_ms, expires_at_ms).
+  Reachable with a DID-issued bearer token from Phase 20 Wave 5,
+  so an autonomous agent can claim without admin scope.
+- **`PolicySpec` extended** — manifest now carries
+  `welcome_loan_amount_trm`, `welcome_loan_term_hours`, and
+  `welcome_loan_available` so an agent knows the bootstrap path
+  exists before its first inference call.
+- **`Config.stake_gate_enabled` default flipped to `true`.**
+  Fresh deploys now enforce stake-required mining out of the box.
+  The bootstrap window + welcome-loan auto-claim together cover
+  the legitimate-newcomer path; operators with custom flows that
+  pre-inflate contributions past the cap without staking can set
+  the flag back to `false` explicitly.
 
-- Extend `inference_eligibility` to recognise an active welcome
-  loan ≥ `MIN_PROVIDER_STAKE_TRM` as effective stake.
-- Add a `POST /v1/tirami/agent/claim-welcome` endpoint reachable
-  from a DID-issued session token (Phase 20 Wave 5), so an
-  autonomous agent can claim its own loan without admin scope.
-- **Flip `Config::stake_gate_enabled` default to `true`.** With
-  welcome-loan auto-claim in place, the gate has a real fallback
-  path for fresh joiners. Status Honesty in the README flips
-  this item from 🟡 to ✅.
+Error response shape on duplicate claim:
+
+```json
+{
+  "error": {
+    "type": "welcome_loan_denied",
+    "code": "already_has_balance" | "sunset_reached" | "sybil_ceiling",
+    "message": "..."
+  }
+}
+```
+
+Mapped to status codes 409 / 410 / 429 respectively.
 
 ### Wave 3 — Stake gate on the P2P trade-recording path
 


### PR DESCRIPTION
## Summary

Wave 1 shipped an opt-in stake gate. Wave 2 completes the **autonomous bootstrap path** and **flips the default to on**.

The missing piece was: a fresh joiner only had 10 TRM of stakeless grace, and the welcome loan (1,000 TRM × 72 h, advertised in constants for two phases) had no actual grant implementation. Wave 2 wires it end-to-end.

## What ships

### New types

\`\`\`rust
pub struct WelcomeLoanGrant { node_id, principal_trm, granted_at_ms, expires_at_ms, repaid }
pub enum WelcomeLoanError { AlreadyHasBalance, SunsetReached, SybilCeiling }
pub enum InferenceEligibility {
    Staked { … },
    WelcomeLoan { principal_trm, expires_at_ms },   // ← NEW
    BootstrapWindow { … },
}
\`\`\`

\`ComputeLedger.welcome_loans: HashMap<NodeId, WelcomeLoanGrant>\` (serialized).

### New ledger method

\`grant_welcome_loan(node_id, bucket, now_ms) -> Result<Grant, Error>\` — enforces sunset epoch, single-grant-per-node, updates Sybil rate limiter.

### New eligibility verdict order

1. Real stake ≥ \`MIN_PROVIDER_STAKE_TRM\` → \`Staked\`
2. \`PreviouslySlashed\` → \`Err\`
3. **Active welcome loan (unrepaid + unexpired)** → \`WelcomeLoan\` ← NEW
4. \`contributed < STAKELESS_EARN_CAP_TRM\` → \`BootstrapWindow\`
5. Else → \`Err(StakeRequired)\`

### New endpoint

| Method | Path | Purpose |
|---|---|---|
| POST | \`/v1/tirami/agent/claim-welcome\` | Autonomous claim; sender via X-Tirami-Node-Id |

Status codes: 200 (grant), 409 (already_has_balance), 410 (sunset_reached), 429 (sybil_ceiling).

### Manifest extension

\`PolicySpec\` gains:
\`\`\`json
{
  "stake_gate_enabled": true,
  "welcome_loan_amount_trm": 1000,
  "welcome_loan_term_hours": 72,
  "welcome_loan_available": true
}
\`\`\`

Plus \`claim_welcome_loan\` ActionDescriptor.

### Default flip ⚠️

**\`Config.stake_gate_enabled\` default is now \`true\`.** Fresh deploys enforce stake-required mining out of the box. A fresh node passes via the bootstrap window → claim welcome loan → eventually real stake.

Operators with custom flows that pre-inflate contributions past the cap without staking can opt out with \`stake_gate_enabled = false\`.

## Stacked on Wave 1

Base: \`phase-21/wave-1-stake-enforcement\` (PR #97). Merge order: #97 → this PR.

## What this PR does NOT do (Wave 3 deferral)

- **Stake check on the P2P gossip-receive path.** \`pipeline.rs\` still records incoming gossiped trades without consulting \`inference_eligibility\`. Wave 3.
- **Welcome-loan repayment automation** — the 72-hour term elapses naturally; explicit repayment is a Wave 3.5 / Phase 22 concern.
- **On-disk persistence of the welcome_loans map** — field is \`#[serde(default)]\` so existing snapshots remain loadable, but new grants ride the existing ledger snapshot pipeline only if the operator's setup includes it.

## Test plan

- [x] \`cargo test --workspace\` → **1,301 passed, 0 failed** (was 1,297 → +4 new; pre-existing Wave 1 tests still pass with the flipped default)
- [x] 4 integration tests (claim happy path; second claim → 409 \`already_has_balance\`; stake gate with active welcome loan passes inference past the cap; manifest exposes new policy + action)
- [x] **Live smoke** on \`tirami node --api-token t\`:
  - manifest reports \`stake_gate_enabled: true\` (default flipped), \`welcome_loan_amount_trm: 1000\`, \`welcome_loan_term_hours: 72\`, \`welcome_loan_available: true\`, action \`claim_welcome_loan\` present
  - \`POST /v1/tirami/agent/claim-welcome\` (with X-Tirami-Node-Id: cc…dd) → 200, principal_trm=1000, term=72 h
  - Duplicate claim → 409 \`already_has_balance\`

## Phase 21 progress

| Wave | Subject | Status |
|---|---|---|
| 1 | opt-in gate on HTTP path | ✅ #97 |
| 2 | welcome-loan-as-stake + flip default | ✅ **this** |
| 3 | gossip-receive enforcement | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)