### PR TITLE
feat(phase-21/wave-3): stake gate on the P2P gossip-receive path

### DIFF
--- a/crates/tirami-node/src/pipeline.rs
+++ b/crates/tirami-node/src/pipeline.rs
@@ -1,5 +1,8 @@
 use tirami_core::{Config, ModelManifest, NodeId, PipelineTopology};
-use tirami_ledger::{ComputeLedger, LoanRecord, LoanStatus, SignedTradeRecord, TradeRecord};
+use tirami_ledger::{
+    ComputeLedger, InferenceIneligible, LoanRecord, LoanStatus, SignedTradeRecord, StakingPool,
+    TradeRecord,
+};
 use tirami_net::{ClusterManager, ForgeTransport, GossipState};
 use tirami_proto::{
     Envelope, ErrorCode, ErrorMsg, InferenceRequest, LoanAccept, Payload, PipelineTopologyMsg,
@@ -389,11 +392,49 @@ impl PipelineCoordinator {
                         let gossip = gossip.clone();
                         let ledger = ledger.clone();
                         let ledger_path = ledger_path.clone();
+                        // Phase 21 Wave 3 — capture the staking pool +
+                        // gate flag so the spawned task can consult
+                        // `ComputeLedger::inference_eligibility` before
+                        // it records a remote-originated trade.
+                        let staking = staking_pool.clone();
+                        let stake_gate_enabled = config.stake_gate_enabled;
                         tokio::spawn(async move {
                             if let Some(signed) =
                                 tirami_net::gossip::handle_trade_gossip(&gossip, &trade_gossip).await
                             {
                                 let mut ledger = ledger.lock().await;
+                                // Phase 21 Wave 3 — gate the gossip-
+                                // receive path on the same eligibility
+                                // verdict the HTTP path enforces. Defense
+                                // in depth: the dual-sig already
+                                // validates the bilateral agreement, but
+                                // this keeps the local ledger free of
+                                // contribution-inflation from remote
+                                // providers this node's policy
+                                // considers ineligible (slashed, or
+                                // past the stakeless cap without stake
+                                // and without a welcome loan).
+                                //
+                                // Failure here only refuses the LOCAL
+                                // recording — the remote bilateral
+                                // agreement is unaffected.
+                                {
+                                    let staking_guard = staking.lock().await;
+                                    if let Err(ineligible) = check_gossip_trade_eligibility(
+                                        &ledger,
+                                        &staking_guard,
+                                        &signed.trade.provider,
+                                        now_millis(),
+                                        stake_gate_enabled,
+                                    ) {
+                                        tracing::warn!(
+                                            "Rejected gossip trade: provider {} is ineligible per local policy: {}",
+                                            signed.trade.provider.to_hex(),
+                                            ineligible
+                                        );
+                                        return;
+                                    }
+                                }
                                 // Phase 17 Wave 1.2 — route inbound gossip
                                 // through the signed path so nonce dedup
                                 // rejects replays of already-observed v2
@@ -1082,6 +1123,156 @@ fn now_millis() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+/// Phase 21 Wave 3 — does the local-policy stake gate allow the
+/// node to **record** an incoming gossiped trade?
+///
+/// This is a deliberately small wrapper around
+/// [`ComputeLedger::inference_eligibility`] so the gossip handler's
+/// behaviour is unit-testable in isolation from `tokio::spawn` /
+/// network setup. The semantics are intentionally local-only:
+///
+/// - `gate_enabled = false` → always `Ok(())`. Restores pre-Phase-21
+///   behaviour for operators that explicitly opt out.
+/// - `gate_enabled = true` → consult the verdict. `Ok` for Staked /
+///   WelcomeLoan / BootstrapWindow; `Err(InferenceIneligible)` for
+///   PreviouslySlashed / StakeRequired.
+///
+/// A denial here only refuses **local** recording; the dual-signed
+/// trade still stands as a bilateral agreement between the remote
+/// provider and consumer, and other nodes with different policies
+/// may still record it.
+pub(crate) fn check_gossip_trade_eligibility(
+    ledger: &ComputeLedger,
+    staking: &StakingPool,
+    provider: &NodeId,
+    now_ms: u64,
+    gate_enabled: bool,
+) -> Result<(), InferenceIneligible> {
+    if !gate_enabled {
+        return Ok(());
+    }
+    ledger
+        .inference_eligibility(provider, staking, now_ms)
+        .map(|_| ())
+}
+
+#[cfg(test)]
+mod gossip_gate_tests {
+    use super::*;
+    use tirami_ledger::{ComputeLedger, StakeDuration, StakingPool};
+
+    #[test]
+    fn gate_disabled_always_passes_even_for_slashed_provider() {
+        let mut ledger = ComputeLedger::new();
+        let staking = StakingPool::new();
+        let provider = NodeId([0xA1u8; 32]);
+        ledger.record_slash_event(provider.clone(), 0.3, 100, "collusion", 0);
+        assert!(
+            check_gossip_trade_eligibility(&ledger, &staking, &provider, 1_000, false).is_ok()
+        );
+    }
+
+    #[test]
+    fn gate_enabled_passes_fresh_provider_via_bootstrap_window() {
+        let ledger = ComputeLedger::new();
+        let staking = StakingPool::new();
+        let provider = NodeId([0xA2u8; 32]);
+        assert!(
+            check_gossip_trade_eligibility(&ledger, &staking, &provider, 1_000, true).is_ok()
+        );
+    }
+
+    #[test]
+    fn gate_enabled_rejects_previously_slashed_provider() {
+        let mut ledger = ComputeLedger::new();
+        let staking = StakingPool::new();
+        let provider = NodeId([0xA3u8; 32]);
+        ledger.record_slash_event(provider.clone(), 0.3, 100, "collusion", 0);
+        let verdict =
+            check_gossip_trade_eligibility(&ledger, &staking, &provider, 1_000, true);
+        assert_eq!(verdict, Err(InferenceIneligible::PreviouslySlashed));
+    }
+
+    #[test]
+    fn gate_enabled_passes_provider_with_active_welcome_loan_past_cap() {
+        // Provider with an active welcome loan AND past the
+        // stakeless cap. The HTTP-path test in api.rs covers the
+        // same case from the server-serving side; this exercise
+        // it from the gossip-receive side.
+        let mut ledger = ComputeLedger::new();
+        let staking = StakingPool::new();
+        let provider = NodeId([0xA4u8; 32]);
+        // Wall-clock now so the 72 h expiry is in the future.
+        let now = now_millis();
+        ledger.grant_welcome_loan(provider.clone(), "", now).expect("grant");
+        let cap_buster = TradeRecord {
+            provider: provider.clone(),
+            consumer: NodeId([0x77u8; 32]),
+            trm_amount: tirami_ledger::lending::STAKELESS_EARN_CAP_TRM + 1,
+            tokens_processed: 1,
+            timestamp: now,
+            model_id: "pump".into(),
+            flops_estimated: 0,
+            nonce: [0u8; 16],
+        };
+        ledger.execute_trade(&cap_buster);
+        assert!(
+            check_gossip_trade_eligibility(&ledger, &staking, &provider, now, true).is_ok(),
+            "active welcome loan should let the gate accept a past-cap provider"
+        );
+    }
+
+    #[test]
+    fn gate_enabled_rejects_past_cap_provider_without_stake_or_loan() {
+        // Seed a balance via the public API: grant a welcome loan
+        // (creates the balance entry), pump contributions past cap,
+        // then mark the loan repaid so the eligibility check falls
+        // through to StakeRequired.
+        let mut ledger = ComputeLedger::new();
+        let staking = StakingPool::new();
+        let provider = NodeId([0xA5u8; 32]);
+        let now = now_millis();
+        ledger.grant_welcome_loan(provider.clone(), "", now).expect("grant");
+        let cap_buster = TradeRecord {
+            provider: provider.clone(),
+            consumer: NodeId([0x77u8; 32]),
+            trm_amount: tirami_ledger::lending::STAKELESS_EARN_CAP_TRM + 1,
+            tokens_processed: 1,
+            timestamp: now,
+            model_id: "pump".into(),
+            flops_estimated: 0,
+            nonce: [0u8; 16],
+        };
+        ledger.execute_trade(&cap_buster);
+        // Flip the welcome loan to repaid so it no longer satisfies
+        // the gate. The remaining path is then StakeRequired.
+        if let Some(grant) = ledger.welcome_loans.get_mut(&provider) {
+            grant.repaid = true;
+        }
+        let verdict =
+            check_gossip_trade_eligibility(&ledger, &staking, &provider, now, true);
+        assert!(
+            matches!(verdict, Err(InferenceIneligible::StakeRequired { .. })),
+            "got {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn gate_enabled_accepts_staked_provider() {
+        use tirami_ledger::lending::MIN_PROVIDER_STAKE_TRM;
+        let ledger = ComputeLedger::new();
+        let mut staking = StakingPool::new();
+        let provider = NodeId([0xA6u8; 32]);
+        let now = now_millis();
+        staking
+            .stake(provider.clone(), MIN_PROVIDER_STAKE_TRM, StakeDuration::Days7, now)
+            .expect("stake ok");
+        assert!(
+            check_gossip_trade_eligibility(&ledger, &staking, &provider, now, true).is_ok()
+        );
+    }
 }
 
 async fn send_protocol_error(

--- a/docs/phase-21-stake-enforcement.md
+++ b/docs/phase-21-stake-enforcement.md
@@ -109,18 +109,66 @@ Error response shape on duplicate claim:
 
 Mapped to status codes 409 / 410 / 429 respectively.
 
-### Wave 3 — Stake gate on the P2P trade-recording path
+### Wave 3 — Stake gate on the P2P gossip-receive path ✅ shipped
 
-The Wave 1 / Wave 2 gate sits on the HTTP serving path. The P2P
-`broadcast_trade` / `handle_trade_gossip` path in `pipeline.rs` is
-where a gossiped trade from a remote provider lands locally. Wave 3
-adds the gate there too:
+Wave 1 + Wave 2 sit on the HTTP serving path. Wave 3 adds the same
+verdict to the P2P `Payload::TradeGossip` handler in
+`pipeline.rs`'s `run_seed` recv loop. The semantics are
+intentionally local-only:
 
-- When receiving a gossiped signed trade, also verify the provider
-  was eligible at the time of trade (per the receiver's view of
-  staking + slashing).
-- Reject the trade record if not — keeps the local ledger free of
-  inflation from Sybil-staked nodes elsewhere on the mesh.
+- A denied gossip trade refuses **local recording only**. The
+  dual-signed bilateral agreement between the remote provider and
+  consumer is unaffected; other nodes with different policy may
+  still record it.
+- The gate is conditional on `Config.stake_gate_enabled` (default
+  `true` since Wave 2). Operators that explicitly opted out keep
+  the pre-Phase-21 permissive gossip behaviour.
+
+Implementation: a new pure helper
+`pipeline::check_gossip_trade_eligibility` wraps
+`ComputeLedger::inference_eligibility` and is consulted before
+`execute_signed_trade` runs on a gossip-received signed trade:
+
+```rust
+pub(crate) fn check_gossip_trade_eligibility(
+    ledger: &ComputeLedger,
+    staking: &StakingPool,
+    provider: &NodeId,
+    now_ms: u64,
+    gate_enabled: bool,
+) -> Result<(), InferenceIneligible>
+```
+
+A denial logs at `WARN` level with the provider's hex id + the
+reason; the trade is dropped silently from the perspective of the
+gossip helper. The wire-level signature verification + nonce dedup
+that the existing path already does run *after* the gate, so a
+malformed or replayed trade still gets caught by those layers.
+
+**Verdict matrix at the gossip-receive boundary (gate_enabled = true)**:
+
+| Provider state | Verdict | Recorded locally? |
+|---|---|---|
+| Staked ≥ MIN_PROVIDER_STAKE_TRM | Ok(Staked) | yes |
+| Active welcome loan (unrepaid, unexpired) | Ok(WelcomeLoan) | yes |
+| Stakeless cap not yet reached | Ok(BootstrapWindow) | yes |
+| Previously slashed | Err(PreviouslySlashed) | **no** |
+| Past cap, no stake, no loan | Err(StakeRequired) | **no** |
+
+## Phase 21 closing summary
+
+After Wave 3, the stake-required mining property the README
+advertised as 🟡 *scaffolded* in Wave 4 is now 🟢 *enforced* across
+both the HTTP serving path and the P2P gossip-receive path. A
+single eligibility predicate
+(`ComputeLedger::inference_eligibility`) is the source of truth;
+both ingress paths consult it before recording.
+
+What this Phase explicitly does NOT do (Phase 22 territory):
+- zkML real backends (`ezkl` / `risc0`).
+- NIP-90 Schnorr signing for cross-mesh advertisements.
+- Welcome-loan auto-repayment.
+- Portable reputation receipts across DID migrations.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 21 Wave 3 — final wave. Adds the same stake-required mining verdict (Wave 1 + Wave 2's \`ComputeLedger::inference_eligibility\`) to the **P2P gossip-receive path** so a single eligibility predicate is now authoritative across both ingress paths.

Where the gate fires
====================

\`pipeline.rs::run_seed\`, \`Payload::TradeGossip\` handler. Before calling \`execute_signed_trade\` on an incoming gossiped trade, the spawned task consults the local-policy verdict on the trade's **provider** (not the consumer — they're the one earning TRM that we're being asked to record). A denial is logged at WARN level and the trade is dropped silently from this node's view.

Local-only semantics
====================

A denial here refuses **local recording only**:
- the dual-signed bilateral agreement between the remote provider and consumer stands;
- other nodes with different policy may still record the trade;
- the existing signature verification + nonce dedup at the gossip-helper layer is unchanged.

This is defense-in-depth: each node enforces its own view of eligibility on what it ledgers, without claiming consensus authority over the network.

New pure helper for testability
================================

\`\`\`rust
pub(crate) fn check_gossip_trade_eligibility(
    ledger: &ComputeLedger,
    staking: &StakingPool,
    provider: &NodeId,
    now_ms: u64,
    gate_enabled: bool,
) -> Result<(), InferenceIneligible>
\`\`\`

When \`gate_enabled = false\` returns Ok unconditionally (restores pre-Phase-21 permissive behaviour for operators that opted out). When \`true\` delegates to \`inference_eligibility\` and maps the verdict to Ok / Err.

Stacked on Wave 2
=================

Base: \`phase-21/wave-2-welcome-loan-stake\` (PR #98). Merge order: #97 → #98 → this PR.

Test plan
=========

- [x] \`cargo test --workspace\` → **1,307 passed, 0 failed** (was 1,301 → +6 new)
- [x] 6 unit tests on the gate helper covering the full verdict matrix:
  - gate disabled always passes (even for slashed providers)
  - gate enabled + fresh provider via bootstrap window → ok
  - gate enabled + previously-slashed → \`PreviouslySlashed\`
  - gate enabled + active welcome loan past cap → ok
  - gate enabled + repaid loan past cap → \`StakeRequired\`
  - gate enabled + real stake ≥ floor → \`Staked\`

Phase 21 complete
=================

| Wave | Subject | Status |
|---|---|---|
| 1 | opt-in HTTP gate + structured verdict | ✅ #97 |
| 2 | welcome-loan-as-stake + flip default | ✅ #98 |
| 3 | gossip-receive parity | ✅ **this** |

The stake-required mining property that the public README flagged as 🟡 *scaffolded* in Phase 20 Wave 4 is now 🟢 *enforced* across both ingress paths. The next round of 🟡 → 🟢 work is Phase 22 (zkML real backends, NIP-90 Schnorr signing, welcome-loan repayment, portable reputation receipts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)