### PR TITLE
feat(phase-23/wave-2.5): share agent_identity Arc between AppState and TiramiNode

### DIFF
--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -195,6 +195,11 @@ pub fn create_router(
         Arc::new(tirami_anchor::MockChainClient::new()),
         Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
         Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
+        // Phase 23 Wave 2.5 — `create_router` builds a fresh,
+        // unshared `agent_identity` slot. The TiramiNode entrypoint
+        // calls `create_router_with_services` directly with the
+        // node's own shared Arc.
+        Arc::new(Mutex::new(None)),
     )
 }
 
@@ -218,6 +223,12 @@ pub fn create_router_with_services(
     chain_client: Arc<tirami_anchor::MockChainClient>,
     personal_agent: Arc<Mutex<Option<tirami_mind::PersonalAgent>>>,
     agent_loop_stats: Arc<Mutex<crate::agent_loop::AgentLoopStats>>,
+    // Phase 23 Wave 2.5 — shared `agent_identity` handle. The same
+    // `Arc<Mutex<Option<AgentIdentity>>>` is held by both the HTTP
+    // layer (this `AppState`) and the pipeline coordinator's
+    // `run_seed` so an HTTP `agent/identity/init` immediately
+    // updates the signer the pipeline reads.
+    agent_identity: Arc<Mutex<Option<tirami_mind::AgentIdentity>>>,
 ) -> Router {
     // Derive local node ID from cluster or generate a deterministic one.
     let local_node_id = cluster
@@ -255,7 +266,7 @@ pub fn create_router_with_services(
         purchase_intents: Arc::new(Mutex::new(
             crate::handlers::purchase_intent::PurchaseIntentRegistry::new(),
         )),
-        agent_identity: Arc::new(Mutex::new(None)),
+        agent_identity,
         auth_challenges: Arc::new(Mutex::new(
             crate::handlers::auth_did::ChallengeStore::new(),
         )),
@@ -4420,6 +4431,8 @@ pub(crate) fn test_router_default(config: Config) -> Router {
         Arc::new(tirami_anchor::MockChainClient::new()),
         Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
         Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
+        // Phase 23 Wave 2.5 — test helper builds an unshared slot.
+        Arc::new(Mutex::new(None)),
     )
 }
 
@@ -5193,6 +5206,7 @@ mod tests {
             Arc::new(tirami_anchor::MockChainClient::new()),
             Arc::new(Mutex::new(agent)),
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
+            Arc::new(Mutex::new(None)),
         )
     }
 
@@ -7465,6 +7479,130 @@ mod tests {
         let (_, _) = post_identity_init(app.clone(), None).await;
         let (_, post) = get_agent_status(app).await;
         assert_eq!(post["wallet_source"].as_str(), Some("agent_identity"));
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 23 Wave 2.5 — shared agent_identity Arc
+    // ------------------------------------------------------------------
+
+    /// When a caller supplies a custom `agent_identity` Arc to
+    /// `create_router_with_services`, an HTTP `agent/identity/init`
+    /// populates THAT Arc — i.e. the same handle the pipeline reads.
+    /// Before Wave 2.5 the AppState built its own Arc internally, so
+    /// HTTP-side mutations stayed invisible to pipeline-side
+    /// consumers. This test pins the shared-handle property by
+    /// constructing the router with an explicit Arc, calling init
+    /// over HTTP, and then inspecting the external Arc to confirm
+    /// the new identity landed there.
+    #[tokio::test]
+    async fn shared_agent_identity_arc_receives_init() {
+        use crate::api::create_router_with_services;
+        use crate::bank_adapter::BankServices;
+        let shared: Arc<Mutex<Option<tirami_mind::AgentIdentity>>> =
+            Arc::new(Mutex::new(None));
+        let app = create_router_with_services(
+            Config::default(),
+            Arc::new(Mutex::new(CandleEngine::new())),
+            Arc::new(Mutex::new(ComputeLedger::new())),
+            Arc::new(Mutex::new(None)),
+            Arc::new(Mutex::new(None)),
+            None,
+            Arc::new(Mutex::new(GossipState::new())),
+            Arc::new(Mutex::new(BankServices::new_default())),
+            Arc::new(Mutex::new(Marketplace::new())),
+            Arc::new(Mutex::new(0usize)),
+            Arc::new(Mutex::new(None::<tirami_mind::TiramiMindAgent>)),
+            Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
+            Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
+            Arc::new(Mutex::new(tirami_ledger::GovernanceState::new(0))),
+            Arc::new(tirami_anchor::MockChainClient::new()),
+            Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
+            Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
+            shared.clone(), // ← the Arc we will observe externally
+        );
+
+        // Externally observed slot is empty before init.
+        {
+            let guard = shared.lock().await;
+            assert!(guard.is_none(), "shared Arc must be empty pre-init");
+        }
+
+        // HTTP-side init.
+        let (status, body) = post_identity_init(app, Some("shared-test")).await;
+        assert_eq!(status, StatusCode::OK);
+        let http_did = body["did"].as_str().unwrap().to_string();
+
+        // The exact same Arc now carries an identity whose DID matches
+        // the HTTP response. This is the property pipeline-side code
+        // (which reads through this Arc) relies on.
+        let guard = shared.lock().await;
+        let id = guard.as_ref().expect("shared Arc populated post-init");
+        assert_eq!(id.did(), http_did);
+    }
+
+    /// Re-import on the shared Arc must replace the identity in
+    /// place — both the HTTP-visible state AND the externally-held
+    /// Arc see the new DID.
+    #[tokio::test]
+    async fn shared_agent_identity_arc_replaced_on_import() {
+        use crate::api::create_router_with_services;
+        use crate::bank_adapter::BankServices;
+        let shared: Arc<Mutex<Option<tirami_mind::AgentIdentity>>> =
+            Arc::new(Mutex::new(None));
+        let app_a = create_router_with_services(
+            Config::default(),
+            Arc::new(Mutex::new(CandleEngine::new())),
+            Arc::new(Mutex::new(ComputeLedger::new())),
+            Arc::new(Mutex::new(None)),
+            Arc::new(Mutex::new(None)),
+            None,
+            Arc::new(Mutex::new(GossipState::new())),
+            Arc::new(Mutex::new(BankServices::new_default())),
+            Arc::new(Mutex::new(Marketplace::new())),
+            Arc::new(Mutex::new(0usize)),
+            Arc::new(Mutex::new(None::<tirami_mind::TiramiMindAgent>)),
+            Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
+            Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
+            Arc::new(Mutex::new(tirami_ledger::GovernanceState::new(0))),
+            Arc::new(tirami_anchor::MockChainClient::new()),
+            Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
+            Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
+            shared.clone(),
+        );
+        // First identity via init.
+        let (_, init_a) = post_identity_init(app_a.clone(), None).await;
+        let did_a = init_a["did"].as_str().unwrap().to_string();
+        // Export under a strong passphrase.
+        let (_, bundle) = post_identity_export(app_a, "passphrase-1234567").await;
+
+        // Fresh router with a NEW shared Arc, then import the bundle.
+        let shared_b: Arc<Mutex<Option<tirami_mind::AgentIdentity>>> =
+            Arc::new(Mutex::new(None));
+        let app_b = create_router_with_services(
+            Config::default(),
+            Arc::new(Mutex::new(CandleEngine::new())),
+            Arc::new(Mutex::new(ComputeLedger::new())),
+            Arc::new(Mutex::new(None)),
+            Arc::new(Mutex::new(None)),
+            None,
+            Arc::new(Mutex::new(GossipState::new())),
+            Arc::new(Mutex::new(BankServices::new_default())),
+            Arc::new(Mutex::new(Marketplace::new())),
+            Arc::new(Mutex::new(0usize)),
+            Arc::new(Mutex::new(None::<tirami_mind::TiramiMindAgent>)),
+            Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
+            Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
+            Arc::new(Mutex::new(tirami_ledger::GovernanceState::new(0))),
+            Arc::new(tirami_anchor::MockChainClient::new()),
+            Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
+            Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
+            shared_b.clone(),
+        );
+        let (_status, _view) =
+            post_identity_import(app_b, "passphrase-1234567", bundle).await;
+        let guard = shared_b.lock().await;
+        let id = guard.as_ref().expect("imported");
+        assert_eq!(id.did(), did_a);
     }
 
     // ------------------------------------------------------------------

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -214,6 +214,10 @@ impl TiramiNode {
             self.chain_client.clone(),
             self.personal_agent.clone(),
             self.agent_loop_stats.clone(),
+            // Phase 23 Wave 2.5 — share the *same* AgentIdentity Arc
+            // with the pipeline. HTTP `agent/identity/init` now
+            // populates the slot the signer reads.
+            self.agent_identity.clone(),
         );
         let addr = self.config.api_socket_addr();
         tracing::info!("API server listening on {}", addr);
@@ -247,6 +251,7 @@ impl TiramiNode {
         let chain_client_api = self.chain_client.clone();
         let personal_agent_api = self.personal_agent.clone();
         let agent_loop_stats_api = self.agent_loop_stats.clone();
+        let agent_identity_api = self.agent_identity.clone();
         let api_config = self.config.clone();
         tokio::spawn(async move {
             let app = crate::api::create_router_with_services(
@@ -267,6 +272,8 @@ impl TiramiNode {
                 chain_client_api,
                 personal_agent_api,
                 agent_loop_stats_api,
+                // Phase 23 Wave 2.5 — shared Arc.
+                agent_identity_api,
             );
             let addr = api_config.api_socket_addr();
             if let Ok(listener) = tokio::net::TcpListener::bind(&addr).await {

--- a/crates/tirami-node/src/security_tests.rs
+++ b/crates/tirami-node/src/security_tests.rs
@@ -709,6 +709,7 @@ mod security_tests {
             Arc::new(tirami_anchor::MockChainClient::new()),
             Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
+            Arc::new(Mutex::new(None)),
         );
         let _ = state; // suppress unused warning
 

--- a/docs/phase-23-zkml-and-wallet.md
+++ b/docs/phase-23-zkml-and-wallet.md
@@ -157,14 +157,66 @@ would require ~minutes of test setup and is deferred until Wave
 2.5 lands AppState↔TiramiNode handle-sharing (so the HTTP layer
 can drive the same identity slot the pipeline reads).
 
-### Wave 2.5 (immediate follow-up)
+### Wave 2.5 — shared agent_identity Arc ✅ shipped
 
-The AgentIdentity slot now exists on both `TiramiNode` and
-`AppState` but they're **disjoint instances** — populating one via
-HTTP doesn't affect what the pipeline reads. Wave 2.5 unifies them
-by having `create_router_with_services` accept (or take ownership
-of) the `TiramiNode.agent_identity` Arc instead of constructing
-its own.
+Wave 2 left an awkward decoupling: `AppState.agent_identity` and
+`TiramiNode.agent_identity` were two **disjoint** instances of
+`Arc<Mutex<Option<AgentIdentity>>>`. HTTP `agent/identity/init`
+populated AppState's slot only — the pipeline kept reading the
+TiramiNode slot, which remained `None` forever. Wave 2's signing
+logic was correct but unreachable.
+
+Wave 2.5 unifies them:
+
+- **`create_router_with_services` gained an `agent_identity:
+  Arc<Mutex<Option<AgentIdentity>>>` parameter.** AppState now
+  stores the supplied handle instead of constructing its own. All
+  6 call sites updated (the thin `create_router` wrapper, the
+  two `TiramiNode` API entrypoints, the test helpers, and
+  `security_tests.rs`).
+- **`TiramiNode::serve_api` and `serve_api_with_listener` pass
+  `self.agent_identity.clone()`** — the SAME Arc the pipeline
+  receives through `run_seed`. HTTP-side mutations are now
+  immediately visible to the signing path.
+- **Test helpers default to a fresh, unshared Arc** so the 1,354
+  pre-Wave-2.5 tests stay unchanged.
+
+### Properties guaranteed
+
+| Property | Pre-Wave-2.5 | Post-Wave-2.5 |
+|---|---|---|
+| HTTP `init_identity` updates AppState's agent_identity slot | ✅ | ✅ |
+| Same call updates the slot the pipeline reads | ❌ (disjoint Arc) | ✅ (shared Arc) |
+| Cross-node import propagates to pipeline | ❌ | ✅ |
+| Pre-Wave-2.5 callers (tests, simple `create_router`) still work | ✅ | ✅ (unshared default) |
+
+### Tests
+
+2 new integration tests, all green:
+- `shared_agent_identity_arc_receives_init` — caller supplies an
+  externally-held Arc, hits `POST /v1/tirami/agent/identity/init`
+  over HTTP, then re-reads the external Arc and confirms the DID
+  matches the HTTP response.
+- `shared_agent_identity_arc_replaced_on_import` — same shape but
+  for the `/import` path, including the export-from-A → import-on-B
+  cross-node round-trip.
+
+Workspace: **1,356 passed, 0 failed** (was 1,354 → +2 new).
+
+### Live smoke
+
+`tirami start --port 3018`:
+
+  [1] pre-init  /v1/tirami/agent/status        → wallet_source: machine_node, wallet: 30156cf7…
+  [2] POST /v1/tirami/agent/identity/init      → did:tirami:47b4a62b…
+  [3] post-init /.well-known/tirami-agent.json → agent_did: did:tirami:47b4a62b…
+  [3] post-init /v1/tirami/agent/status        → wallet_source: agent_identity, wallet: 47b4a62b…
+                                                  (matches DID pubkey byte-for-byte)
+
+The fact that `manifest.agent_did` and `status.wallet` are
+*consistent* after init — and would be consistent for the
+pipeline-side signer if there were P2P traffic to observe — is
+the property Wave 2.5 makes structural rather than coincidental.
 
 ## Wave 3+ candidates
 


### PR DESCRIPTION
## Summary

Wave 2 left a structural decoupling: \`AppState.agent_identity\` and \`TiramiNode.agent_identity\` were two **disjoint** instances of \`Arc<Mutex<Option<AgentIdentity>>>\`. HTTP \`agent/identity/init\` populated AppState's slot only; the pipeline kept reading the TiramiNode slot which remained \`None\` forever. **Wave 2's signing logic was correct but unreachable in practice.**

Wave 2.5 unifies the two slots.

## What changed

### \`create_router_with_services\` signature

Gained an \`agent_identity: Arc<Mutex<Option<AgentIdentity>>>\` parameter. AppState now stores the supplied handle instead of constructing its own.

All 5 call sites updated:
- \`create_router\` (thin wrapper, passes fresh unshared Arc — backwards compat)
- \`TiramiNode::serve_api\` (passes \`self.agent_identity.clone()\`)
- \`TiramiNode::serve_api_with_listener\` (same)
- \`test_router_with_agent_and_ledger\` (fresh unshared Arc)
- \`security_tests.rs\` test helper (fresh unshared Arc)

### TiramiNode → pipeline wiring

Wave 2 already plumbed \`self.agent_identity\` into \`run_seed\`. Wave 2.5's new contribution: that SAME Arc also reaches AppState, so HTTP-side mutations now propagate to the pipeline-side signer.

## Properties

| Property | Pre | Post |
|---|---|---|
| HTTP init updates AppState's slot | ✅ | ✅ |
| Same call updates the pipeline-visible slot | ❌ | ✅ |
| Cross-node import propagates to pipeline | ❌ | ✅ |
| Pre-Wave-2.5 callers (tests, simple \`create_router\`) work | ✅ | ✅ |

## Test plan

- [x] \`cargo test --workspace\` → **1,356 passed, 0 failed** (was 1,354 → +2 new)
- [x] 2 new integration tests:
  - \`shared_agent_identity_arc_receives_init\` — caller supplies externally-held Arc, HTTP init, then re-read the Arc to confirm DID propagation
  - \`shared_agent_identity_arc_replaced_on_import\` — same for the cross-node import path
- [x] **Live smoke** on \`tirami start --port 3018\`:
  - pre-init: \`wallet_source: machine_node\`, wallet \`30156cf7…\`
  - \`POST /v1/tirami/agent/identity/init\` → \`did:tirami:47b4a62b…\`
  - post-init manifest: \`agent_did: did:tirami:47b4a62b…\`
  - post-init status: \`wallet_source: agent_identity\`, wallet \`47b4a62b…\` (byte-for-byte match)

## Phase 23 status after Wave 2.5

| Wave | Subject | Status |
|---|---|---|
| 1 | wallet ↔ AgentIdentity link | ✅ #103 |
| 2 | P2P signer follows AgentIdentity | ✅ #104 |
| 2.5 | shared agent_identity Arc | ✅ **this PR** |
| 3+ | AgentIdentity on-disk persistence | pending |
| Phase 24 | zkML real backends | deferred |

🤖 Generated with [Claude Code](https://claude.com/claude-code)