### PR TITLE
feat(phase-23/wave-3): AgentIdentity on-disk persistence + auto-load

### DIFF
--- a/crates/tirami-core/src/config.rs
+++ b/crates/tirami-core/src/config.rs
@@ -29,6 +29,24 @@ pub struct Config {
     /// Optional path to the persisted user-facing PersonalAgent state.
     pub personal_agent_state_path: Option<PathBuf>,
 
+    /// Phase 23 Wave 3 — optional path for the encrypted
+    /// `AgentIdentity` bundle on disk. When `Some(_)` AND the env
+    /// var named by [`Self::agent_identity_passphrase_env`] is set,
+    /// `TiramiNode::new` auto-loads the identity at startup and
+    /// `agent/identity/init` / `/import` write back to the same
+    /// path after each mutation. When either side is missing the
+    /// identity stays ephemeral (in-memory only).
+    #[serde(default)]
+    pub agent_identity_path: Option<PathBuf>,
+
+    /// Phase 23 Wave 3 — name of the environment variable that
+    /// carries the Argon2id passphrase for the persisted identity.
+    /// Default: `"TIRAMI_AGENT_IDENTITY_PASSPHRASE"`. Operators
+    /// who run multiple nodes on the same host can rebind this to
+    /// per-node names.
+    #[serde(default = "default_agent_identity_passphrase_env")]
+    pub agent_identity_passphrase_env: String,
+
     /// Whether to share compute with the network.
     pub share_compute: bool,
 
@@ -226,6 +244,12 @@ fn default_welcome_settle_interval_secs() -> u64 {
     300
 }
 
+/// Phase 23 Wave 3 — environment-variable name carrying the
+/// Argon2id passphrase for the persisted `AgentIdentity` bundle.
+fn default_agent_identity_passphrase_env() -> String {
+    "TIRAMI_AGENT_IDENTITY_PASSPHRASE".to_string()
+}
+
 fn default_slashing_interval_secs() -> u64 {
     300
 }
@@ -346,6 +370,8 @@ impl Default for Config {
             marketplace_state_path: None,
             mind_state_path: None,
             personal_agent_state_path: None,
+            agent_identity_path: None,
+            agent_identity_passphrase_env: default_agent_identity_passphrase_env(),
             share_compute: false,
             max_memory_gb: 4.0,
             api_port: 3000,

--- a/crates/tirami-node/src/handlers/agent_identity.rs
+++ b/crates/tirami-node/src/handlers/agent_identity.rs
@@ -136,12 +136,20 @@ pub(crate) async fn init_identity(
     let id = AgentIdentity::generate(now_millis_pub(), req.display_name);
     let view = IdentityPublicView::from(&id);
     let pk = id.public_key_bytes();
+    // Phase 23 Wave 3 — clone for the persist path BEFORE moving
+    // the original into the slot (`Some(id)` consumes `id`).
+    let id_for_persist = id.clone();
     *guard = Some(id);
     drop(guard);
     // Phase 23 Wave 1 — propagate the new identity to the
     // PersonalAgent wallet so trade attribution follows the DID,
     // not the machine key.
     rebind_personal_agent_wallet(&state, pk).await;
+    // Phase 23 Wave 3 — write the encrypted bundle to disk if a
+    // path + passphrase are configured. Best-effort: a write
+    // failure logs at warn but does NOT fail the HTTP request,
+    // since the in-memory identity is still valid.
+    persist_agent_identity_if_configured(&state, &id_for_persist);
     Ok(Json(view))
 }
 
@@ -175,12 +183,50 @@ pub(crate) async fn import_identity(
     let imported = AgentIdentity::import(&req.bundle, &req.passphrase).map_err(map_err)?;
     let pk = imported.public_key_bytes();
     let view = IdentityPublicView::from(&imported);
+    let imported_clone = imported.clone();
     let mut guard = state.agent_identity.lock().await;
     *guard = Some(imported);
     drop(guard);
     // Phase 23 Wave 1 — same rebind hook as `init_identity`.
     rebind_personal_agent_wallet(&state, pk).await;
+    // Phase 23 Wave 3 — persist the imported identity so a restart
+    // doesn't drop it. Same best-effort semantics as init.
+    persist_agent_identity_if_configured(&state, &imported_clone);
     Ok(Json(view))
+}
+
+/// Phase 23 Wave 3 — best-effort save to the configured path.
+///
+/// Returns silently when path or passphrase env var is unset; logs at
+/// `warn` on any I/O / serialization / encryption error. The in-memory
+/// identity remains valid regardless.
+fn persist_agent_identity_if_configured(
+    state: &AppState,
+    id: &AgentIdentity,
+) {
+    let Some(path) = state.config.agent_identity_path.as_ref() else {
+        return;
+    };
+    let Ok(passphrase) = std::env::var(&state.config.agent_identity_passphrase_env) else {
+        tracing::debug!(
+            "agent_identity_path set but env var {} unset — skipping persist",
+            state.config.agent_identity_passphrase_env
+        );
+        return;
+    };
+    if let Err(err) = crate::state_persist::save_agent_identity(id, path, &passphrase) {
+        tracing::warn!(
+            "Failed to persist AgentIdentity to {}: {}",
+            path.display(),
+            err
+        );
+    } else {
+        tracing::info!(
+            "Persisted AgentIdentity to {} (did:tirami:{}…)",
+            path.display(),
+            &id.public_key_hex()[..12]
+        );
+    }
 }
 
 /// Phase 23 Wave 1 — propagate a fresh agent pubkey down to the

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -138,6 +138,11 @@ impl TiramiNode {
         // for a snapshot file and calls agent.restore_from_snapshot()).
         let mind_agent: Option<tirami_mind::TiramiMindAgent> = None;
 
+        // Phase 23 Wave 3 — compute BEFORE `config` is moved into
+        // `self`. Best-effort load; returns `None` if path or
+        // passphrase env var is unset.
+        let agent_identity = load_persisted_agent_identity(&config);
+
         Self {
             config,
             engine: Arc::new(Mutex::new(CandleEngine::new())),
@@ -156,10 +161,12 @@ impl TiramiNode {
             chain_client: Arc::new(tirami_anchor::MockChainClient::new()),
             personal_agent: Arc::new(Mutex::new(None)),
             agent_loop_stats: Arc::new(Mutex::new(AgentLoopStats::new())),
-            // Phase 23 Wave 2 — empty by default; populated by the
-            // HTTP `agent/identity/init` or `…/import` flow once
-            // Wave 2.5 wires the shared handle into AppState.
-            agent_identity: Arc::new(Mutex::new(None)),
+            // Phase 23 Wave 3 — auto-load the persisted identity if
+            // BOTH `agent_identity_path` AND the passphrase env var
+            // are configured. Silent fallback to None when either
+            // is missing so the in-memory-only path remains the
+            // out-of-the-box default.
+            agent_identity: Arc::new(Mutex::new(agent_identity)),
             heartbeat_started: false,
         }
     }
@@ -1217,6 +1224,56 @@ impl TiramiNode {
         }
 
         tracing::info!("Tirami node shut down");
+    }
+}
+
+/// Phase 23 Wave 3 — best-effort load of the persisted
+/// `AgentIdentity` at startup.
+///
+/// Returns `None` (and logs at `info`/`warn`) on any of: path
+/// unconfigured, passphrase env var unset, file missing, file
+/// malformed, or wrong passphrase. The semantics are deliberately
+/// permissive — a missing file is the common first-boot case and
+/// must not abort startup. A wrong passphrase logs at `warn` so
+/// the operator notices but the node still comes up (with a fresh
+/// in-memory-only identity slot).
+fn load_persisted_agent_identity(
+    config: &tirami_core::Config,
+) -> Option<tirami_mind::AgentIdentity> {
+    let Some(path) = config.agent_identity_path.as_ref() else {
+        return None;
+    };
+    let Ok(passphrase) = std::env::var(&config.agent_identity_passphrase_env) else {
+        tracing::info!(
+            "agent_identity_path is set but env var {} is unset — identity stays in-memory",
+            config.agent_identity_passphrase_env
+        );
+        return None;
+    };
+    match state_persist::load_agent_identity(path, &passphrase) {
+        Ok(Some(id)) => {
+            tracing::info!(
+                "Loaded persisted AgentIdentity from {} (did:tirami:{}…)",
+                path.display(),
+                &id.public_key_hex()[..12]
+            );
+            Some(id)
+        }
+        Ok(None) => {
+            tracing::debug!(
+                "No persisted AgentIdentity at {} — starting fresh",
+                path.display()
+            );
+            None
+        }
+        Err(err) => {
+            tracing::warn!(
+                "Failed to load AgentIdentity from {}: {} — starting fresh",
+                path.display(),
+                err
+            );
+            None
+        }
     }
 }
 

--- a/crates/tirami-node/src/state_persist.rs
+++ b/crates/tirami-node/src/state_persist.rs
@@ -134,6 +134,71 @@ pub fn load_personal_agent(path: &Path) -> io::Result<Option<PersonalAgent>> {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 23 Wave 3 — `AgentIdentity` on-disk persistence.
+//
+// The Wave-4 `AgentIdentityBundle` already encodes a passphrase-
+// encrypted JSON envelope (Argon2id + XChaCha20-Poly1305) suitable
+// for transport. We reuse exactly that envelope as the at-rest
+// format, so an exported bundle and a persisted-on-disk file are
+// byte-identical structures: the operator can roll their own backup
+// strategy without diverging on the format.
+// ---------------------------------------------------------------------------
+
+use tirami_mind::{AgentIdentity, AgentIdentityBundle};
+
+/// Persist an `AgentIdentity` to `path` as an encrypted bundle. The
+/// `passphrase` is fed straight to `AgentIdentity::export`, which
+/// runs Argon2id + XChaCha20-Poly1305 over the 32-byte seed.
+///
+/// Caller must supply a non-trivial passphrase (≥ 8 chars); the
+/// export path enforces this and propagates the error if not.
+pub fn save_agent_identity(
+    id: &AgentIdentity,
+    path: &Path,
+    passphrase: &str,
+) -> io::Result<()> {
+    let bundle = id
+        .export(passphrase)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    let json = serde_json::to_string(&bundle)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    fs::write(path, json)?;
+    // Restrict permissions on Unix — the bundle is encrypted, but
+    // chmod 600 still adds defense in depth against accidental
+    // multi-user reads.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o600);
+        fs::set_permissions(path, perms)?;
+    }
+    Ok(())
+}
+
+/// Load and decrypt an `AgentIdentity` from `path` using
+/// `passphrase`. Returns:
+///
+/// - `Ok(None)` if the file does not exist (clean first-boot state)
+/// - `Ok(Some(_))` if the file decrypts cleanly
+/// - `Err(_)` on I/O failure, malformed JSON, schema mismatch, or
+///   wrong passphrase (the AEAD authentication failure)
+pub fn load_agent_identity(
+    path: &Path,
+    passphrase: &str,
+) -> io::Result<Option<AgentIdentity>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path)?;
+    let bundle: AgentIdentityBundle = serde_json::from_str(&raw)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let id = AgentIdentity::import(&bundle, passphrase)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    Ok(Some(id))
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -449,5 +514,113 @@ mod tests {
             let roundtripped: StrategyKind = serde_json::from_str(&json).expect("must deserialize");
             assert_eq!(kind, roundtripped, "StrategyKind must roundtrip via JSON");
         }
+    }
+
+    // -------------------------------------------------------------
+    // Phase 23 Wave 3 — AgentIdentity on-disk persistence
+    // -------------------------------------------------------------
+
+    fn agent_id_tmp_path(suffix: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "forge_agent_identity_test_{}_{}.json",
+            std::process::id(),
+            suffix
+        ))
+    }
+
+    #[test]
+    fn agent_identity_save_then_load_round_trip() {
+        let path = agent_id_tmp_path("rt");
+        let _ = std::fs::remove_file(&path);
+        let original = AgentIdentity::generate(1_000, Some("persist-test".into()));
+        save_agent_identity(&original, &path, "correct-horse-battery-staple")
+            .expect("save ok");
+        let loaded = load_agent_identity(&path, "correct-horse-battery-staple")
+            .expect("load ok")
+            .expect("must be Some");
+        assert_eq!(loaded.public_key_hex(), original.public_key_hex());
+        assert_eq!(loaded.display_name, original.display_name);
+        assert_eq!(loaded.created_at_ms, original.created_at_ms);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn agent_identity_load_missing_path_returns_none() {
+        let path = agent_id_tmp_path("missing-never-created");
+        let _ = std::fs::remove_file(&path);
+        let loaded = load_agent_identity(&path, "anything").expect("Ok");
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn agent_identity_load_wrong_passphrase_returns_err() {
+        let path = agent_id_tmp_path("wrong-pass");
+        let _ = std::fs::remove_file(&path);
+        let id = AgentIdentity::generate(0, None);
+        save_agent_identity(&id, &path, "right-passphrase-12345").expect("save");
+        let err = load_agent_identity(&path, "wrong-passphrase-12345").expect_err("must err");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn agent_identity_save_rejects_short_passphrase() {
+        let path = agent_id_tmp_path("short-pass");
+        let _ = std::fs::remove_file(&path);
+        let id = AgentIdentity::generate(0, None);
+        let err = save_agent_identity(&id, &path, "short").expect_err("must err");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        // File must NOT have been created on the rejection path.
+        assert!(!path.exists(), "save should not write on validation failure");
+    }
+
+    #[test]
+    fn agent_identity_save_corruption_then_load_returns_err() {
+        let path = agent_id_tmp_path("corrupt");
+        let _ = std::fs::remove_file(&path);
+        let id = AgentIdentity::generate(0, None);
+        save_agent_identity(&id, &path, "correct-passphrase-1234").expect("save");
+        // Corrupt the file body.
+        std::fs::write(&path, "not-a-json-bundle").unwrap();
+        let err = load_agent_identity(&path, "correct-passphrase-1234")
+            .expect_err("must err on malformed JSON");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn agent_identity_save_file_has_restrictive_permissions_on_unix() {
+        let path = agent_id_tmp_path("perm");
+        let _ = std::fs::remove_file(&path);
+        let id = AgentIdentity::generate(0, None);
+        save_agent_identity(&id, &path, "correct-passphrase-1234").expect("save");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "got mode {:o}", mode);
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn agent_identity_two_round_trips_preserve_seed_byte_for_byte() {
+        // Save → load → save → load must yield the exact same seed
+        // bytes. This catches any nondeterminism in the persistence
+        // path (e.g., re-keying or rotating salts on read).
+        let path = agent_id_tmp_path("two-rt");
+        let _ = std::fs::remove_file(&path);
+        let original = AgentIdentity::generate(0, None);
+        let original_seed = original.seed();
+        save_agent_identity(&original, &path, "pass-12345678").expect("save 1");
+        let loaded1 = load_agent_identity(&path, "pass-12345678")
+            .expect("load 1")
+            .expect("Some");
+        save_agent_identity(&loaded1, &path, "pass-12345678").expect("save 2");
+        let loaded2 = load_agent_identity(&path, "pass-12345678")
+            .expect("load 2")
+            .expect("Some");
+        assert_eq!(loaded2.seed(), original_seed);
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/docs/phase-23-zkml-and-wallet.md
+++ b/docs/phase-23-zkml-and-wallet.md
@@ -218,13 +218,99 @@ The fact that `manifest.agent_did` and `status.wallet` are
 pipeline-side signer if there were P2P traffic to observe — is
 the property Wave 2.5 makes structural rather than coincidental.
 
-## Wave 3+ candidates
+## Wave 3 — AgentIdentity on-disk persistence + auto-load ✅ shipped
 
-- **AgentIdentity on-disk persistence + auto-load.** Today the
-  imported identity lives only in memory; a restart drops it.
-  Adding an encrypted snapshot path (using the same
-  Argon2id+XChaCha20-Poly1305 stack as Wave 4's
-  `AgentIdentityBundle`) closes another portability footgun.
+Until Wave 3, an imported AgentIdentity lived only in memory — a
+restart dropped it and the operator had to re-import from a
+bundle. Wave 3 adds optional encrypted persistence so the
+identity survives restarts as cleanly as the rest of the ledger
+state.
+
+### Design
+
+Wave 4 already shipped the perfect on-disk format: the
+`AgentIdentityBundle` is JSON-serialisable, encrypted with
+Argon2id + XChaCha20-Poly1305, and authenticates the salted
+ciphertext. Wave 3 reuses **exactly that envelope** as the
+at-rest format — an exported bundle and a persisted-on-disk file
+are byte-identical structures. An operator can roll their own
+backup strategy (rsync, B2, etc.) without diverging on schema.
+
+### What changed
+
+- **`state_persist::save_agent_identity(&id, path, passphrase)`** —
+  writes the encrypted bundle. On Unix, sets `chmod 600` after
+  the write for defense-in-depth (the file is already encrypted;
+  the perm bit just blocks accidental multi-user reads on shared
+  hosts).
+- **`state_persist::load_agent_identity(path, passphrase)`** —
+  returns `Ok(None)` when the file is absent (clean first-boot),
+  `Ok(Some(_))` on success, `Err(_)` on I/O / JSON / passphrase
+  failures.
+- **`Config.agent_identity_path: Option<PathBuf>`** and
+  **`Config.agent_identity_passphrase_env: String`** (default
+  `"TIRAMI_AGENT_IDENTITY_PASSPHRASE"`). Both must be set for
+  persistence to engage. Either alone is a silent no-op — the
+  identity stays ephemeral.
+- **`TiramiNode::new` auto-loads** at startup. A wrong passphrase
+  logs at `warn` but does NOT abort: the node still boots with
+  a fresh in-memory-only identity slot.
+- **HTTP `init_identity` and `import_identity` auto-persist** —
+  after the AppState slot is populated, the same encrypted
+  bundle is written to disk. Best-effort: a write failure logs
+  at `warn` but the HTTP request still returns the in-memory
+  identity normally.
+
+### Operator UX
+
+To enable persistence:
+
+```bash
+export TIRAMI_AGENT_IDENTITY_PASSPHRASE="$(openssl rand -hex 32)"
+# in the config file or via CLI:
+agent_identity_path = "~/.tirami/agent_identity.json"
+```
+
+Without the env var, the path is ignored. Without the path, the
+env var is ignored. This means a misconfigured deploy can't
+silently store unencrypted material — the only fail-open is
+"don't persist", never "persist in plaintext".
+
+### Tests
+
+7 new unit tests on `state_persist`:
+- `agent_identity_save_then_load_round_trip`
+- `agent_identity_load_missing_path_returns_none`
+- `agent_identity_load_wrong_passphrase_returns_err`
+- `agent_identity_save_rejects_short_passphrase`
+- `agent_identity_save_corruption_then_load_returns_err`
+- `agent_identity_save_file_has_restrictive_permissions_on_unix`
+- `agent_identity_two_round_trips_preserve_seed_byte_for_byte`
+
+Workspace: **1,363 passed, 0 failed** (was 1,356 → +7 new).
+
+### Properties
+
+| Property | Pre-Wave-3 | Post-Wave-3 |
+|---|---|---|
+| AgentIdentity survives node restart | ❌ | ✅ (when configured) |
+| Persisted file is encrypted at rest | N/A | ✅ (Argon2id + XChaCha20-Poly1305) |
+| Wrong passphrase aborts startup | N/A | ❌ (warn + fall back to ephemeral) |
+| Missing env var silently disables persist | N/A | ✅ |
+| File mode 0600 on Unix | N/A | ✅ |
+
+## Phase 24 — zkML real backends
+
+Now the only 🟡 remaining from Phase 20-23. Bound by:
+- `ezkl` workspace dep (with feature flags for native vs WASM proving)
+- bridging `tirami-zkml-bench`'s `MockBackend` to a real backend
+  behind a runtime selector
+- per-model benchmark calibration so proof time stays bounded
+- governance ratchet wiring so the proof requirement can step
+  up from Optional → Recommended → Required without breaking
+  legacy clients
+
+Multi-week scope and deliberately reserved for its own phase.
 
 ## Out of Phase 23 scope (Phase 24+)
 


### PR DESCRIPTION
## Summary

Until Wave 3, an imported AgentIdentity lived only in memory: a restart dropped it and the operator had to re-import from a bundle every time. Wave 3 adds **optional encrypted persistence** so the identity survives restarts as cleanly as the rest of the ledger.

## Design

Wave 4 already shipped the perfect at-rest format: \`AgentIdentityBundle\` is JSON-serialisable, encrypted with **Argon2id + XChaCha20-Poly1305**, and authenticates the salted ciphertext. Wave 3 reuses **exactly that envelope** as the on-disk format — an exported bundle and a persisted file are byte-identical structures. Operators can rsync / B2 / etc. without diverging on schema.

## What ships

### \`state_persist::{save,load}_agent_identity\`

\`\`\`rust
pub fn save_agent_identity(id: &AgentIdentity, path: &Path, passphrase: &str) -> io::Result<()>
pub fn load_agent_identity(path: &Path, passphrase: &str) -> io::Result<Option<AgentIdentity>>
\`\`\`

On Unix the save path sets \`chmod 600\` after the write (the file is already encrypted; the perm bit adds defense-in-depth on shared hosts).

### \`Config\` additions

\`\`\`rust
pub agent_identity_path: Option<PathBuf>           // default None
pub agent_identity_passphrase_env: String          // default "TIRAMI_AGENT_IDENTITY_PASSPHRASE"
\`\`\`

**Both must be set** for persistence to engage. Either alone is a silent no-op — the identity stays ephemeral. A misconfigured deploy can't silently store unencrypted material; the only fail-open is "don't persist".

### \`TiramiNode::new\` auto-loads at startup

- Wrong passphrase → log at \`warn\`, node still boots with a fresh ephemeral slot
- Missing file → \`debug\` (clean first-boot)
- Missing env var → \`info\` (persistence intentionally disabled)

### HTTP \`init\` / \`import\` auto-saves

After the AppState slot is populated, the encrypted bundle is written. Best-effort — write failure logs at \`warn\` but the HTTP request still returns the in-memory identity normally.

## Properties

| Property | Pre-Wave-3 | Post-Wave-3 |
|---|---|---|
| AgentIdentity survives node restart | ❌ | ✅ (when configured) |
| Persisted file is encrypted at rest | N/A | ✅ |
| Wrong passphrase aborts startup | N/A | ❌ (warn + ephemeral fallback) |
| Missing env var silently disables persist | N/A | ✅ |
| File mode 0600 on Unix | N/A | ✅ |

## Test plan

- [x] \`cargo test --workspace\` → **1,363 passed, 0 failed** (was 1,356 → +7 new)
- [x] 7 new unit tests on \`state_persist\`:
  - save → load round-trip preserves seed / pubkey / display_name / created_at_ms
  - load missing path → \`Ok(None)\`
  - load wrong passphrase → \`Err(InvalidInput)\`
  - save short passphrase → \`Err(InvalidInput)\` AND file is NOT created
  - save → corrupt file → load → \`Err(InvalidData)\`
  - Unix file mode is exactly \`0o600\`
  - save → load → save → load preserves the seed byte-for-byte (no nondeterminism)

## Operator UX

\`\`\`bash
export TIRAMI_AGENT_IDENTITY_PASSPHRASE="$(openssl rand -hex 32)"
# config:
agent_identity_path = "~/.tirami/agent_identity.json"
\`\`\`

## Phase 23 status after Wave 3

| Wave | Subject | Status |
|---|---|---|
| 1 | wallet ↔ AgentIdentity link | ✅ #103 |
| 2 | P2P signer follows AgentIdentity | ✅ #104 |
| 2.5 | shared agent_identity Arc | ✅ #105 |
| 3 | on-disk persistence + auto-load | ✅ **this PR** |
| Phase 24 | zkML real backends (ezkl / risc0) | deferred |

All of "the AgentIdentity follows the agent across machines AND restarts" is now structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)