### PR TITLE
feat(phase-24/wave-2.5): pipeline ed-attest produce + ledger signer enforcement

### DIFF
--- a/crates/tirami-ledger/src/ledger.rs
+++ b/crates/tirami-ledger/src/ledger.rs
@@ -554,6 +554,24 @@ impl SignedTradeRecord {
 
         Ok(())
     }
+
+    /// Phase 24 Wave 2.5 — lightweight check on the optional zkML
+    /// attestation: if present, its embedded signer pubkey must
+    /// match the trade's `provider`. Does NOT verify the underlying
+    /// Ed25519 signature on the attestation (Wave 3 will wire that
+    /// once the wire format carries the prompt/output hashes
+    /// receivers need to reconstruct the BenchSpec).
+    ///
+    /// Returns `Ok(())` when there is no attestation (no constraint).
+    pub fn check_attestation_signer(&self) -> Result<(), SignatureError> {
+        let Some(att) = self.attestation.as_ref() else {
+            return Ok(());
+        };
+        match att.ed_attest_signer() {
+            Some(pk) if pk == self.trade.provider.0 => Ok(()),
+            _ => Err(SignatureError::AttestationSignerMismatch),
+        }
+    }
 }
 
 /// Errors during trade signature verification.
@@ -574,6 +592,11 @@ pub enum SignatureError {
     /// the trade would be a replay (double-bill the consumer).
     #[error("replayed nonce for provider {provider}")]
     ReplayedNonce { provider: String },
+    /// Phase 24 Wave 2.5 — the optional zkML attestation's embedded
+    /// signer pubkey did not match the trade's `provider`, OR the
+    /// attestation bytes are malformed (wrong backend / wrong length).
+    #[error("attestation signer does not match trade provider")]
+    AttestationSignerMismatch,
 }
 
 /// Errors raised when creating a new loan via [`ComputeLedger::create_loan`].
@@ -1292,6 +1315,11 @@ impl ComputeLedger {
         signed: &SignedTradeRecord,
     ) -> Result<(), SignatureError> {
         signed.verify()?;
+        // Phase 24 Wave 2.5 — if the trade carries a zkML attestation,
+        // the attestation's embedded signer pubkey must equal the
+        // trade's provider. Tampered/swapped attestations are rejected
+        // here regardless of `proof_policy`.
+        signed.check_attestation_signer()?;
         if signed.trade.has_nonce() {
             let cache = self
                 .seen_nonces
@@ -2947,6 +2975,120 @@ mod tests {
         assert!(ledger.execute_signed_trade(&signed).is_ok());
         // v1 path must NOT populate the nonce cache.
         assert!(ledger.seen_nonces.is_empty());
+    }
+
+    // ---------------------------------------------------------------------
+    // Phase 24 Wave 2.5 — attestation signer enforcement on
+    // execute_signed_trade
+    // ---------------------------------------------------------------------
+
+    fn build_attested_trade(
+        attestation: Option<TradeAttestation>,
+    ) -> (SignedTradeRecord, ed25519_dalek::SigningKey) {
+        use ed25519_dalek::{Signer, SigningKey};
+        let mut rng = rand::thread_rng();
+        let provider_key = SigningKey::generate(&mut rng);
+        let consumer_key = SigningKey::generate(&mut rng);
+        let trade = TradeRecord {
+            provider: NodeId(provider_key.verifying_key().to_bytes()),
+            consumer: NodeId(consumer_key.verifying_key().to_bytes()),
+            trm_amount: 100,
+            tokens_processed: 10,
+            timestamp: now_millis(),
+            model_id: "wave25".to_string(),
+            flops_estimated: 0,
+            nonce: TradeRecord::fresh_nonce(),
+        };
+        let canonical = trade.canonical_bytes();
+        let signed = SignedTradeRecord {
+            trade,
+            provider_sig: provider_key.sign(&canonical).to_bytes().to_vec(),
+            consumer_sig: consumer_key.sign(&canonical).to_bytes().to_vec(),
+            attestation,
+        };
+        (signed, provider_key)
+    }
+
+    #[test]
+    fn check_attestation_signer_passes_when_attestation_is_none() {
+        let (signed, _) = build_attested_trade(None);
+        assert!(signed.check_attestation_signer().is_ok());
+    }
+
+    #[test]
+    fn check_attestation_signer_passes_when_signer_matches_provider() {
+        // Build an ed-attest attestation with the provider's own pubkey
+        // embedded — the only configuration honest providers should
+        // produce.
+        let (mut signed, provider_key) = build_attested_trade(None);
+        let mut bytes = vec![0u8; 96];
+        bytes[..32].copy_from_slice(&provider_key.verifying_key().to_bytes());
+        signed.attestation = Some(TradeAttestation::new("ed-attest".into(), bytes));
+        signed.check_attestation_signer().expect("signer match");
+    }
+
+    #[test]
+    fn check_attestation_signer_rejects_signer_mismatch() {
+        let (mut signed, _) = build_attested_trade(None);
+        let mut bytes = vec![0u8; 96];
+        // Pubkey segment is a different random value (not provider).
+        bytes[0] = 0xAB;
+        signed.attestation = Some(TradeAttestation::new("ed-attest".into(), bytes));
+        let err = signed.check_attestation_signer().unwrap_err();
+        assert!(matches!(err, SignatureError::AttestationSignerMismatch));
+    }
+
+    #[test]
+    fn check_attestation_signer_rejects_wrong_backend_name() {
+        let (mut signed, provider_key) = build_attested_trade(None);
+        // Even with the right pubkey, the wrong backend label means
+        // ed_attest_signer() returns None → reject.
+        let mut bytes = vec![0u8; 96];
+        bytes[..32].copy_from_slice(&provider_key.verifying_key().to_bytes());
+        signed.attestation = Some(TradeAttestation::new("mock".into(), bytes));
+        let err = signed.check_attestation_signer().unwrap_err();
+        assert!(matches!(err, SignatureError::AttestationSignerMismatch));
+    }
+
+    #[test]
+    fn check_attestation_signer_rejects_short_attestation_bytes() {
+        let (mut signed, _) = build_attested_trade(None);
+        signed.attestation = Some(TradeAttestation::new("ed-attest".into(), vec![0u8; 64]));
+        let err = signed.check_attestation_signer().unwrap_err();
+        assert!(matches!(err, SignatureError::AttestationSignerMismatch));
+    }
+
+    #[test]
+    fn execute_signed_trade_accepts_valid_attestation() {
+        let (mut signed, provider_key) = build_attested_trade(None);
+        let mut bytes = vec![0u8; 96];
+        bytes[..32].copy_from_slice(&provider_key.verifying_key().to_bytes());
+        signed.attestation = Some(TradeAttestation::new("ed-attest".into(), bytes));
+        let mut ledger = ComputeLedger::new();
+        assert!(ledger.execute_signed_trade(&signed).is_ok());
+    }
+
+    #[test]
+    fn execute_signed_trade_rejects_tampered_attestation() {
+        let (mut signed, _) = build_attested_trade(None);
+        let mut bytes = vec![0u8; 96];
+        bytes[0] = 0xCD; // wrong pubkey, not the provider
+        signed.attestation = Some(TradeAttestation::new("ed-attest".into(), bytes));
+        let mut ledger = ComputeLedger::new();
+        let err = ledger.execute_signed_trade(&signed).unwrap_err();
+        assert!(matches!(err, SignatureError::AttestationSignerMismatch));
+    }
+
+    #[test]
+    fn execute_signed_trade_no_attestation_path_is_unchanged() {
+        let (signed, _) = build_attested_trade(None);
+        let mut ledger = ComputeLedger::new();
+        assert!(ledger.execute_signed_trade(&signed).is_ok());
+        // Confirm the trade landed by inspecting balances.
+        assert_eq!(
+            ledger.get_balance(&signed.trade.provider).unwrap().contributed,
+            signed.trade.trm_amount
+        );
     }
 
     #[test]

--- a/crates/tirami-node/Cargo.toml
+++ b/crates/tirami-node/Cargo.toml
@@ -21,6 +21,7 @@ tirami-bank = { workspace = true }
 tirami-mind = { workspace = true }
 tirami-anchor = { workspace = true }
 tirami-agora = { workspace = true }
+tirami-zkml-bench = { workspace = true }
 iroh = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/tirami-node/src/pipeline.rs
+++ b/crates/tirami-node/src/pipeline.rs
@@ -3,6 +3,8 @@ use tirami_ledger::{
     ComputeLedger, InferenceIneligible, LoanRecord, LoanStatus, SignedTradeRecord, StakingPool,
     TradeRecord,
 };
+use tirami_ledger::ledger::TradeAttestation;
+use tirami_zkml_bench::{BenchSpec, EdAttestBackend, BenchBackend};
 use tirami_net::{ClusterManager, ForgeTransport, GossipState};
 use tirami_proto::{
     Envelope, ErrorCode, ErrorMsg, InferenceRequest, LoanAccept, Payload, PipelineTopologyMsg,
@@ -1011,6 +1013,20 @@ async fn handle_inference(
         agent_identity.as_ref(),
     );
 
+    // Phase 24 Wave 2.5 — produce a zkML attestation when the operator
+    // has selected `ed-attest` AND an AgentIdentity is loaded. The
+    // attestation rides on the SignedTradeRecord so receivers can
+    // verify it independently of the dual-signature.
+    let attestation = produce_ed_attest_attestation(
+        config,
+        agent_identity.as_ref(),
+        &req.prompt_text,
+        &tokens,
+        &trade.model_id,
+        total_tokens,
+        trade.flops_estimated,
+    );
+
     // Fix #80 — register the dispatcher slot BEFORE sending the
     // TradeProposal so we can't race a very-fast counter-sign.
     let (accept_tx, accept_rx) = oneshot::channel::<Vec<u8>>();
@@ -1066,7 +1082,7 @@ async fn handle_inference(
                 trade: trade.clone(),
                 provider_sig,
                 consumer_sig,
-            attestation: None,
+                attestation,
             };
             // Phase 17 Wave 1.2 — route through execute_signed_trade so the
             // ledger re-verifies signatures AND enforces nonce dedup. The
@@ -1175,6 +1191,69 @@ fn now_millis() -> u64 {
 ///
 /// Extracted as a free function so the per-trade logic is unit-
 /// testable without spinning up the whole pipeline.
+/// Phase 24 Wave 2.5 — build a `BenchSpec` from the inputs and
+/// outputs of an inference call. Pure function so it's trivially
+/// testable. `model_id`, `prompt`, and the concatenated
+/// `output_tokens` get hashed with SHA-256.
+pub(crate) fn build_bench_spec(
+    prompt: &str,
+    output_tokens: &[String],
+    model_id: &str,
+    token_count: u64,
+    flops: u64,
+) -> BenchSpec {
+    use sha2::{Digest, Sha256};
+    let model_hash: [u8; 32] = Sha256::digest(model_id.as_bytes()).into();
+    let prompt_hash: [u8; 32] = Sha256::digest(prompt.as_bytes()).into();
+    let output_hash: [u8; 32] = {
+        let mut h = Sha256::new();
+        for t in output_tokens {
+            h.update(t.as_bytes());
+        }
+        h.finalize().into()
+    };
+    BenchSpec {
+        model_hash,
+        prompt_hash,
+        output_hash,
+        token_count,
+        flops,
+    }
+}
+
+/// Phase 24 Wave 2.5 — produce an ed-attest attestation, but only
+/// when `config.zkml_backend == "ed-attest"` AND an `AgentIdentity`
+/// is loaded. Returns `None` otherwise so the trade goes out
+/// without an attestation (existing pre-Wave-2 behaviour).
+pub(crate) fn produce_ed_attest_attestation(
+    config: &Config,
+    agent_identity: Option<&tirami_mind::AgentIdentity>,
+    prompt: &str,
+    output_tokens: &[String],
+    model_id: &str,
+    token_count: u64,
+    flops: u64,
+) -> Option<TradeAttestation> {
+    if config.zkml_backend.trim().to_ascii_lowercase() != "ed-attest" {
+        return None;
+    }
+    let agent = agent_identity?;
+    if token_count == 0 {
+        // EdAttestBackend rejects token_count = 0; skip cleanly.
+        return None;
+    }
+    let spec = build_bench_spec(prompt, output_tokens, model_id, token_count, flops);
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&agent.seed());
+    let backend = EdAttestBackend::from_signing_key(signing_key);
+    match backend.prove(&spec) {
+        Ok(proof) => Some(proof.into()),
+        Err(e) => {
+            tracing::warn!("ed-attest proof generation failed: {e}");
+            None
+        }
+    }
+}
+
 pub(crate) fn resolve_outbound_trade_signing<F>(
     canonical: &[u8],
     machine_node_id: &NodeId,
@@ -1702,5 +1781,110 @@ mod tests {
         transport_worker.close().await;
         transport_seed.close().await;
         seed_task.await.expect("seed task");
+    }
+
+    // ---------------------------------------------------------------------
+    // Phase 24 Wave 2.5 — attestation produce path
+    // ---------------------------------------------------------------------
+
+    fn config_with_zkml_backend(backend: &str) -> Config {
+        Config {
+            zkml_backend: backend.to_string(),
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn build_bench_spec_is_deterministic() {
+        let a = build_bench_spec("hello", &["world".to_string()], "m", 1, 0);
+        let b = build_bench_spec("hello", &["world".to_string()], "m", 1, 0);
+        assert_eq!(a.model_hash, b.model_hash);
+        assert_eq!(a.prompt_hash, b.prompt_hash);
+        assert_eq!(a.output_hash, b.output_hash);
+    }
+
+    #[test]
+    fn build_bench_spec_changes_with_any_input() {
+        let base = build_bench_spec("p", &["o".to_string()], "m", 1, 0);
+        assert_ne!(base.prompt_hash, build_bench_spec("p2", &["o".to_string()], "m", 1, 0).prompt_hash);
+        assert_ne!(base.output_hash, build_bench_spec("p", &["o2".to_string()], "m", 1, 0).output_hash);
+        assert_ne!(base.model_hash, build_bench_spec("p", &["o".to_string()], "m2", 1, 0).model_hash);
+        assert_eq!(base.token_count + 1, build_bench_spec("p", &["o".to_string()], "m", 2, 0).token_count);
+        assert_eq!(base.flops + 1, build_bench_spec("p", &["o".to_string()], "m", 1, 1).flops);
+    }
+
+    #[test]
+    fn produce_ed_attest_skips_when_backend_is_mock() {
+        let config = config_with_zkml_backend("mock");
+        let agent = tirami_mind::AgentIdentity::generate(0, None);
+        let att = produce_ed_attest_attestation(
+            &config, Some(&agent), "p", &["o".to_string()], "m", 1, 0,
+        );
+        assert!(att.is_none());
+    }
+
+    #[test]
+    fn produce_ed_attest_skips_without_agent_identity() {
+        let config = config_with_zkml_backend("ed-attest");
+        let att = produce_ed_attest_attestation(
+            &config, None, "p", &["o".to_string()], "m", 1, 0,
+        );
+        assert!(att.is_none());
+    }
+
+    #[test]
+    fn produce_ed_attest_skips_when_token_count_is_zero() {
+        let config = config_with_zkml_backend("ed-attest");
+        let agent = tirami_mind::AgentIdentity::generate(0, None);
+        let att = produce_ed_attest_attestation(
+            &config, Some(&agent), "p", &[], "m", 0, 0,
+        );
+        assert!(att.is_none());
+    }
+
+    #[test]
+    fn produce_ed_attest_emits_attestation_with_agent_pubkey() {
+        let config = config_with_zkml_backend("ed-attest");
+        let agent = tirami_mind::AgentIdentity::generate(0, None);
+        let att = produce_ed_attest_attestation(
+            &config, Some(&agent), "hello", &["world".to_string()], "m", 1, 0,
+        ).expect("must produce attestation");
+        assert_eq!(att.backend, "ed-attest");
+        let signer = att.ed_attest_signer().expect("96-byte ed-attest");
+        assert_eq!(signer, agent.public_key_bytes());
+    }
+
+    #[test]
+    fn produce_ed_attest_is_case_insensitive_on_backend_name() {
+        let config = config_with_zkml_backend("Ed-Attest");
+        let agent = tirami_mind::AgentIdentity::generate(0, None);
+        let att = produce_ed_attest_attestation(
+            &config, Some(&agent), "p", &["o".to_string()], "m", 1, 0,
+        );
+        assert!(att.is_some());
+    }
+
+    #[test]
+    fn produce_ed_attest_verifies_with_zkml_helper() {
+        // End-to-end: producer → verify_trade_attestation with the
+        // same BenchSpec succeeds; with the wrong signer fails.
+        let config = config_with_zkml_backend("ed-attest");
+        let agent = tirami_mind::AgentIdentity::generate(0, None);
+        let prompt = "p";
+        let outputs = vec!["o".to_string()];
+        let att = produce_ed_attest_attestation(
+            &config, Some(&agent), prompt, &outputs, "m", 1, 0,
+        ).expect("produce");
+        let spec = build_bench_spec(prompt, &outputs, "m", 1, 0);
+        // Correct signer passes.
+        tirami_zkml_bench::verify_trade_attestation(
+            &spec, &att, &agent.public_key_bytes(),
+        ).expect("correct signer");
+        // Wrong signer fails.
+        let other = tirami_mind::AgentIdentity::generate(0, None);
+        let err = tirami_zkml_bench::verify_trade_attestation(
+            &spec, &att, &other.public_key_bytes(),
+        );
+        assert!(err.is_err());
     }
 }

--- a/docs/phase-24-zkml-real-backends.md
+++ b/docs/phase-24-zkml-real-backends.md
@@ -8,7 +8,7 @@
 > forgeable" to "production-grade proof of inference" without a
 > single multi-week commit.
 
-Status: Wave 1 + Wave 2 (data-plane) shipped.
+Status: Wave 1 + Wave 2 + Wave 2.5 shipped.
 
 ## The trajectory
 
@@ -159,27 +159,56 @@ without yet wiring the producer/verifier into `handle_inference`
 - Tests: `tirami-zkml-bench` +9, `tirami-core` +6. Workspace
   passes 1,397 tests.
 
-### Wave 2.5 (next, bounded) — pipeline produce + verify
+### Wave 2.5 ✅ shipped — pipeline produce + signer enforcement
 
-The protocol now *carries* attestations but `pipeline.rs::handle_inference`
-does not yet *produce* them, and `TradeGossip` does not yet *verify*
-them. Wave 2.5 wires:
+Wave 2.5 wires the producer path and the lightweight receiver-side
+enforcement onto the data-plane Wave 2 added.
 
-- Provider side (`handle_inference`): when `config.zkml_backend ==
-  "ed-attest"` AND an `AgentIdentity` is loaded, construct a
-  `BenchSpec` over (model_id_hash, prompt_hash, output_hash,
-  total_tokens, flops_estimated), call
-  `EdAttestBackend::from_signing_key(agent_identity.signing_key())
-  .prove(spec)`, and attach the resulting `TradeAttestation` to
-  the `SignedTradeRecord` before `execute_signed_trade`.
-- Consumer/Gossip side: when receiving a `SignedTradeRecord` with
-  `attestation: Some(_)`, call `verify_trade_attestation(spec,
-  attestation, &trade.provider.0)`. Failure → reject the trade
-  (in `proof_policy = "required"` mode) or downgrade reputation
-  (in `recommended` mode).
+- ✅ `pipeline.rs::handle_inference` produces an ed-attest
+  attestation when `config.zkml_backend == "ed-attest"` AND an
+  `AgentIdentity` is loaded. Helpers:
+  - `build_bench_spec(prompt, output_tokens, model_id,
+    token_count, flops)` — pure function, deterministic SHA-256
+    digest construction.
+  - `produce_ed_attest_attestation(config, agent_identity, ...)`
+    — returns `Some(TradeAttestation)` for the happy path,
+    `None` when the backend is not `ed-attest`, no agent is
+    loaded, or `token_count == 0`.
+- ✅ `SignedTradeRecord::check_attestation_signer()` —
+  lightweight check that the attestation's embedded signer
+  pubkey (bytes[0..32]) equals `trade.provider`. Does NOT
+  cryptographically verify the underlying Ed25519 signature
+  yet — Wave 3 (full crypto) requires the wire format to carry
+  prompt/output hashes so the receiver can rebuild the BenchSpec.
+- ✅ `ComputeLedger::execute_signed_trade` enforces
+  `check_attestation_signer` BEFORE recording the trade.
+  Tampered or swapped attestations are rejected with
+  `SignatureError::AttestationSignerMismatch` regardless of
+  `proof_policy`.
 
-Wave 2.5 is bounded but touches the inference path so it ships as
-its own PR.
+#### Tests added
+
+`tirami-ledger` +8: `check_attestation_signer_*` (5) + execute path
+(3 — accepts valid, rejects tampered, no-attestation path
+unchanged). `tirami-node::pipeline` +8: `build_bench_spec_*` (2) +
+`produce_ed_attest_*` (6). Workspace passes **1,413** tests
+(Wave 1 1,380 → Wave 2 1,397 → Wave 2.5 1,413).
+
+### Wave 3 (next) — gossip wire + full crypto verify
+
+Wave 2.5 leaves two surfaces still TODO:
+
+1. **Gossip transport.** `TradeGossip` proto messages do not yet
+   carry `attestation`. Wave 3 widens the wire format (in a
+   serde-default-compatible way) so attestations propagate.
+2. **Full crypto verify.** Today the receiver only verifies
+   *signer ↔ provider* equality. Wave 3 carries `prompt_hash`,
+   `output_hash`, `model_hash`, `token_count`, `flops` along
+   with the trade so receivers can rebuild the BenchSpec and
+   call `verify_trade_attestation` for the actual signature
+   check. Alternatively (and preferably), pick a real zk
+   backend (`risc0` or `ezkl`) so the attestation itself proves
+   computation correctness, not just signer identity.
 
 ## Wave 3 — risc0 or ezkl integration
 


### PR DESCRIPTION
## Summary

Phase 24 Wave 2.5 — wires the **producer** path and a **lightweight receiver-side check** onto the Wave 2 data-plane.

### Producer (tirami-node::pipeline)

- `build_bench_spec(prompt, outputs, model_id, token_count, flops)` — pure, deterministic SHA-256 over the inputs.
- `produce_ed_attest_attestation(config, agent, ...)` — returns `Some(TradeAttestation)` when `config.zkml_backend == \"ed-attest\"` AND an `AgentIdentity` is loaded AND `token_count > 0`; `None` otherwise.
- `handle_inference` now attaches the attestation to the `SignedTradeRecord` it executes after `TradeAccept`.

### Receiver enforcement (tirami-ledger)

- `SignedTradeRecord::check_attestation_signer()` — lightweight check that the attestation's embedded signer pubkey equals `trade.provider`.
- `ComputeLedger::execute_signed_trade` calls it **before** recording the trade. Tampered/swapped attestations are rejected with `SignatureError::AttestationSignerMismatch` regardless of `proof_policy`.

### What's not yet done (Wave 3)

Full cryptographic verify of the underlying Ed25519 signature on the attestation requires the receiver to reconstruct the `BenchSpec` (prompt/output hashes), which gossip receivers do not have today. Wave 3 widens the wire format or moves to a real zk backend.

## Test count

Workspace **1,413 passing** (Wave 2 1,397 → Wave 2.5 1,413, +16):
- `tirami-ledger` +8: `check_attestation_signer` matrix (5) + execute path (3 — accepts valid, rejects tampered, no-attestation path unchanged)
- `tirami-node::pipeline` +8: `build_bench_spec` determinism + field-sensitivity (2) + `produce_ed_attest_*` happy/sad paths (6)

## Test plan

- [x] `cargo check --workspace` — warnings only
- [x] `cargo test --workspace` — 1,413 pass, 0 fail
- [x] `cargo test -p tirami-ledger` — 548 pass (was 540 → +8)
- [x] `cargo test -p tirami-node --lib pipeline::` — all new tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)