### PR TITLE
feat(phase-24/wave-3): gossip wire carries attestation + full crypto verify

### DIFF
--- a/crates/tirami-ledger/src/ledger.rs
+++ b/crates/tirami-ledger/src/ledger.rs
@@ -513,6 +513,33 @@ impl TradeAttestation {
     }
 }
 
+// Phase 24 Wave 3 — wire <-> ledger conversions. tirami-proto's
+// `TradeAttestationWire` is a structural mirror; the dep direction
+// (proto < ledger) prevents us from defining the conversion there.
+impl From<&TradeAttestation> for tirami_proto::TradeAttestationWire {
+    fn from(t: &TradeAttestation) -> Self {
+        Self { backend: t.backend.clone(), bytes: t.bytes.clone() }
+    }
+}
+
+impl From<TradeAttestation> for tirami_proto::TradeAttestationWire {
+    fn from(t: TradeAttestation) -> Self {
+        Self { backend: t.backend, bytes: t.bytes }
+    }
+}
+
+impl From<&tirami_proto::TradeAttestationWire> for TradeAttestation {
+    fn from(w: &tirami_proto::TradeAttestationWire) -> Self {
+        Self { backend: w.backend.clone(), bytes: w.bytes.clone() }
+    }
+}
+
+impl From<tirami_proto::TradeAttestationWire> for TradeAttestation {
+    fn from(w: tirami_proto::TradeAttestationWire) -> Self {
+        Self { backend: w.backend, bytes: w.bytes }
+    }
+}
+
 impl SignedTradeRecord {
     /// Verify both signatures on this trade.
     /// Maximum age of a trade timestamp before rejection (1 hour).

--- a/crates/tirami-net/Cargo.toml
+++ b/crates/tirami-net/Cargo.toml
@@ -20,6 +20,7 @@ rand = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 tirami-ledger = { workspace = true }
+tirami-zkml-bench = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 

--- a/crates/tirami-net/src/gossip.rs
+++ b/crates/tirami-net/src/gossip.rs
@@ -158,11 +158,17 @@ impl Default for GossipState {
     }
 }
 
-/// Broadcast a signed trade to all connected peers.
+/// Broadcast a signed trade to all connected peers. `bench_spec_hint`
+/// (Phase 24 Wave 3) is shipped alongside the trade when the provider
+/// has attached a zkML attestation; receivers use it to rebuild the
+/// `BenchSpec` and verify the proof. Pass `None` if no attestation
+/// was attached or no hint is available — the trade still propagates,
+/// just without verifiable computation evidence.
 pub async fn broadcast_trade(
     transport: &ForgeTransport,
     gossip: &Arc<Mutex<GossipState>>,
     signed: &SignedTradeRecord,
+    bench_spec_hint: Option<tirami_proto::BenchSpecHint>,
 ) {
     // Mark as seen locally first
     gossip.lock().await.mark_seen(signed);
@@ -173,6 +179,8 @@ pub async fn broadcast_trade(
     if peers.is_empty() {
         return;
     }
+
+    let attestation = signed.attestation.as_ref().map(Into::into);
 
     let msg = Envelope {
         msg_id: rand::random(),
@@ -188,6 +196,8 @@ pub async fn broadcast_trade(
             provider_sig: signed.provider_sig.clone(),
             consumer_sig: signed.consumer_sig.clone(),
             nonce: signed.trade.nonce,
+            attestation,
+            bench_spec_hint,
         }),
     };
 
@@ -224,17 +234,47 @@ pub async fn handle_trade_gossip(
         nonce: msg.nonce,
     };
 
+    // Phase 24 Wave 3 — reconstruct the on-trade attestation from the
+    // wire form, if the producer attached one.
+    let attestation: Option<tirami_ledger::ledger::TradeAttestation> =
+        msg.attestation.as_ref().map(Into::into);
+
     let signed = SignedTradeRecord {
         trade,
         provider_sig: msg.provider_sig.clone(),
         consumer_sig: msg.consumer_sig.clone(),
-            attestation: None,
+        attestation,
     };
 
     // Verify both signatures
     if let Err(e) = signed.verify() {
         tracing::warn!("Gossip trade failed verification: {}", e);
         return None;
+    }
+
+    // Phase 24 Wave 3 — full cryptographic verification of the
+    // attestation if both (a) an attestation is attached AND
+    // (b) the producer shipped a `BenchSpecHint`. We can rebuild
+    // the producer's `BenchSpec` and call the zkml-bench verifier.
+    // The cheap signer-match check already happens inside
+    // `ComputeLedger::execute_signed_trade`; this is the
+    // *cryptographic* layer above that.
+    if let (Some(att), Some(hint)) = (signed.attestation.as_ref(), msg.bench_spec_hint.as_ref()) {
+        let spec = tirami_zkml_bench::BenchSpec {
+            model_hash: hint.model_hash,
+            prompt_hash: hint.prompt_hash,
+            output_hash: hint.output_hash,
+            token_count: signed.trade.tokens_processed,
+            flops: hint.flops,
+        };
+        if let Err(e) = tirami_zkml_bench::verify_trade_attestation(
+            &spec,
+            att,
+            &signed.trade.provider.0,
+        ) {
+            tracing::warn!("Gossip trade attestation verify failed: {e:?}");
+            return None;
+        }
     }
 
     // Check if we've already seen this trade
@@ -649,6 +689,8 @@ mod tests {
             provider_sig: vec![0u8; 64], // invalid
             consumer_sig: vec![0u8; 64], // invalid
             nonce: [0u8; 16],
+            attestation: None,
+            bench_spec_hint: None,
         };
 
         let result = handle_trade_gossip(&gossip, &msg).await;
@@ -670,6 +712,8 @@ mod tests {
             provider_sig: signed.provider_sig.clone(),
             consumer_sig: signed.consumer_sig.clone(),
             nonce: signed.trade.nonce,
+            attestation: None,
+            bench_spec_hint: None,
         };
 
         let result = handle_trade_gossip(&gossip, &msg).await;
@@ -678,6 +722,260 @@ mod tests {
         // Second time should be deduplicated
         let result2 = handle_trade_gossip(&gossip, &msg).await;
         assert!(result2.is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 24 Wave 3 — attestation propagation + cryptographic verify
+    // ---------------------------------------------------------------
+
+    /// Build a dual-signed trade whose provider keypair is exposed so
+    /// the test can additionally produce an ed-attest proof under the
+    /// same identity (so attestation.signer == trade.provider).
+    fn make_signed_trade_with_keys() -> (SignedTradeRecord, SigningKey) {
+        let mut rng = rand::thread_rng();
+        let provider_key = SigningKey::generate(&mut rng);
+        let consumer_key = SigningKey::generate(&mut rng);
+        let trade = tirami_ledger::TradeRecord {
+            provider: NodeId(provider_key.verifying_key().to_bytes()),
+            consumer: NodeId(consumer_key.verifying_key().to_bytes()),
+            trm_amount: 100,
+            tokens_processed: 5,
+            timestamp: now_millis(),
+            model_id: "wave3".to_string(),
+            flops_estimated: 0,
+            nonce: [1u8; 16],
+        };
+        let canonical = trade.canonical_bytes();
+        let provider_sig = provider_key.sign(&canonical).to_bytes().to_vec();
+        let consumer_sig = consumer_key.sign(&canonical).to_bytes().to_vec();
+        let signed = SignedTradeRecord {
+            trade,
+            provider_sig,
+            consumer_sig,
+            attestation: None,
+        };
+        (signed, provider_key)
+    }
+
+    /// Synthesise an ed-attest attestation + matching BenchSpecHint
+    /// over arbitrary prompt/output blobs. Used to put the gossip
+    /// receiver's full-crypto verify path under test.
+    fn ed_attest_for(
+        provider_key: &SigningKey,
+        prompt: &str,
+        outputs: &[&str],
+        model_id: &str,
+        token_count: u64,
+        flops: u64,
+    ) -> (tirami_proto::TradeAttestationWire, tirami_proto::BenchSpecHint) {
+        use sha2::{Digest, Sha256};
+        let model_hash: [u8; 32] = Sha256::digest(model_id.as_bytes()).into();
+        let prompt_hash: [u8; 32] = Sha256::digest(prompt.as_bytes()).into();
+        let output_hash: [u8; 32] = {
+            let mut h = Sha256::new();
+            for o in outputs {
+                h.update(o.as_bytes());
+            }
+            h.finalize().into()
+        };
+        let spec = tirami_zkml_bench::BenchSpec {
+            model_hash,
+            prompt_hash,
+            output_hash,
+            token_count,
+            flops,
+        };
+        let backend = tirami_zkml_bench::EdAttestBackend::from_signing_key(
+            SigningKey::from_bytes(&provider_key.to_bytes()),
+        );
+        use tirami_zkml_bench::BenchBackend;
+        let proof = backend.prove(&spec).expect("prove");
+        let att_wire = tirami_proto::TradeAttestationWire {
+            backend: proof.backend.clone(),
+            bytes: proof.bytes.clone(),
+        };
+        let hint = tirami_proto::BenchSpecHint { model_hash, prompt_hash, output_hash, flops };
+        (att_wire, hint)
+    }
+
+    #[tokio::test]
+    async fn handle_gossip_accepts_attested_trade_with_valid_hint() {
+        let gossip = Arc::new(Mutex::new(GossipState::new()));
+        let (signed, provider_key) = make_signed_trade_with_keys();
+        let (att, hint) = ed_attest_for(
+            &provider_key,
+            "p",
+            &["o"],
+            "wave3",
+            signed.trade.tokens_processed,
+            0,
+        );
+        let msg = TradeGossip {
+            provider: signed.trade.provider.clone(),
+            consumer: signed.trade.consumer.clone(),
+            trm_amount: signed.trade.trm_amount,
+            tokens_processed: signed.trade.tokens_processed,
+            timestamp: signed.trade.timestamp,
+            model_id: signed.trade.model_id.clone(),
+            provider_sig: signed.provider_sig.clone(),
+            consumer_sig: signed.consumer_sig.clone(),
+            nonce: signed.trade.nonce,
+            attestation: Some(att),
+            bench_spec_hint: Some(hint),
+        };
+        let result = handle_trade_gossip(&gossip, &msg).await;
+        assert!(result.is_some(), "valid attested trade must be accepted");
+        let recovered = result.unwrap();
+        assert!(recovered.attestation.is_some());
+    }
+
+    #[tokio::test]
+    async fn handle_gossip_rejects_attestation_with_wrong_hint() {
+        // Producer attested over prompt="p", outputs=["o"]. Receiver
+        // gets a hint over a *different* prompt → verify must fail.
+        let gossip = Arc::new(Mutex::new(GossipState::new()));
+        let (signed, provider_key) = make_signed_trade_with_keys();
+        let (att, _) = ed_attest_for(
+            &provider_key,
+            "p",
+            &["o"],
+            "wave3",
+            signed.trade.tokens_processed,
+            0,
+        );
+        // Build a hint that disagrees with what was signed.
+        use sha2::{Digest, Sha256};
+        let wrong_prompt_hash: [u8; 32] = Sha256::digest(b"different-prompt").into();
+        let wrong_hint = tirami_proto::BenchSpecHint {
+            model_hash: Sha256::digest(b"wave3").into(),
+            prompt_hash: wrong_prompt_hash,
+            output_hash: Sha256::digest(b"o").into(),
+            flops: 0,
+        };
+        let msg = TradeGossip {
+            provider: signed.trade.provider.clone(),
+            consumer: signed.trade.consumer.clone(),
+            trm_amount: signed.trade.trm_amount,
+            tokens_processed: signed.trade.tokens_processed,
+            timestamp: signed.trade.timestamp,
+            model_id: signed.trade.model_id.clone(),
+            provider_sig: signed.provider_sig.clone(),
+            consumer_sig: signed.consumer_sig.clone(),
+            nonce: signed.trade.nonce,
+            attestation: Some(att),
+            bench_spec_hint: Some(wrong_hint),
+        };
+        let result = handle_trade_gossip(&gossip, &msg).await;
+        assert!(result.is_none(), "mismatched hint must cause rejection");
+    }
+
+    #[tokio::test]
+    async fn handle_gossip_skips_crypto_when_hint_absent() {
+        // Attestation present but no hint → receiver can't crypto-
+        // verify, so it skips that layer. The trade is still
+        // accepted on dual-signature grounds.
+        let gossip = Arc::new(Mutex::new(GossipState::new()));
+        let (signed, provider_key) = make_signed_trade_with_keys();
+        let (att, _) = ed_attest_for(
+            &provider_key,
+            "p",
+            &["o"],
+            "wave3",
+            signed.trade.tokens_processed,
+            0,
+        );
+        let msg = TradeGossip {
+            provider: signed.trade.provider.clone(),
+            consumer: signed.trade.consumer.clone(),
+            trm_amount: signed.trade.trm_amount,
+            tokens_processed: signed.trade.tokens_processed,
+            timestamp: signed.trade.timestamp,
+            model_id: signed.trade.model_id.clone(),
+            provider_sig: signed.provider_sig.clone(),
+            consumer_sig: signed.consumer_sig.clone(),
+            nonce: signed.trade.nonce,
+            attestation: Some(att),
+            bench_spec_hint: None,
+        };
+        let result = handle_trade_gossip(&gossip, &msg).await;
+        assert!(result.is_some(), "trade without hint still accepted at the dual-sig layer");
+    }
+
+    #[tokio::test]
+    async fn handle_gossip_rejects_attestation_signed_by_non_provider() {
+        // Attacker signs an attestation for a trade between two
+        // honest parties — the embedded signer pubkey will not match
+        // `trade.provider`, so `verify_trade_attestation` fails.
+        let gossip = Arc::new(Mutex::new(GossipState::new()));
+        let (signed, _provider_key) = make_signed_trade_with_keys();
+        let mut rng = rand::thread_rng();
+        let attacker = SigningKey::generate(&mut rng);
+        let (att, hint) = ed_attest_for(
+            &attacker,
+            "p",
+            &["o"],
+            "wave3",
+            signed.trade.tokens_processed,
+            0,
+        );
+        let msg = TradeGossip {
+            provider: signed.trade.provider.clone(),
+            consumer: signed.trade.consumer.clone(),
+            trm_amount: signed.trade.trm_amount,
+            tokens_processed: signed.trade.tokens_processed,
+            timestamp: signed.trade.timestamp,
+            model_id: signed.trade.model_id.clone(),
+            provider_sig: signed.provider_sig.clone(),
+            consumer_sig: signed.consumer_sig.clone(),
+            nonce: signed.trade.nonce,
+            attestation: Some(att),
+            bench_spec_hint: Some(hint),
+        };
+        let result = handle_trade_gossip(&gossip, &msg).await;
+        assert!(result.is_none(), "non-provider signer must be rejected");
+    }
+
+    #[tokio::test]
+    async fn handle_gossip_rejects_tampered_attestation_bytes() {
+        let gossip = Arc::new(Mutex::new(GossipState::new()));
+        let (signed, provider_key) = make_signed_trade_with_keys();
+        let (mut att, hint) = ed_attest_for(
+            &provider_key,
+            "p",
+            &["o"],
+            "wave3",
+            signed.trade.tokens_processed,
+            0,
+        );
+        // Flip a byte in the signature half (offset 64..96).
+        att.bytes[80] ^= 0xFF;
+        let msg = TradeGossip {
+            provider: signed.trade.provider.clone(),
+            consumer: signed.trade.consumer.clone(),
+            trm_amount: signed.trade.trm_amount,
+            tokens_processed: signed.trade.tokens_processed,
+            timestamp: signed.trade.timestamp,
+            model_id: signed.trade.model_id.clone(),
+            provider_sig: signed.provider_sig.clone(),
+            consumer_sig: signed.consumer_sig.clone(),
+            nonce: signed.trade.nonce,
+            attestation: Some(att),
+            bench_spec_hint: Some(hint),
+        };
+        let result = handle_trade_gossip(&gossip, &msg).await;
+        assert!(result.is_none(), "tampered signature bytes must be rejected");
+    }
+
+    #[test]
+    fn trade_attestation_wire_round_trips_through_ledger_conversion() {
+        let att = tirami_ledger::ledger::TradeAttestation::new(
+            "ed-attest".to_string(),
+            vec![0xAB; 96],
+        );
+        let wire: tirami_proto::TradeAttestationWire = (&att).into();
+        let back: tirami_ledger::ledger::TradeAttestation = (&wire).into();
+        assert_eq!(att.backend, back.backend);
+        assert_eq!(att.bytes, back.bytes);
     }
 
     #[test]
@@ -974,6 +1272,8 @@ mod tests {
             provider_sig: vec![0u8; 64], // all-zero → invalid
             consumer_sig: vec![0u8; 64],
             nonce: [0u8; 16],
+            attestation: None,
+            bench_spec_hint: None,
         };
         let result = handle_trade_gossip(&gossip, &msg).await;
         assert!(
@@ -1024,6 +1324,8 @@ mod tests {
             provider_sig,
             consumer_sig: vec![0xFFu8; 64], // all-0xFF → invalid
             nonce: [0u8; 16],
+            attestation: None,
+            bench_spec_hint: None,
         };
         let result = handle_trade_gossip(&gossip, &msg).await;
         assert!(result.is_none(), "all-0xFF consumer sig must be rejected by gossip handler");

--- a/crates/tirami-node/src/pipeline.rs
+++ b/crates/tirami-node/src/pipeline.rs
@@ -1106,8 +1106,28 @@ async fn handle_inference(
                             // Reputation boost for successful signed trade
                             ledger.update_reputation(&trade.provider, 0.01);
                             drop(ledger);
-                            // Broadcast to mesh via gossip
-                            tirami_net::gossip::broadcast_trade(&transport, &gossip, &signed).await;
+                            // Broadcast to mesh via gossip.
+                            // Phase 24 Wave 3 — when the trade carries
+                            // an attestation, ship the BenchSpecHint
+                            // so receivers can do the full crypto verify.
+                            let bench_spec_hint = signed.attestation.as_ref().map(|_| {
+                                let spec = build_bench_spec(
+                                    &req.prompt_text,
+                                    &tokens,
+                                    &signed.trade.model_id,
+                                    signed.trade.tokens_processed,
+                                    signed.trade.flops_estimated,
+                                );
+                                tirami_proto::BenchSpecHint {
+                                    model_hash: spec.model_hash,
+                                    prompt_hash: spec.prompt_hash,
+                                    output_hash: spec.output_hash,
+                                    flops: spec.flops,
+                                }
+                            });
+                            tirami_net::gossip::broadcast_trade(
+                                &transport, &gossip, &signed, bench_spec_hint,
+                            ).await;
                         }
                         Err(e) => {
                             // Replay or (very unlikely) a second-pass sig

--- a/crates/tirami-proto/src/messages.rs
+++ b/crates/tirami-proto/src/messages.rs
@@ -365,6 +365,41 @@ pub struct TradeGossip {
     /// signed `TradeRecord`. See `TradeProposal::nonce`.
     #[serde(default)]
     pub nonce: [u8; 16],
+    /// Phase 24 Wave 3 — optional zkML attestation produced by the
+    /// provider. Wire-mirror of `tirami_ledger::ledger::TradeAttestation`.
+    /// `None` for unattested trades (legacy / mock backend / no agent
+    /// identity).
+    #[serde(default)]
+    pub attestation: Option<TradeAttestationWire>,
+    /// Phase 24 Wave 3 — companion hint so a gossip *receiver* can
+    /// reconstruct the `BenchSpec` and cryptographically verify the
+    /// `attestation`. The receiver only sees the trade — it does not
+    /// see the original prompt/output, so the producer ships the
+    /// hashes alongside.
+    #[serde(default)]
+    pub bench_spec_hint: Option<BenchSpecHint>,
+}
+
+/// Phase 24 Wave 3 — wire-mirror of `tirami_ledger::ledger::TradeAttestation`.
+/// Kept here in `tirami-proto` so the dependency direction stays
+/// acyclic (proto < ledger). `tirami-ledger` ships
+/// `From<&TradeAttestation> for TradeAttestationWire` conversions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TradeAttestationWire {
+    pub backend: String,
+    pub bytes: Vec<u8>,
+}
+
+/// Phase 24 Wave 3 — minimum information a gossip receiver needs to
+/// rebuild the producer's `BenchSpec` and cryptographically verify
+/// the attached attestation. `token_count` already lives on
+/// `TradeGossip.tokens_processed`, so we don't re-ship it here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BenchSpecHint {
+    pub model_hash: [u8; 32],
+    pub prompt_hash: [u8; 32],
+    pub output_hash: [u8; 32],
+    pub flops: u64,
 }
 
 // --- Loan Signing (CU Lending — Phase 5.5) ---

--- a/docs/phase-24-zkml-real-backends.md
+++ b/docs/phase-24-zkml-real-backends.md
@@ -8,7 +8,7 @@
 > forgeable" to "production-grade proof of inference" without a
 > single multi-week commit.
 
-Status: Wave 1 + Wave 2 + Wave 2.5 shipped.
+Status: Wave 1 + Wave 2 + Wave 2.5 + Wave 3 shipped.
 
 ## The trajectory
 
@@ -194,21 +194,65 @@ unchanged). `tirami-node::pipeline` +8: `build_bench_spec_*` (2) +
 `produce_ed_attest_*` (6). Workspace passes **1,413** tests
 (Wave 1 1,380 → Wave 2 1,397 → Wave 2.5 1,413).
 
-### Wave 3 (next) — gossip wire + full crypto verify
+### Wave 3 ✅ shipped — gossip wire + full crypto verify
 
-Wave 2.5 leaves two surfaces still TODO:
+Wave 3 widens the wire format and runs the full cryptographic
+verifier at gossip-receive time.
 
-1. **Gossip transport.** `TradeGossip` proto messages do not yet
-   carry `attestation`. Wave 3 widens the wire format (in a
-   serde-default-compatible way) so attestations propagate.
-2. **Full crypto verify.** Today the receiver only verifies
-   *signer ↔ provider* equality. Wave 3 carries `prompt_hash`,
-   `output_hash`, `model_hash`, `token_count`, `flops` along
-   with the trade so receivers can rebuild the BenchSpec and
-   call `verify_trade_attestation` for the actual signature
-   check. Alternatively (and preferably), pick a real zk
-   backend (`risc0` or `ezkl`) so the attestation itself proves
-   computation correctness, not just signer identity.
+- ✅ `tirami-proto::TradeGossip` gains two `#[serde(default)]`
+  fields:
+  - `attestation: Option<TradeAttestationWire>` — wire-mirror of
+    `tirami_ledger::ledger::TradeAttestation`. Conversions live
+    in tirami-ledger (proto < ledger, so the impls have to be
+    on the ledger side).
+  - `bench_spec_hint: Option<BenchSpecHint>` — the minimum
+    information a receiver needs to rebuild the producer's
+    `BenchSpec`: `model_hash`, `prompt_hash`, `output_hash`,
+    and `flops`. `token_count` already rides on `tokens_processed`.
+- ✅ `tirami_net::gossip::broadcast_trade(transport, gossip, signed, bench_spec_hint)` —
+  signature widened (breaking-change for the single caller in
+  `tirami-node::pipeline`, kept the no-cost convention for tests).
+  Pipeline ships the hint when (and only when) `signed.attestation`
+  is `Some`.
+- ✅ `tirami_net::gossip::handle_trade_gossip` — when both
+  `attestation` and `bench_spec_hint` are present, the receiver
+  rebuilds `BenchSpec` from the hint and calls
+  `tirami_zkml_bench::verify_trade_attestation`. Failure → drop
+  the trade. Attestation present but hint missing → fall through
+  to the dual-signature check only (degraded but not rejected).
+
+#### Tests added
+
+`tirami-net::gossip` +6:
+- `handle_gossip_accepts_attested_trade_with_valid_hint`
+- `handle_gossip_rejects_attestation_with_wrong_hint`
+- `handle_gossip_skips_crypto_when_hint_absent`
+- `handle_gossip_rejects_attestation_signed_by_non_provider`
+- `handle_gossip_rejects_tampered_attestation_bytes`
+- `trade_attestation_wire_round_trips_through_ledger_conversion`
+
+Workspace passes **1,419** tests (Wave 2.5 1,413 → +6).
+
+### Wave 4 (next) — real zk backend OR governance ratchet
+
+With Wave 3 done, the protocol has end-to-end cryptographic
+verifiability of "*the listed provider attested to this exact
+inference*." The remaining work splits cleanly:
+
+1. **Real zk backend** (week-scale): pick `risc0` or `ezkl` and
+   wire it into `BenchBackend`. The on-trade `TradeAttestation`
+   format already accommodates any backend (it's just a backend
+   name + bytes), and the wire path doesn't change. What
+   changes is the strength of the claim — from "I attested with
+   my key" to "I attest that I correctly computed Y on X."
+2. **Governance ratchet activation** (bounded): introduce the
+   proposal flow that bumps `ProofPolicy` `Optional` →
+   `Recommended` → `Required`. The
+   `IMMUTABLE_CONSTITUTIONAL_PARAMETERS::PROOF_POLICY_RATCHET`
+   constant already prevents downgrade; Wave 4 adds the upgrade
+   path.
+
+These are independent; either can ship first.
 
 ## Wave 3 — risc0 or ezkl integration
 


### PR DESCRIPTION
## Summary

Phase 24 Wave 3 widens the gossip wire format so peers can cryptographically verify zkML attestations, not just check signer ↔ provider identity.

### Wire (tirami-proto::TradeGossip)

- New `attestation: Option<TradeAttestationWire>` (`#[serde(default)]`)
- New `bench_spec_hint: Option<BenchSpecHint>` carrying \`model_hash / prompt_hash / output_hash / flops\` — receivers use it to rebuild `BenchSpec` and call `verify_trade_attestation`

`tirami-ledger` ships `From<&TradeAttestation> for TradeAttestationWire` (and inverse). Dep direction stays acyclic (proto < ledger).

### Producer (tirami-node::pipeline)

`handle_inference` ships the `BenchSpecHint` to `broadcast_trade` when (and only when) it actually attached an attestation.

### Receiver (tirami-net::gossip::handle_trade_gossip)

- attestation + hint both present → call `verify_trade_attestation` → drop on failure
- attestation present but hint missing → degrade to dual-sig only
- no attestation → unchanged

`broadcast_trade` signature widened (`bench_spec_hint: Option<BenchSpecHint>`); single in-workspace caller (pipeline) updated.

## Tests

`tirami-net::gossip` +6:
- `handle_gossip_accepts_attested_trade_with_valid_hint`
- `handle_gossip_rejects_attestation_with_wrong_hint`
- `handle_gossip_skips_crypto_when_hint_absent`
- `handle_gossip_rejects_attestation_signed_by_non_provider`
- `handle_gossip_rejects_tampered_attestation_bytes`
- `trade_attestation_wire_round_trips_through_ledger_conversion`

Workspace **1,419 passing** (Wave 2.5 1,413 → +6).

## Test plan

- [x] `cargo check --workspace` — warnings only
- [x] `cargo test --workspace` — 1,419 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)