### PR TITLE
feat(phase-23/wave-1): PersonalAgent.wallet rebinds to AgentIdentity DID

### DIFF
--- a/crates/tirami-mind/src/lib.rs
+++ b/crates/tirami-mind/src/lib.rs
@@ -35,5 +35,5 @@ pub use federated::{
 };
 pub use personal_agent::{
     AgentDecision, AgentPreferences, PersonalAgent, ServingRequest, TaskCostEstimate, TaskSize,
-    TickAction, TickContext,
+    TickAction, TickContext, WalletSource,
 };

--- a/crates/tirami-mind/src/personal_agent.rs
+++ b/crates/tirami-mind/src/personal_agent.rs
@@ -204,10 +204,30 @@ pub enum AgentDecision {
 /// Network I/O is NOT in this struct — the agent calls out to
 /// `tirami-node` handlers via the `AgentEnv` trait. This keeps
 /// the agent logic unit-testable without spinning up a full node.
+/// Phase 23 Wave 1 — provenance of the wallet `NodeId` held by a
+/// [`PersonalAgent`]. Lets clients tell from one glance whether
+/// trades are attributed to the machine's identity (default) or to a
+/// portable [`crate::AgentIdentity`] that survives node moves.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WalletSource {
+    /// Pre-Wave-23 default: wallet derives from the running node's
+    /// Ed25519 identity (the machine key in `~/.tirami/node.key`).
+    MachineNode,
+    /// Wave-23+: wallet rebound from a loaded `AgentIdentity` pubkey.
+    /// Earnings and budget state follow the DID across machines.
+    AgentIdentity,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersonalAgent {
     /// The Tirami node id this agent uses as its wallet.
     pub wallet: NodeId,
+    /// Phase 23 Wave 1 — provenance of [`Self::wallet`]. `#[serde(default)]`
+    /// keeps pre-Wave-23 snapshots loadable (they default to
+    /// `MachineNode`).
+    #[serde(default = "default_wallet_source")]
+    pub wallet_source: WalletSource,
     /// Spend budget for the current session.
     pub budget: TrmBudget,
     /// User-tunable preferences.
@@ -221,17 +241,53 @@ pub struct PersonalAgent {
     pub day_started_at_ms: u64,
 }
 
+fn default_wallet_source() -> WalletSource {
+    WalletSource::MachineNode
+}
+
 impl PersonalAgent {
     /// Construct a fresh agent with default preferences.
     pub fn new(wallet: NodeId, budget: TrmBudget, now_ms: u64) -> Self {
         Self {
             wallet,
+            wallet_source: WalletSource::MachineNode,
             budget,
             preferences: AgentPreferences::default(),
             spent_today_trm: 0,
             earned_today_trm: 0,
             day_started_at_ms: now_ms,
         }
+    }
+
+    /// Phase 23 Wave 1 — rebind the wallet to an
+    /// [`crate::AgentIdentity`]'s pubkey.
+    ///
+    /// Called from the `AppState` plumbing when an `AgentIdentity` is
+    /// `init`-ed or `import`-ed. The wallet flips to the agent's
+    /// 32-byte Ed25519 public key (the same value behind
+    /// `did:tirami:<hex>`), and the source discriminator records
+    /// that the trade attribution now follows the DID rather than
+    /// the machine key.
+    ///
+    /// Idempotent: rebinding to the same pubkey is a no-op. Rebinding
+    /// to a different pubkey resets daily tallies — the previous
+    /// "today" was for a different economic actor.
+    pub fn rebind_wallet_from_agent_identity(
+        &mut self,
+        agent_public_key: [u8; 32],
+        now_ms: u64,
+    ) {
+        let new_wallet = NodeId(agent_public_key);
+        if self.wallet == new_wallet && self.wallet_source == WalletSource::AgentIdentity {
+            return;
+        }
+        self.wallet = new_wallet;
+        self.wallet_source = WalletSource::AgentIdentity;
+        // Today's tallies belong to whoever was holding the wallet
+        // until now. After a rebind they don't carry over.
+        self.spent_today_trm = 0;
+        self.earned_today_trm = 0;
+        self.day_started_at_ms = now_ms;
     }
 
     /// Construct with explicit preferences. Validates them first.
@@ -244,6 +300,7 @@ impl PersonalAgent {
         preferences.validate()?;
         Ok(Self {
             wallet,
+            wallet_source: WalletSource::MachineNode,
             budget,
             preferences,
             spent_today_trm: 0,

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -3848,6 +3848,11 @@ async fn forge_agent_status(
     Ok(Json(serde_json::json!({
         "configured": true,
         "wallet": agent.wallet.to_hex(),
+        // Phase 23 Wave 1 — provenance discriminator. Clients can
+        // tell at a glance whether trades attribute to the machine
+        // (`machine_node`) or a portable AgentIdentity
+        // (`agent_identity`).
+        "wallet_source": agent.wallet_source,
         "spent_today_trm": agent.spent_today_trm,
         "earned_today_trm": agent.earned_today_trm,
         "net_today_trm": agent.net_today_trm(),
@@ -7279,6 +7284,187 @@ mod tests {
             events.iter().any(|e| e["reason"] == "welcome-loan-default"),
             "no welcome-loan-default in {events:?}"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 23 Wave 1 — PersonalAgent.wallet ↔ AgentIdentity link
+    // ------------------------------------------------------------------
+
+    async fn get_agent_status(app: Router) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/agent/status")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        (status, serde_json::from_slice(&bytes).unwrap_or_default())
+    }
+
+    /// A fresh PersonalAgent without any AgentIdentity init must
+    /// report `wallet_source = "machine_node"` and a wallet equal to
+    /// the test-router's deterministic local NodeId.
+    #[tokio::test]
+    async fn agent_status_pre_identity_reports_machine_node_source() {
+        let agent_node_id = NodeId([0xAAu8; 32]);
+        let app = test_router_with_agent(Config::default(), Some(agent_at(agent_node_id.clone())));
+        let (status, body) = get_agent_status(app).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["configured"], true);
+        assert_eq!(body["wallet_source"], "machine_node");
+        assert_eq!(body["wallet"].as_str().unwrap(), agent_node_id.to_hex());
+    }
+
+    /// After `POST /v1/tirami/agent/identity/init`, the PersonalAgent's
+    /// wallet must flip to the new DID's pubkey AND the
+    /// `wallet_source` must report `agent_identity`.
+    #[tokio::test]
+    async fn agent_identity_init_rebinds_personal_agent_wallet() {
+        let app = test_router_with_agent(
+            Config::default(),
+            Some(agent_at(NodeId([0xAAu8; 32]))),
+        );
+        // Pre-init: wallet is the machine NodeId.
+        let (_, pre) = get_agent_status(app.clone()).await;
+        assert_eq!(pre["wallet_source"], "machine_node");
+        let pre_wallet = pre["wallet"].as_str().unwrap().to_string();
+
+        // Init identity.
+        let (status, init) = post_identity_init(app.clone(), Some("alice")).await;
+        assert_eq!(status, StatusCode::OK);
+        let did = init["did"].as_str().unwrap().to_string();
+        // The DID is "did:tirami:<64-hex-pk>"; the pk part is what the
+        // wallet should now reflect.
+        let did_pk = did.strip_prefix("did:tirami:").unwrap();
+
+        // Post-init: wallet rebound to the DID's pubkey.
+        let (_, post) = get_agent_status(app).await;
+        assert_eq!(post["wallet_source"], "agent_identity");
+        assert_eq!(post["wallet"].as_str().unwrap(), did_pk);
+        assert_ne!(post["wallet"], pre_wallet, "wallet should change");
+    }
+
+    /// Idempotent init must NOT re-flip the wallet (no churn on
+    /// daily tallies).
+    #[tokio::test]
+    async fn agent_identity_init_idempotent_preserves_rebound_wallet() {
+        let app = test_router_with_agent(
+            Config::default(),
+            Some(agent_at(NodeId([0xAAu8; 32]))),
+        );
+        let (_, init1) = post_identity_init(app.clone(), Some("alice")).await;
+        let did1 = init1["did"].as_str().unwrap().to_string();
+        let (_, init2) = post_identity_init(app.clone(), Some("bob")).await;
+        // Idempotent — same DID returned, display name not updated.
+        assert_eq!(init2["did"], did1);
+        // Wallet unchanged.
+        let (_, status) = get_agent_status(app).await;
+        let did_pk = did1.strip_prefix("did:tirami:").unwrap();
+        assert_eq!(status["wallet"].as_str().unwrap(), did_pk);
+        assert_eq!(status["wallet_source"], "agent_identity");
+    }
+
+    /// Import (replacing a previously-imported identity) must rebind
+    /// the wallet to the imported DID's pubkey.
+    #[tokio::test]
+    async fn agent_identity_import_rebinds_personal_agent_wallet() {
+        let app_a = test_router_with_agent(
+            Config::default(),
+            Some(agent_at(NodeId([0xAAu8; 32]))),
+        );
+        let (_, init_a) = post_identity_init(app_a.clone(), Some("alice")).await;
+        let did_a = init_a["did"].as_str().unwrap().to_string();
+        let (_, bundle) = post_identity_export(app_a, "passphrase-1234567").await;
+
+        // Move to a second node and import.
+        let app_b = test_router_with_agent(
+            Config::default(),
+            Some(agent_at(NodeId([0xBBu8; 32]))),
+        );
+        // Pre-import on B: wallet is the machine NodeId
+        // ([0; 32] for the test router), source = machine_node.
+        let (_, pre_b) = get_agent_status(app_b.clone()).await;
+        assert_eq!(pre_b["wallet_source"], "machine_node");
+        let (status, view) =
+            post_identity_import(app_b.clone(), "passphrase-1234567", bundle).await;
+        assert_eq!(status, StatusCode::OK, "import: {view}");
+        assert_eq!(view["did"], did_a);
+        // Post-import on B: wallet now matches A's DID pubkey.
+        let (_, post_b) = get_agent_status(app_b).await;
+        assert_eq!(post_b["wallet_source"], "agent_identity");
+        let did_pk = did_a.strip_prefix("did:tirami:").unwrap();
+        assert_eq!(post_b["wallet"].as_str().unwrap(), did_pk);
+    }
+
+    /// Init on a node with NO PersonalAgent configured is a clean
+    /// no-op for the wallet path. The init itself succeeds; the
+    /// rebind is silently skipped.
+    #[tokio::test]
+    async fn agent_identity_init_without_personal_agent_is_safe() {
+        let app = test_router_with_agent(Config::default(), None);
+        let (status, _) = post_identity_init(app.clone(), Some("headless")).await;
+        assert_eq!(status, StatusCode::OK);
+        // Status reports "configured: false" since no PersonalAgent.
+        let (status, body) = get_agent_status(app).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["configured"], false);
+    }
+
+    /// Unit-level: rebinding to the same pubkey AND source is a
+    /// total no-op (does not reset daily tallies).
+    #[tokio::test]
+    async fn rebind_to_same_identity_does_not_reset_tallies() {
+        use tirami_mind::WalletSource;
+        let mut agent = agent_at(NodeId([0xAAu8; 32]));
+        let new_pk = [0xCCu8; 32];
+        agent.rebind_wallet_from_agent_identity(new_pk, 1_000_000);
+        agent.earned_today_trm = 5;
+        agent.spent_today_trm = 3;
+        // Rebind to the same pubkey + source.
+        agent.rebind_wallet_from_agent_identity(new_pk, 2_000_000);
+        // Tallies preserved.
+        assert_eq!(agent.earned_today_trm, 5);
+        assert_eq!(agent.spent_today_trm, 3);
+        assert_eq!(agent.wallet_source, WalletSource::AgentIdentity);
+    }
+
+    /// Unit-level: rebinding to a DIFFERENT pubkey resets tallies
+    /// (those belonged to whoever held the wallet before).
+    #[tokio::test]
+    async fn rebind_to_different_identity_resets_tallies() {
+        use tirami_mind::WalletSource;
+        let mut agent = agent_at(NodeId([0xAAu8; 32]));
+        agent.earned_today_trm = 100;
+        agent.spent_today_trm = 50;
+        agent.rebind_wallet_from_agent_identity([0xCCu8; 32], 1_000_000);
+        // Different pk → reset.
+        assert_eq!(agent.earned_today_trm, 0);
+        assert_eq!(agent.spent_today_trm, 0);
+        assert_eq!(agent.day_started_at_ms, 1_000_000);
+        assert_eq!(agent.wallet_source, WalletSource::AgentIdentity);
+    }
+
+    /// Status response from `/v1/tirami/agent/status` must serialise
+    /// the `wallet_source` enum using snake_case (so JSON consumers
+    /// don't have to deserialise PascalCase).
+    #[tokio::test]
+    async fn agent_status_wallet_source_serialises_as_snake_case() {
+        let app = test_router_with_agent(
+            Config::default(),
+            Some(agent_at(NodeId([0xAAu8; 32]))),
+        );
+        let (_, pre) = get_agent_status(app.clone()).await;
+        assert_eq!(pre["wallet_source"].as_str(), Some("machine_node"));
+        let (_, _) = post_identity_init(app.clone(), None).await;
+        let (_, post) = get_agent_status(app).await;
+        assert_eq!(post["wallet_source"].as_str(), Some("agent_identity"));
     }
 
     // ------------------------------------------------------------------

--- a/crates/tirami-node/src/handlers/agent_identity.rs
+++ b/crates/tirami-node/src/handlers/agent_identity.rs
@@ -135,7 +135,13 @@ pub(crate) async fn init_identity(
     }
     let id = AgentIdentity::generate(now_millis_pub(), req.display_name);
     let view = IdentityPublicView::from(&id);
+    let pk = id.public_key_bytes();
     *guard = Some(id);
+    drop(guard);
+    // Phase 23 Wave 1 — propagate the new identity to the
+    // PersonalAgent wallet so trade attribution follows the DID,
+    // not the machine key.
+    rebind_personal_agent_wallet(&state, pk).await;
     Ok(Json(view))
 }
 
@@ -167,8 +173,25 @@ pub(crate) async fn import_identity(
 ) -> Result<Json<IdentityPublicView>, (StatusCode, String)> {
     check_forge_rate_limit(&state).await?;
     let imported = AgentIdentity::import(&req.bundle, &req.passphrase).map_err(map_err)?;
+    let pk = imported.public_key_bytes();
     let view = IdentityPublicView::from(&imported);
     let mut guard = state.agent_identity.lock().await;
     *guard = Some(imported);
+    drop(guard);
+    // Phase 23 Wave 1 — same rebind hook as `init_identity`.
+    rebind_personal_agent_wallet(&state, pk).await;
     Ok(Json(view))
+}
+
+/// Phase 23 Wave 1 — propagate a fresh agent pubkey down to the
+/// `PersonalAgent.wallet` slot, if one is configured.
+///
+/// No-op when no PersonalAgent exists. Idempotent when the agent's
+/// wallet already matches `pk` and its source is already
+/// `WalletSource::AgentIdentity`.
+async fn rebind_personal_agent_wallet(state: &AppState, pk: [u8; 32]) {
+    let mut guard = state.personal_agent.lock().await;
+    if let Some(agent) = guard.as_mut() {
+        agent.rebind_wallet_from_agent_identity(pk, now_millis_pub());
+    }
 }

--- a/docs/phase-23-zkml-and-wallet.md
+++ b/docs/phase-23-zkml-and-wallet.md
@@ -1,0 +1,124 @@
+# Phase 23 — closing the last residual 🟡 items
+
+> Phase 22 left two 🟡 markers in the Status Honesty section:
+> 1. **zkML real backends** (`ezkl` / `risc0`) — multi-week scope.
+> 2. **PersonalAgent.wallet ↔ AgentIdentity link** — bounded refactor.
+>
+> Phase 23 starts with the bounded item (Wave 1) and leaves zkML for a
+> later wave or a dedicated Phase 24.
+
+## Wave 1 — PersonalAgent.wallet ↔ AgentIdentity link ✅ shipped
+
+### Problem
+
+Until Wave 1, `PersonalAgent.wallet: NodeId` always held the host
+machine's Ed25519 public key (the `~/.tirami/node.key`-derived
+`NodeId`). The Phase-20-Wave-4 `AgentIdentity` (with its portable
+`did:tirami:<hex>`) lived alongside it but had no effect on trade
+attribution. An agent that exported its identity and imported it on a
+different host kept its DID but **earned and spent as the new host's
+machine identity** — the portability was decorative.
+
+### What changed
+
+- **New enum `tirami_mind::WalletSource`** with two variants:
+  - `MachineNode` (pre-Wave-1 default; wallet derives from the
+    machine key).
+  - `AgentIdentity` (post-Wave-1 when an `AgentIdentity` is loaded;
+    wallet derives from the DID pubkey).
+- **New field `PersonalAgent.wallet_source: WalletSource`**, with
+  `#[serde(default = "default_wallet_source")]` so pre-Wave-1
+  snapshots stay loadable and default to `MachineNode`.
+- **New method `PersonalAgent::rebind_wallet_from_agent_identity`**
+  (idempotent on same-pubkey-and-source; tally-resetting on
+  pubkey change because "today's earnings" belonged to a different
+  actor before the rebind).
+- **Rebind hook in the `agent_identity` HTTP handler**:
+  `POST /v1/tirami/agent/identity/init` and
+  `POST /v1/tirami/agent/identity/import` both propagate the
+  new pubkey into `PersonalAgent.wallet` via a private helper. A
+  node without a configured PersonalAgent is a clean no-op.
+- **`/v1/tirami/agent/status` response gained `wallet_source`** —
+  clients can tell at a glance whether trades attribute to the
+  machine (`"machine_node"`) or the portable DID
+  (`"agent_identity"`). Enum is serialised in snake_case so JSON
+  consumers don't have to think about it.
+
+### What this PR does NOT do (Wave 2+ deferrals)
+
+- **P2P trade signing**. Outbound P2P trades are still signed with
+  the **machine** SigningKey, not the AgentIdentity SigningKey.
+  That's a deeper refactor (the signing key has to follow the
+  identity, which means rebinding the identity must also rebind
+  the signer in `tirami-net`). Wave 1 only moves the **wallet
+  attribution** to the DID — that's what shows up on
+  `/v1/tirami/balance` and the unsigned self-bookkeeping trades.
+  The full crypto-identity unification is Wave 2 work.
+- **Migration of historical trades** — pre-rebind trades stay
+  attributed to the machine NodeId on the ledger. That's an audit
+  trail of who-was-who-when, intentionally preserved.
+
+### Verdict matrix
+
+| Operation | Pre-Wave-1 | Post-Wave-1 |
+|---|---|---|
+| `POST /agent/identity/init` returns DID | ✅ | ✅ |
+| `/.well-known/tirami-agent.json` shows `agent_did` | ✅ | ✅ |
+| `PersonalAgent.wallet == AgentIdentity pubkey` after init | ❌ (still machine key) | ✅ |
+| `/v1/tirami/agent/status` carries `wallet_source` | ❌ | ✅ |
+| Wallet portability across nodes via export/import | partial (DID portable, wallet not) | ✅ |
+| P2P trade *signing* migrates to AgentIdentity key | ❌ | ❌ (Wave 2) |
+
+### Tests
+
+8 new tests, all green:
+- 2 unit tests on `PersonalAgent::rebind_wallet_from_agent_identity`
+  (idempotent same-pk-and-source no-op; different-pk resets tallies).
+- 6 integration tests on the HTTP surface (pre-init reports
+  `machine_node`; init rebinds; idempotent init preserves the
+  rebound wallet; cross-node import on a fresh node rebinds;
+  init without a PersonalAgent is a safe no-op; status response
+  uses snake_case for the enum).
+
+Workspace: **1,349 passed, 0 failed** (was 1,341 → +8 new).
+
+### Smoke
+
+Against a release-mode `tirami start --port 3017`:
+
+| Step | Observation |
+|---|---|
+| 1. Pre-init `GET /v1/tirami/agent/status` | `wallet_source: machine_node`, wallet `30156cf7…` (machine NodeId) |
+| 2. `POST /v1/tirami/agent/identity/init` | Returns `did:tirami:9c4110ad…` |
+| 3. Post-init `GET /v1/tirami/agent/status` | `wallet_source: agent_identity`, wallet `9c4110ad…` — matches DID pubkey byte-for-byte |
+
+## Wave 2 — TBD
+
+Candidates:
+
+1. **Migrate the P2P trade signer to AgentIdentity.** The remaining
+   half of the wallet/identity link. When an `AgentIdentity` is
+   loaded, outbound `SignedTradeRecord` instances should be signed
+   with the agent's `SigningKey`, not the machine's. Touches
+   `tirami-net` signing paths and the pipeline coordinator. Bounded
+   scope (~one PR) but invasive across crate boundaries.
+2. **AgentIdentity on-disk persistence + auto-load**. Today the
+   imported identity lives only in memory; a restart drops it.
+   Adding a snapshot path that survives restart closes another
+   portability footgun.
+
+## Out of Phase 23 scope (Phase 24+)
+
+- **zkML real backends**. `ezkl` + `risc0` integration is a
+  multi-week project that warrants its own Phase. Scope:
+  - workspace deps for `ezkl` (with feature flags for native vs
+    WASM proving)
+  - bridge `tirami-zkml-bench`'s `MockBackend` to a real backend
+    behind a runtime selector
+  - per-model benchmark calibration so proof time stays bounded
+  - governance ratchet wiring so the proof requirement can step
+    up from Optional → Recommended → Required without breaking
+    legacy clients
+- **NIP-39 binding** between the secp256k1 Nostr pubkey and a
+  `did:tirami:` identity, so an agent's Nostr presence is
+  cryptographically tied to its Tirami identity.


### PR DESCRIPTION
## Summary

Before Wave 1, an AgentIdentity export-and-import on a new host carried the \`did:tirami:<hex>\` but **not the wallet** — earnings and spending attributed to the new machine's NodeId, not the agent. The DID was decorative. Wave 1 makes the wallet follow the DID so trade attribution survives node moves.

## What ships

### \`tirami_mind::WalletSource\` enum (new)

\`\`\`rust
pub enum WalletSource {
    MachineNode,    // pre-Wave-1 default
    AgentIdentity,  // wallet derives from did:tirami:<hex>
}
\`\`\`

### \`PersonalAgent.wallet_source\` (new field)

\`#[serde(default)]\` so pre-Wave-1 snapshots stay loadable.

### \`PersonalAgent::rebind_wallet_from_agent_identity\` (new method)

Idempotent on same-pubkey-and-source. Tally-resetting on pubkey change (today's earnings belonged to whoever held the wallet before).

### Rebind hook in agent_identity handlers

\`POST /v1/tirami/agent/identity/init\` and \`…/import\` both propagate the new pubkey into \`PersonalAgent.wallet\` via a private helper. A node without a configured PersonalAgent is a clean no-op.

### Status endpoint surfaces \`wallet_source\`

\`/v1/tirami/agent/status\` now returns a \`wallet_source\` discriminator (\`"machine_node"\` | \`"agent_identity"\`, snake_case) so clients can tell at a glance whether trades attribute to the machine or to the DID.

## Verdict matrix

| Property | Pre-Wave-1 | Post-Wave-1 |
|---|---|---|
| DID returned by \`init\` | ✅ | ✅ |
| \`manifest.agent_did\` exposed | ✅ | ✅ |
| \`PersonalAgent.wallet == DID pubkey\` after init | ❌ (machine key) | ✅ |
| \`/agent/status\` carries \`wallet_source\` | ❌ | ✅ |
| Wallet portability via export/import | partial | ✅ |
| P2P trade *signing* migrates to DID key | ❌ | ❌ (Wave 2) |

## Stacked on Phase 22 Wave 3

Base: \`phase-22/wave-3-agora-publish\` (PR #102). Merge order: #100 → #101 → #102 → this PR.

## What this PR does NOT do (Wave 2 deferral)

- **P2P trade *signing*** still uses the machine SigningKey. Wave 1 moves wallet ATTRIBUTION but not the signing key. That's a deeper refactor that touches \`tirami-net\` signing paths and the pipeline coordinator. Listed as Wave 2 in \`docs/phase-23-zkml-and-wallet.md\`.

## Test plan

- [x] \`cargo test --workspace\` → **1,349 passed, 0 failed** (was 1,341 → +8 new)
- [x] 2 unit tests on \`rebind_wallet_from_agent_identity\` (same-pk no-op / different-pk resets tallies)
- [x] 6 integration tests (pre-init machine_node / init rebinds / idempotent init preserves wallet / cross-node import rebinds / init without PersonalAgent is safe / snake_case enum serialisation)
- [x] **Live smoke** on \`tirami start --port 3017\`:
  - pre-init: \`wallet_source: machine_node\`, wallet \`30156cf7…\` (machine NodeId)
  - \`POST /v1/tirami/agent/identity/init\` → \`did:tirami:9c4110ad…\`
  - post-init: \`wallet_source: agent_identity\`, wallet \`9c4110ad…\` (matches DID pubkey byte-for-byte)

## Phase 23 progression

| Wave | Subject | Status |
|---|---|---|
| 1 | wallet ↔ AgentIdentity link | ✅ **this PR** |
| 2 | P2P signer follows AgentIdentity | pending |
| 3+ | AgentIdentity on-disk persistence | pending |
| Phase 24 | zkML real backends (ezkl / risc0) | deferred |

🤖 Generated with [Claude Code](https://claude.com/claude-code)