### PR TITLE
feat(phase-22/wave-1): NIP-90 Schnorr signing for Nostr publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5298,6 +5298,7 @@ dependencies = [
  "hmac",
  "prometheus",
  "rand 0.8.5",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ sha2 = "0.10"
 # stable. Pinned to the latest stable line.
 chacha20poly1305 = "0.10"
 argon2 = "0.5"
+# Phase 22 Wave 1 — BIP-340 Schnorr signatures for NIP-01 Nostr event
+# signing. Pinned to 0.29 to match the version `ldk-node` already
+# pulls in transitively (avoids two copies of the native libsecp256k1).
+secp256k1 = { version = "0.29", features = ["rand", "global-context"] }
 
 # Bitcoin Lightning
 ldk-node = "0.4"

--- a/crates/tirami-ledger/Cargo.toml
+++ b/crates/tirami-ledger/Cargo.toml
@@ -27,3 +27,6 @@ tokio-tungstenite = { workspace = true }
 futures-util = { workspace = true }
 prometheus = { workspace = true }
 bitcoin = { workspace = true }
+# Phase 22 Wave 1 — BIP-340 Schnorr signatures for NIP-01 Nostr
+# event signing in `nostr::NostrIdentity`.
+secp256k1 = { workspace = true }

--- a/crates/tirami-ledger/src/agora.rs
+++ b/crates/tirami-ledger/src/agora.rs
@@ -243,6 +243,12 @@ impl Nip90Publisher {
     /// `relay_url` defaults to `agora_relay::DEFAULT_RELAY_URL` if `None`.
     /// Returns `Ok(())` on relay acceptance, or `Err(AgoraError::RelayError(...))` on
     /// connection failure, timeout, or relay rejection.
+    ///
+    /// ⚠️ Wave-1 caveat: this path historically built the event
+    /// **unsigned** — a real Nostr relay rejects unsigned events.
+    /// Use [`Self::publish_signed_advertisement`] (Phase 22 Wave 1)
+    /// to produce a BIP-340-signed event that a public relay will
+    /// accept.
     pub async fn publish_advertisement(
         &self,
         advertisement: &ProviderAdvertisement,
@@ -252,6 +258,31 @@ impl Nip90Publisher {
         let event = self.build_advertisement_event(advertisement)?;
         let url = relay_url.unwrap_or(crate::agora_relay::DEFAULT_RELAY_URL);
         crate::agora_relay::publish_event(url, &event, timeout_sec).await
+    }
+
+    /// Phase 22 Wave 1 — build, **sign**, and publish a NIP-90
+    /// kind-31990 advertisement.
+    ///
+    /// `signer` is a [`crate::nostr::NostrIdentity`] — the secp256k1
+    /// keypair scoped to Nostr publishing. The signer's x-only
+    /// pubkey overrides whatever was supplied in
+    /// `advertisement.node_pubkey_hex` so the event id and signature
+    /// chain match the wire format relays expect.
+    ///
+    /// Returns `Ok(())` on relay acceptance.
+    pub async fn publish_signed_advertisement(
+        &self,
+        advertisement: &ProviderAdvertisement,
+        signer: &crate::nostr::NostrIdentity,
+        relay_url: Option<&str>,
+        timeout_sec: u64,
+    ) -> Result<(), AgoraError> {
+        let unsigned = self.build_advertisement_event(advertisement)?;
+        let signed = signer
+            .sign_event(unsigned)
+            .map_err(|e| AgoraError::Serialization(format!("nostr sign: {e}")))?;
+        let url = relay_url.unwrap_or(crate::agora_relay::DEFAULT_RELAY_URL);
+        crate::agora_relay::publish_event(url, &signed, timeout_sec).await
     }
 
     /// Build a NIP-90 kind 5050 job request event.
@@ -412,5 +443,41 @@ mod tests {
         assert_eq!(tier_label(ModelTier::Medium), "medium");
         assert_eq!(tier_label(ModelTier::Large), "large");
         assert_eq!(tier_label(ModelTier::Frontier), "frontier");
+    }
+
+    // -------------------------------------------------------------
+    // Phase 22 Wave 1 — Schnorr-signed advertisement integration
+    // -------------------------------------------------------------
+
+    #[test]
+    fn signed_advertisement_event_passes_nostr_verification() {
+        use crate::nostr::{verify_event, NostrIdentity};
+        let publisher = Nip90Publisher;
+        let signer = NostrIdentity::generate();
+        let ad = ProviderAdvertisement {
+            node_pubkey_hex: example_pubkey(),
+            models: vec!["qwen3-8b".into()],
+            tier: ModelTier::Medium,
+            trm_per_token: 3,
+            reputation: 0.85,
+            accepted_payment: vec!["cu".into()],
+            relays: vec!["wss://relay.test".into()],
+        };
+        // Build the unsigned event (this is what
+        // `publish_signed_advertisement` does internally) and sign it.
+        let event = publisher.build_advertisement_event(&ad).expect("build");
+        let signed = signer.sign_event(event).expect("sign");
+        // The signed event must round-trip through the verifier — that
+        // proves the same payload that hits the wire is BIP-340 valid.
+        verify_event(&signed).expect("verify must pass");
+        // The signer's pubkey is now the `pubkey` field, not the
+        // advertisement's `node_pubkey_hex` (which is the agent's
+        // Ed25519 identity).
+        let obj = signed.as_object().expect("obj");
+        assert_eq!(obj["pubkey"].as_str().unwrap(), signer.pubkey_hex());
+        assert_eq!(
+            obj["kind"].as_u64().unwrap(),
+            u64::from(kinds::HANDLER_ADVERTISEMENT)
+        );
     }
 }

--- a/crates/tirami-ledger/src/lib.rs
+++ b/crates/tirami-ledger/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fork;
 pub mod kani_proofs;
 pub mod sybil;
 pub mod metrics;
+pub mod nostr;
 pub mod peer_registry;
 pub mod referral;
 pub mod safety;
@@ -71,3 +72,4 @@ pub use sybil::{
     WelcomeLoanLimiter, WelcomeLoanLimiterConfig, DEFAULT_MAX_PER_BUCKET_PER_WINDOW,
     DEFAULT_WELCOME_WINDOW_MS, STAKED_THRESHOLD_MULTIPLIER,
 };
+pub use nostr::{verify_event as verify_nostr_event, NostrError, NostrIdentity};

--- a/crates/tirami-ledger/src/nostr.rs
+++ b/crates/tirami-ledger/src/nostr.rs
@@ -1,0 +1,350 @@
+//! Phase 22 Wave 1 — NIP-01 Schnorr event signing.
+//!
+//! Nostr (NIP-01) requires events to be signed with **Schnorr / BIP-340**
+//! over secp256k1, not the Ed25519 Tirami uses everywhere else for its
+//! own signed trades. This module ships the minimum primitive needed to
+//! make `Nip90Publisher::build_advertisement_event` produce events that
+//! a real Nostr relay will accept.
+//!
+//! Surface:
+//!
+//! - [`NostrIdentity`] — a secp256k1 keypair distinct from any
+//!   Ed25519 NodeId / DID. Exposes the BIP-340 x-only pubkey (32 bytes
+//!   of hex) that goes into the `pubkey` field of every NIP-01 event.
+//! - [`NostrIdentity::sign_event`] — takes a partially-built event
+//!   (with `kind`, `created_at`, `tags`, `content` set, but no `id`,
+//!   `pubkey`, or `sig`), computes the NIP-01 canonical event id,
+//!   signs it, and returns a complete JSON object.
+//! - [`NostrError`] — typed failure surface.
+//!
+//! What this module deliberately does NOT do:
+//!
+//! - It does not generate, persist, or migrate `NostrIdentity` keys
+//!   across nodes. Wave 1 builds the cryptographic primitive; an
+//!   identity-management surface (similar to Phase 20 Wave 4's
+//!   `AgentIdentity`) is a follow-up.
+//! - It does not implement Nostr verification of incoming events
+//!   beyond what `secp256k1::Secp256k1::verify_schnorr` provides.
+
+use secp256k1::rand::rngs::OsRng;
+use secp256k1::schnorr::Signature;
+use secp256k1::{Keypair, Message, Secp256k1, SecretKey, XOnlyPublicKey};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Errors from [`NostrIdentity`] operations.
+#[derive(Debug, Error)]
+pub enum NostrError {
+    #[error("malformed event JSON: {0}")]
+    EventShape(&'static str),
+    #[error("BIP-340 signature error: {0}")]
+    Signature(String),
+    #[error("BIP-340 verify failed: {0}")]
+    Verify(String),
+    #[error("hex decode failed: {0}")]
+    Hex(String),
+}
+
+/// A secp256k1 keypair scoped to Nostr publishing.
+///
+/// Separate from the Tirami node's Ed25519 [`NodeId`](crate::NodeId) and
+/// from any [`AgentIdentity`](https://docs.rs/tirami-mind) DID. A node
+/// that wants to advertise on Nostr generates one of these; the rest
+/// of the protocol (trades, gossip, etc.) is unaffected.
+pub struct NostrIdentity {
+    keypair: Keypair,
+}
+
+impl NostrIdentity {
+    /// Generate a fresh keypair using `OsRng`.
+    pub fn generate() -> Self {
+        let secp = Secp256k1::new();
+        let keypair = Keypair::new(&secp, &mut OsRng);
+        Self { keypair }
+    }
+
+    /// Reconstruct from a 32-byte secret key.
+    pub fn from_secret_bytes(secret: &[u8; 32]) -> Result<Self, NostrError> {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(secret)
+            .map_err(|e| NostrError::Signature(e.to_string()))?;
+        let keypair = Keypair::from_secret_key(&secp, &sk);
+        Ok(Self { keypair })
+    }
+
+    /// 32-byte BIP-340 x-only public key.
+    pub fn x_only_pubkey(&self) -> XOnlyPublicKey {
+        self.keypair.x_only_public_key().0
+    }
+
+    /// Hex-encoded x-only pubkey — this is what shows up in the
+    /// `pubkey` field of every signed Nostr event published by this
+    /// identity.
+    pub fn pubkey_hex(&self) -> String {
+        hex::encode(self.x_only_pubkey().serialize())
+    }
+
+    /// 32-byte secret key (sensitive — do not log).
+    pub fn secret_bytes(&self) -> [u8; 32] {
+        self.keypair.secret_bytes()
+    }
+
+    /// Sign a partially-built Nostr event.
+    ///
+    /// The input must already have `kind`, `created_at`, `tags`, and
+    /// `content` set. This method computes the canonical
+    /// [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)
+    /// event id, signs it with BIP-340 Schnorr, and returns a complete
+    /// event object (`id`, `pubkey`, `created_at`, `kind`, `tags`,
+    /// `content`, `sig`) ready to ship over `agora_relay::publish_event`.
+    pub fn sign_event(&self, mut event: Value) -> Result<Value, NostrError> {
+        // 1. Replace / set the `pubkey` field with our x-only pubkey.
+        let pubkey_hex = self.pubkey_hex();
+        let obj = event
+            .as_object_mut()
+            .ok_or(NostrError::EventShape("event must be a JSON object"))?;
+        obj.insert("pubkey".into(), Value::String(pubkey_hex.clone()));
+
+        // 2. Compute the canonical event id per NIP-01: sha256 of
+        //    the JSON serialisation of the array
+        //    [0, pubkey, created_at, kind, tags, content].
+        let created_at = obj
+            .get("created_at")
+            .and_then(|v| v.as_u64())
+            .ok_or(NostrError::EventShape("missing or non-u64 created_at"))?;
+        let kind = obj
+            .get("kind")
+            .and_then(|v| v.as_u64())
+            .ok_or(NostrError::EventShape("missing or non-u64 kind"))?;
+        let tags = obj
+            .get("tags")
+            .cloned()
+            .ok_or(NostrError::EventShape("missing tags"))?;
+        let content = obj
+            .get("content")
+            .and_then(|v| v.as_str())
+            .ok_or(NostrError::EventShape("missing or non-string content"))?
+            .to_string();
+
+        let serialized = Value::Array(vec![
+            Value::Number(0u64.into()),
+            Value::String(pubkey_hex.clone()),
+            Value::Number(created_at.into()),
+            Value::Number(kind.into()),
+            tags,
+            Value::String(content),
+        ]);
+        let canonical = serde_json::to_string(&serialized)
+            .map_err(|e| NostrError::EventShape(Box::leak(e.to_string().into_boxed_str())))?;
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.as_bytes());
+        let id_bytes: [u8; 32] = hasher.finalize().into();
+        let id_hex = hex::encode(id_bytes);
+        obj.insert("id".into(), Value::String(id_hex.clone()));
+
+        // 3. Sign the id with BIP-340 Schnorr.
+        let secp = Secp256k1::new();
+        let msg = Message::from_digest(id_bytes);
+        let sig = secp.sign_schnorr_no_aux_rand(&msg, &self.keypair);
+        obj.insert(
+            "sig".into(),
+            Value::String(hex::encode(sig.serialize())),
+        );
+
+        Ok(event)
+    }
+}
+
+/// Verify a signed Nostr event in isolation. Returns `Ok(())` on
+/// success or [`NostrError::Verify`] on any failure (malformed
+/// pubkey, id mismatch, signature mismatch).
+///
+/// Provided as a free function so verifiers don't need to hold a
+/// [`NostrIdentity`].
+pub fn verify_event(event: &Value) -> Result<(), NostrError> {
+    let obj = event
+        .as_object()
+        .ok_or(NostrError::EventShape("event must be a JSON object"))?;
+
+    let pubkey_hex = obj
+        .get("pubkey")
+        .and_then(|v| v.as_str())
+        .ok_or(NostrError::EventShape("missing pubkey"))?;
+    let id_hex = obj
+        .get("id")
+        .and_then(|v| v.as_str())
+        .ok_or(NostrError::EventShape("missing id"))?;
+    let sig_hex = obj
+        .get("sig")
+        .and_then(|v| v.as_str())
+        .ok_or(NostrError::EventShape("missing sig"))?;
+
+    // Recompute the id from the event content and compare to the
+    // advertised id — catches tampering with the body that left
+    // the sig untouched.
+    let created_at = obj
+        .get("created_at")
+        .and_then(|v| v.as_u64())
+        .ok_or(NostrError::EventShape("missing or non-u64 created_at"))?;
+    let kind = obj
+        .get("kind")
+        .and_then(|v| v.as_u64())
+        .ok_or(NostrError::EventShape("missing or non-u64 kind"))?;
+    let tags = obj
+        .get("tags")
+        .cloned()
+        .ok_or(NostrError::EventShape("missing tags"))?;
+    let content = obj
+        .get("content")
+        .and_then(|v| v.as_str())
+        .ok_or(NostrError::EventShape("missing or non-string content"))?
+        .to_string();
+
+    let serialized = Value::Array(vec![
+        Value::Number(0u64.into()),
+        Value::String(pubkey_hex.to_string()),
+        Value::Number(created_at.into()),
+        Value::Number(kind.into()),
+        tags,
+        Value::String(content),
+    ]);
+    let canonical = serde_json::to_string(&serialized)
+        .map_err(|_| NostrError::EventShape("event reserialise failed"))?;
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let computed_id: [u8; 32] = hasher.finalize().into();
+    let computed_id_hex = hex::encode(computed_id);
+    if computed_id_hex != id_hex {
+        return Err(NostrError::Verify(format!(
+            "id mismatch (advertised {} vs recomputed {})",
+            id_hex, computed_id_hex
+        )));
+    }
+
+    // Decode the pubkey and signature, then verify.
+    let pk_bytes =
+        hex::decode(pubkey_hex).map_err(|e| NostrError::Hex(format!("pubkey: {e}")))?;
+    let pk = XOnlyPublicKey::from_slice(&pk_bytes)
+        .map_err(|e| NostrError::Verify(format!("pubkey decode: {e}")))?;
+    let sig_bytes = hex::decode(sig_hex).map_err(|e| NostrError::Hex(format!("sig: {e}")))?;
+    if sig_bytes.len() != 64 {
+        return Err(NostrError::Verify(format!(
+            "sig must be 64 bytes, got {}",
+            sig_bytes.len()
+        )));
+    }
+    let mut sig_arr = [0u8; 64];
+    sig_arr.copy_from_slice(&sig_bytes);
+    let sig = Signature::from_slice(&sig_arr)
+        .map_err(|e| NostrError::Verify(format!("sig parse: {e}")))?;
+
+    let secp = Secp256k1::verification_only();
+    let msg = Message::from_digest(computed_id);
+    secp.verify_schnorr(&sig, &msg, &pk)
+        .map_err(|e| NostrError::Verify(format!("schnorr verify: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_event() -> Value {
+        json!({
+            "kind": 31990u64,
+            "created_at": 1_700_000_000u64,
+            "tags": [
+                ["d", "forge-handler"],
+                ["model", "qwen2.5:0.5b"]
+            ],
+            "content": "{\"tier\":\"small\"}",
+        })
+    }
+
+    #[test]
+    fn pubkey_is_32_byte_hex() {
+        let id = NostrIdentity::generate();
+        let hex = id.pubkey_hex();
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn sign_event_attaches_id_pubkey_sig() {
+        let id = NostrIdentity::generate();
+        let signed = id.sign_event(sample_event()).expect("sign ok");
+        let obj = signed.as_object().expect("obj");
+        let id_field = obj["id"].as_str().expect("id");
+        assert_eq!(id_field.len(), 64);
+        assert_eq!(obj["pubkey"].as_str().expect("pubkey").len(), 64);
+        assert_eq!(obj["sig"].as_str().expect("sig").len(), 128);
+    }
+
+    #[test]
+    fn sign_then_verify_round_trip() {
+        let id = NostrIdentity::generate();
+        let signed = id.sign_event(sample_event()).expect("sign ok");
+        verify_event(&signed).expect("verify ok");
+    }
+
+    #[test]
+    fn tampered_content_fails_verification() {
+        let id = NostrIdentity::generate();
+        let mut signed = id.sign_event(sample_event()).expect("sign ok");
+        // Mutate the content field without re-signing.
+        signed["content"] = Value::String("evil-payload".into());
+        let err = verify_event(&signed).expect_err("must fail");
+        // Either the recomputed id doesn't match (caught early) OR
+        // the schnorr verify fails outright; both manifest as
+        // `NostrError::Verify`.
+        assert!(matches!(err, NostrError::Verify(_)));
+    }
+
+    #[test]
+    fn tampered_signature_fails_verification() {
+        let id = NostrIdentity::generate();
+        let mut signed = id.sign_event(sample_event()).expect("sign ok");
+        // Flip the first byte of the sig.
+        let sig_str = signed["sig"].as_str().unwrap().to_string();
+        let mut bytes = hex::decode(&sig_str).unwrap();
+        bytes[0] ^= 0x01;
+        signed["sig"] = Value::String(hex::encode(bytes));
+        let err = verify_event(&signed).expect_err("must fail");
+        assert!(matches!(err, NostrError::Verify(_)));
+    }
+
+    #[test]
+    fn substituted_pubkey_fails_verification() {
+        // Build a valid event with identity A, then swap its pubkey
+        // for identity B's. The id derives from pubkey, so the
+        // recomputed id won't match; verification must fail.
+        let alice = NostrIdentity::generate();
+        let bob = NostrIdentity::generate();
+        let mut signed = alice.sign_event(sample_event()).expect("sign ok");
+        signed["pubkey"] = Value::String(bob.pubkey_hex());
+        let err = verify_event(&signed).expect_err("must fail");
+        assert!(matches!(err, NostrError::Verify(_)));
+    }
+
+    #[test]
+    fn round_trip_from_secret_bytes_preserves_pubkey() {
+        let original = NostrIdentity::generate();
+        let secret = original.secret_bytes();
+        let restored = NostrIdentity::from_secret_bytes(&secret).expect("ok");
+        assert_eq!(original.pubkey_hex(), restored.pubkey_hex());
+    }
+
+    /// Two different identities must produce different ids for the
+    /// same event body — the pubkey is part of the id pre-image, so
+    /// any divergence in identity propagates into the id.
+    #[test]
+    fn different_identities_produce_different_event_ids() {
+        let a = NostrIdentity::generate();
+        let b = NostrIdentity::generate();
+        let sa = a.sign_event(sample_event()).expect("ok");
+        let sb = b.sign_event(sample_event()).expect("ok");
+        assert_ne!(sa["id"], sb["id"]);
+    }
+}

--- a/docs/phase-22-residual-yellow.md
+++ b/docs/phase-22-residual-yellow.md
@@ -1,0 +1,67 @@
+# Phase 22 — closing the residual 🟡 items
+
+> Phase 21 turned **stake-required mining** from 🟡 *scaffolded* into
+> ✅ *enforced* on both the HTTP serving path and the P2P
+> gossip-receive path. The README's Status Honesty section still
+> carries four 🟡 markers; Phase 22 is the staging ground for
+> closing them one at a time.
+
+Date: 2026-05-17.
+
+## Status Honesty items still 🟡 entering Phase 22
+
+1. **NIP-90 publish** — the WebSocket transport (`agora_relay::publish_event`) and the event builder (`Nip90Publisher::build_advertisement_event`) have existed since Phase 9, but the events they produced were **unsigned** — NIP-01 requires a BIP-340 Schnorr signature, and a real Nostr relay drops unsigned events.
+2. **zkML real backends** — `tirami-zkml-bench` carries only a `MockBackend`. `ezkl` / `risc0` integration is multi-week scope.
+3. **Welcome-loan repayment / settlement** — the Phase 21 Wave 2 grant has an `expires_at_ms` field but no automatic settlement at expiry. Eligibility naturally falls through, but the grant record lingers in memory.
+4. **PersonalAgent.wallet ↔ AgentIdentity link** — today the wallet still points at the machine's Ed25519 NodeId. Migrating it to derive from a Phase-20-Wave-4 `AgentIdentity` would let an agent move across machines without losing access to its accumulated TRM in `/v1/tirami/balance`.
+
+Phase 22 picks them off one wave at a time.
+
+---
+
+## Wave 1 — NIP-90 Schnorr signing ✅ shipped
+
+### What changed
+
+- **New workspace dep** `secp256k1 = "0.29"` (matches the version `ldk-node` already pulls in transitively — no second copy of the native libsecp256k1). Features: `rand` for keypair generation, `global-context` so the `Secp256k1` ctx can be shared.
+- **New module `tirami_ledger::nostr`**:
+  - `NostrIdentity` — secp256k1 keypair scoped to Nostr publishing. **Distinct** from the Ed25519 node identity AND from the Phase-20-Wave-4 `AgentIdentity` DID; a node that wants to advertise on Nostr generates one of these and the rest of the protocol is unaffected.
+  - `NostrIdentity::sign_event(event: Value) -> Result<Value, NostrError>` — takes a partially-built NIP-01 event (with `kind`, `created_at`, `tags`, `content` set), computes the canonical event id per NIP-01 (`sha256(json([0, pubkey, created_at, kind, tags, content]))`), signs the id with BIP-340 Schnorr, and returns a complete event ready to ship over `agora_relay::publish_event`.
+  - `verify_event(&Value) -> Result<(), NostrError>` — free function that re-derives the id from the event body and verifies the BIP-340 signature. Lets relays / consumers verify without holding a `NostrIdentity` instance.
+- **`Nip90Publisher::publish_signed_advertisement`** — new method that wraps `build_advertisement_event` → `NostrIdentity::sign_event` → `agora_relay::publish_event` in one call. The legacy `publish_advertisement` is kept (with a 🟡 caveat in its rustdoc) so existing call sites compile, but new code should prefer the signed variant.
+
+### Verdict matrix
+
+| Operation | Pre-Wave-1 | Post-Wave-1 |
+|---|---|---|
+| Build event JSON | ✅ | ✅ |
+| Send over WebSocket | ✅ | ✅ |
+| Pass NIP-01 signature check at the relay | ❌ (silently dropped) | ✅ |
+
+### Tests
+
+9 new tests, all green:
+- Unit tests on `NostrIdentity` (8): pubkey-is-32-byte-hex; sign-event-attaches-id-pubkey-sig; sign→verify round-trip; tampered content fails verification; tampered signature fails verification; substituted pubkey fails verification; round-trip from secret bytes preserves pubkey; different identities yield different event ids for the same body.
+- Integration test on `Nip90Publisher` (1): a signed advertisement event passes `verify_event` AND its `pubkey` field reflects the signer (not the agent's Ed25519 `node_pubkey_hex` from the advertisement payload).
+
+Workspace: **1,316 passed, 0 failed** (was 1,307 → +9 new).
+
+### What Wave 1 explicitly does NOT do
+
+- **Identity-management surface** for `NostrIdentity`. Wave 1 ships the cryptographic primitive only; persistent keys, export/import, and integration into `AppState` come in Wave 1.5.
+- **Operator HTTP endpoint** to trigger a `publish_signed_advertisement`. Library-level call exists; surfacing it via `POST /v1/tirami/agora/publish` is a follow-up.
+- **Cross-DID linkage**. The `did:tirami:<hex>` for the agent and the secp256k1 Nostr pubkey are separate identifiers by design — bridging them (e.g. via a self-signed NIP-39 identity proof) is its own scoping decision.
+
+---
+
+## Wave 2 — TBD
+
+Candidates in priority order:
+
+- **Welcome-loan settlement loop** (mechanical, bounded scope). Periodic task scans `welcome_loans` for expired grants and marks them as such; bonus: garbage-collects the map and records a small reputation event for any grant that produced zero serving activity during its 72-hour window.
+- **PersonalAgent wallet → AgentIdentity link**. Refactor `PersonalAgent.wallet: NodeId` so it can be derived from a loaded `AgentIdentity`. Backwards-compat important; needs careful migration of existing snapshots.
+- **`POST /v1/tirami/agora/publish`** — surfacing the Wave-1 primitive via HTTP so an autonomous agent can announce itself on a public Nostr relay. Adds an `AppState.nostr_identity: Arc<Mutex<Option<NostrIdentity>>>` slot.
+
+### Out of Phase 22 scope (Phase 23 / 24 territory)
+
+- **zkML real backends** (`ezkl` / `risc0`). Real proof-of-inference is the main remaining 🟡 → ✅ jump and warrants its own Phase. Likely a multi-PR effort spanning crate integration, proof-vs-trade plumbing, governance ratchet wiring, and per-model benchmark calibration.


### PR DESCRIPTION
## Summary

Phase 22 starts closing the residual 🟡 items the README's Status Honesty section has carried since Phase 9. Wave 1 closes the **NIP-90 publishing** gap.

Until this PR, \`Nip90Publisher::build_advertisement_event\` + \`agora_relay::publish_event\` produced **unsigned** Nostr events. NIP-01 mandates a BIP-340 Schnorr signature over secp256k1, and a real Nostr relay drops anything unsigned on receipt — so the protocol *advertised* a Nostr discovery surface that the implementation could not actually use against a public relay.

## What ships

### New workspace dep

\`\`\`
secp256k1 = "0.29"  with features = ["rand", "global-context"]
\`\`\`

Pinned to 0.29 to match the version \`ldk-node\` pulls in transitively — avoids two copies of the native libsecp256k1 in the binary.

### New \`tirami_ledger::nostr\` module

\`\`\`rust
pub struct NostrIdentity { /* secp256k1::Keypair */ }

impl NostrIdentity {
    pub fn generate() -> Self;
    pub fn from_secret_bytes(secret: &[u8; 32]) -> Result<Self, NostrError>;
    pub fn x_only_pubkey(&self) -> XOnlyPublicKey;
    pub fn pubkey_hex(&self) -> String;
    pub fn secret_bytes(&self) -> [u8; 32];
    pub fn sign_event(&self, event: Value) -> Result<Value, NostrError>;
}

pub fn verify_event(event: &Value) -> Result<(), NostrError>;
\`\`\`

\`sign_event\` takes a partially-built NIP-01 event (\`kind\`, \`created_at\`, \`tags\`, \`content\` set), computes the canonical event id per NIP-01 (\`sha256\` over the JSON serialisation of \`[0, pubkey, created_at, kind, tags, content]\`), signs the id with BIP-340 Schnorr, and returns a complete event ready to ship.

\`NostrIdentity\` is deliberately separate from the Ed25519 NodeId AND the Phase-20-Wave-4 \`AgentIdentity\` (did:tirami:<hex>) because the curves are different. Bridging them (NIP-39-style identity proofs) is Wave 2+.

### New \`Nip90Publisher::publish_signed_advertisement\`

One-call wrapper: build → sign → publish over the existing \`agora_relay\` WebSocket transport. The legacy \`publish_advertisement\` (unsigned) is kept so existing callers compile, with a 🟡 caveat in its rustdoc pointing new code at the signed variant.

## Verdict matrix

| Operation | Pre-Wave-1 | Post-Wave-1 |
|---|---|---|
| Build event JSON | ✅ | ✅ |
| Send over WebSocket | ✅ | ✅ |
| Pass NIP-01 signature check at the relay | ❌ (silently dropped) | ✅ |

## Stacked on Phase 21 Wave 3

Base: \`phase-21/wave-3-gossip-stake-gate\` (PR #99). Merge order: #92 → #93 → #94 → #95 → #96 → #97 → #98 → #99 → this PR.

## What this PR does NOT do

- **Identity-management surface** for \`NostrIdentity\` (persistence, export/import, \`AppState\` wiring). Wave 1.5.
- **\`POST /v1/tirami/agora/publish\` HTTP endpoint**. Library call is in place; HTTP surface is Wave 1.5.
- **Cross-DID linkage** (NIP-39 proof binding the secp256k1 Nostr pubkey to a did:tirami: identity). Wave 2+.
- **\`ezkl\` / \`risc0\` zkML backends**. Phase 23 / 24.

## Test plan

- [x] \`cargo test --workspace\` → **1,316 passed, 0 failed** (was 1,307 → +9 new)
- [x] 8 unit tests on \`NostrIdentity\` (pubkey shape / sign attaches id+pubkey+sig / sign→verify round-trip / tampered content fails verify / tampered sig fails verify / substituted pubkey fails verify / round-trip from secret_bytes preserves pubkey / different identities yield different event ids for same body)
- [x] 1 integration test on \`Nip90Publisher\`: signed advertisement event passes \`verify_event\` AND its \`pubkey\` field is the signer's (not the advertisement's Ed25519 node_pubkey_hex)
- [ ] Manual smoke against \`wss://relay.damus.io\` is deferred until Wave 1.5 wires the HTTP endpoint (avoids burning a real relay relationship on a draft surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)