### PR TITLE
feat(phase-24/wave-4): governance ratchet activates ProofPolicy upgrades

### DIFF
--- a/crates/tirami-ledger/src/governance.rs
+++ b/crates/tirami-ledger/src/governance.rs
@@ -224,6 +224,27 @@ pub enum GovernanceError {
          See docs/constitution.md"
     )]
     ConstitutionalParameter { name: String },
+    /// Phase 24 Wave 4 — execute called on a proposal that hasn't
+    /// passed the tally yet (status != Passed).
+    #[error("proposal {id} cannot execute: status is {status:?}, expected Passed")]
+    ProposalNotPassed { id: u64, status: ProposalStatus },
+    /// Phase 24 Wave 4 — execute called on a non-PROOF_POLICY
+    /// ChangeParameter, or a non-ChangeParameter proposal. PROOF_POLICY
+    /// execution is the only kind wired in Wave 4.
+    #[error("proposal {id} is not a PROOF_POLICY change: {kind_description}")]
+    UnsupportedExecution { id: u64, kind_description: String },
+    /// Phase 24 Wave 4 — the proposal's `new_value` did not parse to a
+    /// valid `ProofPolicy` (must be 0/1/2/3).
+    #[error("proposal {id} carries an invalid PROOF_POLICY value: {value}")]
+    InvalidProofPolicyValue { id: u64, value: f64 },
+    /// Phase 24 Wave 4 — execute attempted a downgrade, vetoed by the
+    /// Constitutional no-downgrade ratchet
+    /// (`tirami_ledger::zk::try_ratchet_proof_policy`).
+    #[error("proof policy downgrade vetoed: {current} → {proposed}")]
+    ProofPolicyDowngradeVetoed {
+        current: &'static str,
+        proposed: &'static str,
+    },
 }
 
 // ---------- Seniority ----------
@@ -400,6 +421,55 @@ impl GovernanceState {
             .iter()
             .filter(|p| p.status == ProposalStatus::Active)
             .collect()
+    }
+
+    /// Phase 24 Wave 4 — execute a Passed `ChangeParameter
+    /// { name: "PROOF_POLICY", new_value }` proposal. Applies the
+    /// no-downgrade ratchet, marks the proposal as `Executed`, and
+    /// returns the new policy on success. Caller is responsible for
+    /// writing the new policy into shared runtime state.
+    pub fn execute_proof_policy_proposal(
+        &mut self,
+        proposal_id: u64,
+        current: crate::zk::ProofPolicy,
+    ) -> Result<crate::zk::ProofPolicy, GovernanceError> {
+        // Find + verify status without holding a mutable borrow that
+        // would block the ratchet call.
+        let (kind, status) = {
+            let p = self
+                .proposals
+                .iter()
+                .find(|p| p.id == proposal_id)
+                .ok_or(GovernanceError::ProposalNotFound { id: proposal_id })?;
+            (p.kind.clone(), p.status)
+        };
+        if status != ProposalStatus::Passed {
+            return Err(GovernanceError::ProposalNotPassed { id: proposal_id, status });
+        }
+        let new_value = match kind {
+            ProposalKind::ChangeParameter { ref name, new_value } if name == "PROOF_POLICY" => {
+                new_value
+            }
+            other => {
+                return Err(GovernanceError::UnsupportedExecution {
+                    id: proposal_id,
+                    kind_description: format!("{other:?}"),
+                });
+            }
+        };
+        let proposed = crate::zk::ProofPolicy::from_governance_value(new_value)
+            .ok_or(GovernanceError::InvalidProofPolicyValue {
+                id: proposal_id,
+                value: new_value,
+            })?;
+        let new_policy = crate::zk::try_ratchet_proof_policy(current, proposed).map_err(|e| {
+            let crate::zk::ProofPolicyRatchetError::Downgrade { current, proposed } = e;
+            GovernanceError::ProofPolicyDowngradeVetoed { current, proposed }
+        })?;
+        if let Some(p) = self.proposals.iter_mut().find(|p| p.id == proposal_id) {
+            p.status = ProposalStatus::Executed;
+        }
+        Ok(new_policy)
     }
 
     /// Advance to a new epoch: close and tally any proposals whose deadline has passed.
@@ -1005,5 +1075,217 @@ mod tests {
         assert!(is_constitutional_parameter("TOTAL_TRM_SUPPLY"));
         assert!(is_constitutional_parameter("FLOPS_PER_CU"));
         assert!(!is_constitutional_parameter("WELCOME_LOAN_AMOUNT"));
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 24 Wave 4 — execute_proof_policy_proposal
+    // ---------------------------------------------------------------
+
+    use crate::zk::ProofPolicy;
+
+    fn pass_proposal(gov: &mut GovernanceState, kind: ProposalKind) -> u64 {
+        let id = gov.create_proposal(node(1), kind, NOW, DEADLINE).unwrap();
+        // Cast a single approving vote so tally → Passed.
+        gov.cast_vote(node(2), id, true, 5_000, 0.9, 3).unwrap();
+        let status = gov.tally(id).unwrap();
+        assert_eq!(status, ProposalStatus::Passed);
+        id
+    }
+
+    #[test]
+    fn execute_proof_policy_upgrade_optional_to_recommended() {
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(
+            &mut gov,
+            ProposalKind::ChangeParameter {
+                name: "PROOF_POLICY".into(),
+                new_value: 2.0, // Recommended
+            },
+        );
+        let new_policy = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Optional)
+            .expect("upgrade allowed");
+        assert_eq!(new_policy, ProofPolicy::Recommended);
+        let p = gov.proposals.iter().find(|p| p.id == id).unwrap();
+        assert_eq!(p.status, ProposalStatus::Executed);
+    }
+
+    #[test]
+    fn execute_proof_policy_terminal_upgrade_to_required() {
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(
+            &mut gov,
+            ProposalKind::ChangeParameter {
+                name: "PROOF_POLICY".into(),
+                new_value: 3.0,
+            },
+        );
+        let new_policy = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Recommended)
+            .expect("upgrade allowed");
+        assert_eq!(new_policy, ProofPolicy::Required);
+    }
+
+    #[test]
+    fn execute_proof_policy_idempotent_when_same_value() {
+        // Re-proposing the same value is allowed (no-downgrade ratchet
+        // permits ≥, not strictly >).
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(
+            &mut gov,
+            ProposalKind::ChangeParameter {
+                name: "PROOF_POLICY".into(),
+                new_value: 1.0,
+            },
+        );
+        let new_policy = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Optional)
+            .expect("same-value allowed");
+        assert_eq!(new_policy, ProofPolicy::Optional);
+    }
+
+    #[test]
+    fn execute_proof_policy_downgrade_vetoed() {
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(
+            &mut gov,
+            ProposalKind::ChangeParameter {
+                name: "PROOF_POLICY".into(),
+                new_value: 1.0, // Optional
+            },
+        );
+        let err = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Required)
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::ProofPolicyDowngradeVetoed { .. }));
+        // Status stays Passed; the downgrade attempt does not "consume"
+        // the proposal. (Alternative semantics — mark as Rejected on
+        // ratchet veto — would surprise governance UI clients.)
+        let p = gov.proposals.iter().find(|p| p.id == id).unwrap();
+        assert_eq!(p.status, ProposalStatus::Passed);
+    }
+
+    #[test]
+    fn execute_proof_policy_skip_steps_allowed() {
+        // Skipping straight from Disabled to Required is allowed by
+        // the ratchet (monotonic, not single-step).
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(
+            &mut gov,
+            ProposalKind::ChangeParameter {
+                name: "PROOF_POLICY".into(),
+                new_value: 3.0,
+            },
+        );
+        let new_policy = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Disabled)
+            .expect("skip allowed");
+        assert_eq!(new_policy, ProofPolicy::Required);
+    }
+
+    #[test]
+    fn execute_proof_policy_rejects_invalid_value() {
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(
+            &mut gov,
+            ProposalKind::ChangeParameter {
+                name: "PROOF_POLICY".into(),
+                new_value: 99.0,
+            },
+        );
+        let err = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Optional)
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::InvalidProofPolicyValue { .. }));
+    }
+
+    #[test]
+    fn execute_proof_policy_rejects_nan_value() {
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(
+            &mut gov,
+            ProposalKind::ChangeParameter {
+                name: "PROOF_POLICY".into(),
+                new_value: f64::NAN,
+            },
+        );
+        let err = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Optional)
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::InvalidProofPolicyValue { .. }));
+    }
+
+    #[test]
+    fn execute_proof_policy_rejects_not_passed() {
+        let mut gov = GovernanceState::new(1);
+        let id = gov
+            .create_proposal(
+                node(1),
+                ProposalKind::ChangeParameter {
+                    name: "PROOF_POLICY".into(),
+                    new_value: 2.0,
+                },
+                NOW,
+                DEADLINE,
+            )
+            .unwrap();
+        // Active, not Passed.
+        let err = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Optional)
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::ProposalNotPassed { .. }));
+    }
+
+    #[test]
+    fn execute_proof_policy_rejects_wrong_param_name() {
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(
+            &mut gov,
+            ProposalKind::ChangeParameter {
+                name: "WELCOME_LOAN_AMOUNT".into(),
+                new_value: 500.0,
+            },
+        );
+        let err = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Optional)
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::UnsupportedExecution { .. }));
+    }
+
+    #[test]
+    fn execute_proof_policy_rejects_non_change_parameter_kind() {
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(&mut gov, ProposalKind::EmergencyPause);
+        let err = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Optional)
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::UnsupportedExecution { .. }));
+    }
+
+    #[test]
+    fn execute_proof_policy_unknown_proposal_id() {
+        let mut gov = GovernanceState::new(1);
+        let err = gov
+            .execute_proof_policy_proposal(9999, ProofPolicy::Optional)
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::ProposalNotFound { .. }));
+    }
+
+    #[test]
+    fn execute_proof_policy_cannot_execute_twice() {
+        let mut gov = GovernanceState::new(1);
+        let id = pass_proposal(
+            &mut gov,
+            ProposalKind::ChangeParameter {
+                name: "PROOF_POLICY".into(),
+                new_value: 2.0,
+            },
+        );
+        gov.execute_proof_policy_proposal(id, ProofPolicy::Optional).unwrap();
+        let err = gov
+            .execute_proof_policy_proposal(id, ProofPolicy::Recommended)
+            .unwrap_err();
+        // After first execute, status = Executed → NotPassed.
+        assert!(matches!(err, GovernanceError::ProposalNotPassed { .. }));
     }
 }

--- a/crates/tirami-ledger/src/zk.rs
+++ b/crates/tirami-ledger/src/zk.rs
@@ -132,6 +132,24 @@ impl ProofPolicy {
             _ => None,
         }
     }
+
+    /// Phase 24 Wave 4 — parse from the `new_value: f64` field of a
+    /// `ProposalKind::ChangeParameter { name: "PROOF_POLICY", ... }`
+    /// proposal. The float is rounded to the nearest non-negative
+    /// integer and matched against `as_u8()`. Returns `None` for
+    /// out-of-range values or NaN/Infinity.
+    pub fn from_governance_value(v: f64) -> Option<Self> {
+        if !v.is_finite() || v < -0.5 {
+            return None;
+        }
+        match v.round() as u64 {
+            0 => Some(Self::Disabled),
+            1 => Some(Self::Optional),
+            2 => Some(Self::Recommended),
+            3 => Some(Self::Required),
+            _ => None,
+        }
+    }
 }
 
 /// Phase 18.3 — is a trade *allowed* to settle under the current
@@ -1033,5 +1051,50 @@ mod tests {
             matches!(err, ZkError::VerificationFailed(_)),
             "tampered generated_at_ms must cause VerificationFailed, got {err:?}"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 24 Wave 4 — ProofPolicy::from_governance_value
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn from_governance_value_round_trips_for_each_policy() {
+        for p in [
+            ProofPolicy::Disabled,
+            ProofPolicy::Optional,
+            ProofPolicy::Recommended,
+            ProofPolicy::Required,
+        ] {
+            let v = p.as_u8() as f64;
+            assert_eq!(ProofPolicy::from_governance_value(v), Some(p));
+        }
+    }
+
+    #[test]
+    fn from_governance_value_rounds_to_nearest() {
+        // Float reprs in ChangeParameter proposals may carry tiny
+        // rounding error from human input; the parser must absorb it.
+        assert_eq!(
+            ProofPolicy::from_governance_value(2.0000001),
+            Some(ProofPolicy::Recommended)
+        );
+        assert_eq!(
+            ProofPolicy::from_governance_value(1.9999999),
+            Some(ProofPolicy::Recommended)
+        );
+    }
+
+    #[test]
+    fn from_governance_value_rejects_out_of_range() {
+        assert!(ProofPolicy::from_governance_value(4.0).is_none());
+        assert!(ProofPolicy::from_governance_value(100.0).is_none());
+        assert!(ProofPolicy::from_governance_value(-1.0).is_none());
+    }
+
+    #[test]
+    fn from_governance_value_rejects_non_finite() {
+        assert!(ProofPolicy::from_governance_value(f64::NAN).is_none());
+        assert!(ProofPolicy::from_governance_value(f64::INFINITY).is_none());
+        assert!(ProofPolicy::from_governance_value(f64::NEG_INFINITY).is_none());
     }
 }

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -97,6 +97,14 @@ pub(crate) struct AppState {
     /// per-DID session tokens. In-memory only; persistence is a
     /// follow-up.
     pub nostr_identity: crate::handlers::nostr_publish::NostrIdentityState,
+    /// Phase 24 Wave 4 — the *currently enforced* `ProofPolicy`,
+    /// distinct from the string in `config.proof_policy` which is
+    /// the boot-time default. Governance can ratchet this upward
+    /// via `POST /v1/tirami/governance/execute/:id` for PROOF_POLICY
+    /// proposals. The no-downgrade Constitutional ratchet is
+    /// enforced inside
+    /// `GovernanceState::execute_proof_policy_proposal`.
+    pub current_proof_policy: Arc<tokio::sync::RwLock<tirami_ledger::zk::ProofPolicy>>,
 }
 
 /// Simple rate limiter for authentication failures.
@@ -236,6 +244,14 @@ pub fn create_router_with_services(
         .map(|c| c.local_capability().node_id.clone())
         .unwrap_or_else(|| NodeId([0u8; 32]));
 
+    // Phase 24 Wave 4 — boot-time proof_policy from Config; governance
+    // ratchets this upward. Unknown / malformed strings fall back to
+    // the conservative `Disabled` so a misconfigured node doesn't
+    // silently start running an unintended policy.
+    let initial_proof_policy = tirami_ledger::zk::ProofPolicy::parse(&config.proof_policy)
+        .unwrap_or(tirami_ledger::zk::ProofPolicy::Disabled);
+    let current_proof_policy = Arc::new(tokio::sync::RwLock::new(initial_proof_policy));
+
     let state = AppState {
         config,
         engine,
@@ -271,6 +287,7 @@ pub fn create_router_with_services(
             crate::handlers::auth_did::ChallengeStore::new(),
         )),
         nostr_identity: Arc::new(Mutex::new(None)),
+        current_proof_policy,
     };
     let api_max_request_body_bytes = state.config.api_max_request_body_bytes;
 
@@ -437,6 +454,15 @@ pub fn create_router_with_services(
         .route(
             "/v1/tirami/governance/tally/{id}",
             get(crate::handlers::governance::governance_tally),
+        )
+        // Phase 24 Wave 4 — governance ratchet apply + read
+        .route(
+            "/v1/tirami/governance/execute/{id}",
+            post(crate::handlers::governance::governance_execute),
+        )
+        .route(
+            "/v1/tirami/governance/proof-policy",
+            get(crate::handlers::governance::governance_proof_policy),
         )
         // Phase 10 P6 — Bitcoin OP_RETURN anchoring
         .route(

--- a/crates/tirami-node/src/handlers/governance.rs
+++ b/crates/tirami-node/src/handlers/governance.rs
@@ -265,6 +265,71 @@ pub(crate) async fn governance_tally(
     }
 }
 
+/// Phase 24 Wave 4 — POST /v1/tirami/governance/execute/:id
+///
+/// Executes a Passed PROOF_POLICY proposal: parses the proposal's
+/// `new_value` to a `ProofPolicy`, applies the no-downgrade ratchet,
+/// updates `AppState.current_proof_policy`, and marks the proposal
+/// as Executed.
+///
+/// Today only PROOF_POLICY execution is wired; other Passed
+/// proposals will return 400 UnsupportedExecution. Future waves can
+/// dispatch by `name` to other parameter slots.
+pub(crate) async fn governance_execute(
+    State(state): State<AppState>,
+    Path(id): Path<u64>,
+) -> impl IntoResponse {
+    if let Err(e) = check_forge_rate_limit(&state).await {
+        return e.into_response();
+    }
+    let current = *state.current_proof_policy.read().await;
+    let mut gov = state.governance.lock().await;
+    match gov.execute_proof_policy_proposal(id, current) {
+        Ok(new_policy) => {
+            drop(gov);
+            *state.current_proof_policy.write().await = new_policy;
+            Json(json!({
+                "ok": true,
+                "proposal_id": id,
+                "previous_policy": current.as_str(),
+                "new_policy": new_policy.as_str(),
+                "ratchet": "no-downgrade",
+            }))
+            .into_response()
+        }
+        Err(e) => {
+            use tirami_ledger::GovernanceError;
+            let code = match &e {
+                GovernanceError::ProposalNotFound { .. } => StatusCode::NOT_FOUND,
+                GovernanceError::ProofPolicyDowngradeVetoed { .. } => StatusCode::CONFLICT,
+                GovernanceError::ProposalNotPassed { .. } => StatusCode::CONFLICT,
+                _ => StatusCode::BAD_REQUEST,
+            };
+            (code, Json(json!({ "error": e.to_string() }))).into_response()
+        }
+    }
+}
+
+/// Phase 24 Wave 4 — GET /v1/tirami/governance/proof-policy
+///
+/// Returns the currently *enforced* proof policy (separate from the
+/// boot-time string in `config.proof_policy`). Agents read this to
+/// decide whether to attach an attestation to their trades.
+pub(crate) async fn governance_proof_policy(
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    if let Err(e) = check_forge_rate_limit(&state).await {
+        return e.into_response();
+    }
+    let current = *state.current_proof_policy.read().await;
+    Json(json!({
+        "policy": current.as_str(),
+        "as_u8": current.as_u8(),
+        "ratchet": "monotonic upward; downgrades constitutionally vetoed",
+    }))
+    .into_response()
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -711,5 +776,294 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json["status"].as_str().unwrap(), "Passed");
         assert_eq!(json["proposal_id"].as_u64().unwrap(), proposal_id);
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 24 Wave 4 — governance_execute + governance_proof_policy
+    // -----------------------------------------------------------------
+
+    /// Pass a PROOF_POLICY change proposal and return its id. Helper
+    /// for the Wave-4 execute tests.
+    async fn pass_proof_policy_proposal(
+        app: &axum::Router,
+        new_value: f64,
+    ) -> u64 {
+        let propose_body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "change_parameter",
+            "name": "PROOF_POLICY",
+            "new_value": new_value,
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(propose_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let pjson: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let id = pjson["proposal_id"].as_u64().unwrap();
+        let vote_body = serde_json::json!({
+            "voter": voter_hex(),
+            "proposal_id": id,
+            "approve": true,
+            "stake": 5_000,
+            "reputation": 0.9,
+            "epochs_participated": 3,
+        })
+        .to_string();
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/vote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(vote_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&format!("/v1/tirami/governance/tally/{}", id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn proof_policy_default_endpoint_returns_optional() {
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/governance/proof-policy")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["policy"].as_str().unwrap(), "optional");
+        assert_eq!(json["as_u8"].as_u64().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn proof_policy_execute_advances_state() {
+        let app = test_router_default(Config::default());
+        let id = pass_proof_policy_proposal(&app, 2.0).await; // Recommended
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&format!("/v1/tirami/governance/execute/{}", id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["new_policy"].as_str().unwrap(), "recommended");
+        assert_eq!(json["previous_policy"].as_str().unwrap(), "optional");
+
+        // GET should reflect the new policy.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/governance/proof-policy")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["policy"].as_str().unwrap(), "recommended");
+    }
+
+    #[tokio::test]
+    async fn proof_policy_execute_rejects_downgrade_with_conflict() {
+        // Start at default Optional, ratchet UP to Required, then
+        // try to "downgrade" via a proposal that proposes Optional —
+        // the execute endpoint must 409.
+        let app = test_router_default(Config::default());
+        let id_up = pass_proof_policy_proposal(&app, 3.0).await;
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&format!("/v1/tirami/governance/execute/{}", id_up))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let id_down = pass_proof_policy_proposal(&app, 1.0).await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&format!("/v1/tirami/governance/execute/{}", id_down))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn proof_policy_execute_rejects_not_passed_with_conflict() {
+        let app = test_router_default(Config::default());
+        // Create proposal without voting/tallying → status Active.
+        let propose_body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "change_parameter",
+            "name": "PROOF_POLICY",
+            "new_value": 2.0,
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(propose_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let pjson: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let id = pjson["proposal_id"].as_u64().unwrap();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&format!("/v1/tirami/governance/execute/{}", id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn proof_policy_execute_rejects_unknown_proposal_404() {
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/execute/99999")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn proof_policy_execute_rejects_unsupported_param_400() {
+        // A Passed proposal for a non-PROOF_POLICY parameter is
+        // rejected by execute (only PROOF_POLICY is wired in Wave 4).
+        let app = test_router_default(Config::default());
+        let propose_body = serde_json::json!({
+            "proposer": proposer_hex(),
+            "kind": "change_parameter",
+            "name": "ANCHOR_INTERVAL_SECS",
+            "new_value": 900.0,
+            "deadline_ms": 9_999_999_999u64,
+        })
+        .to_string();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/propose")
+                    .header("content-type", "application/json")
+                    .body(Body::from(propose_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(resp.into_body(), 10_000).await.unwrap();
+        let pjson: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let id = pjson["proposal_id"].as_u64().unwrap();
+        // Vote + tally → Passed.
+        let vote_body = serde_json::json!({
+            "voter": voter_hex(),
+            "proposal_id": id,
+            "approve": true,
+            "stake": 5_000,
+            "reputation": 0.9,
+            "epochs_participated": 3,
+        })
+        .to_string();
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/tirami/governance/vote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(vote_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&format!("/v1/tirami/governance/tally/{}", id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&format!("/v1/tirami/governance/execute/{}", id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/docs/phase-24-zkml-real-backends.md
+++ b/docs/phase-24-zkml-real-backends.md
@@ -8,7 +8,7 @@
 > forgeable" to "production-grade proof of inference" without a
 > single multi-week commit.
 
-Status: Wave 1 + Wave 2 + Wave 2.5 + Wave 3 shipped.
+Status: Wave 1 + Wave 2 + Wave 2.5 + Wave 3 + Wave 4 shipped.
 
 ## The trajectory
 
@@ -233,26 +233,74 @@ verifier at gossip-receive time.
 
 Workspace passes **1,419** tests (Wave 2.5 1,413 → +6).
 
-### Wave 4 (next) — real zk backend OR governance ratchet
+### Wave 4 ✅ shipped — governance ratchet activation
 
-With Wave 3 done, the protocol has end-to-end cryptographic
-verifiability of "*the listed provider attested to this exact
-inference*." The remaining work splits cleanly:
+Wave 4 wires the proposal-driven upgrade path for `ProofPolicy`,
+together with runtime state separate from the boot-time config
+string.
 
-1. **Real zk backend** (week-scale): pick `risc0` or `ezkl` and
-   wire it into `BenchBackend`. The on-trade `TradeAttestation`
-   format already accommodates any backend (it's just a backend
-   name + bytes), and the wire path doesn't change. What
-   changes is the strength of the claim — from "I attested with
-   my key" to "I attest that I correctly computed Y on X."
-2. **Governance ratchet activation** (bounded): introduce the
-   proposal flow that bumps `ProofPolicy` `Optional` →
-   `Recommended` → `Required`. The
-   `IMMUTABLE_CONSTITUTIONAL_PARAMETERS::PROOF_POLICY_RATCHET`
-   constant already prevents downgrade; Wave 4 adds the upgrade
-   path.
+#### What's new
 
-These are independent; either can ship first.
+- **`ProofPolicy::from_governance_value(v: f64) -> Option<Self>`** —
+  parses the `new_value` of a `ChangeParameter` proposal. Rounds
+  to nearest non-negative integer; rejects out-of-range and
+  non-finite floats.
+- **`GovernanceState::execute_proof_policy_proposal(id, current)`** —
+  takes a Passed `ChangeParameter { name: "PROOF_POLICY", ... }`,
+  applies `try_ratchet_proof_policy` (Constitutional no-downgrade),
+  marks the proposal as `Executed`, and returns the new policy.
+  Returns dedicated error variants for:
+  - `ProposalNotPassed` — execute called on Active/Rejected/Executed
+  - `UnsupportedExecution` — wrong parameter name / wrong proposal kind
+  - `InvalidProofPolicyValue` — `new_value` outside 0..=3
+  - `ProofPolicyDowngradeVetoed` — ratchet violated
+- **`AppState.current_proof_policy: Arc<RwLock<ProofPolicy>>`** —
+  the **runtime-enforced** policy, distinct from the boot-time
+  string in `config.proof_policy`. Future code that gates
+  trade-accept on policy reads this field.
+- **`POST /v1/tirami/governance/execute/:id`** — applies a Passed
+  PROOF_POLICY proposal. Status codes:
+  - `200 OK` → `{ ok, proposal_id, previous_policy, new_policy, ratchet }`
+  - `404` → proposal not found
+  - `409 Conflict` → downgrade vetoed OR proposal not in Passed status
+  - `400 Bad Request` → unsupported parameter / invalid value
+- **`GET /v1/tirami/governance/proof-policy`** — read current
+  policy: `{ policy, as_u8, ratchet }`.
+
+#### What's NOT in Wave 4
+
+The endpoints establish the **upgrade path**; they do not yet
+**enforce** the new policy at trade-accept time. The runtime
+`AppState.current_proof_policy` is the substrate; the gate at
+`execute_signed_trade` still reads `proof_policy` from the boot
+Config. Wiring the runtime substrate into the gate is a follow-up
+Wave 4.5 (bounded — single function, plus tests).
+
+#### Tests added
+
+- `tirami-ledger::zk` +4: `from_governance_value` round-trip,
+  rounding tolerance, out-of-range rejection, non-finite rejection
+- `tirami-ledger::governance` +12: ratchet upgrade matrix,
+  same-value idempotence, skip-steps allowed, downgrade vetoed,
+  invalid value, NaN, not-passed, wrong-name, wrong-kind,
+  unknown-id, execute-twice
+- `tirami-node::handlers::governance` +6: HTTP-level happy/error
+  paths for `/execute/:id` and `/proof-policy`
+
+Workspace passes **1,441** tests (Wave 3 1,419 → +22).
+
+### Wave 5 (next) — runtime gate hookup OR real zk backend
+
+Two bounded follow-ups remain:
+
+1. **Wave 4.5 — runtime gate** (bounded, ≤ 100 LOC): change
+   `policy_allows_trade` callers to read
+   `AppState.current_proof_policy` instead of the immutable
+   boot-time `config.proof_policy`. Plumbing only — the gate
+   logic itself already exists.
+2. **Wave 5 — real zk backend** (week-scale): pick `risc0` or
+   `ezkl` and ship a real proof-of-inference. Wire format,
+   conversions, attestation typing all unchanged.
 
 ## Wave 3 — risc0 or ezkl integration
 


### PR DESCRIPTION
## Summary

Phase 24 Wave 4 wires the proposal-driven upgrade path for `ProofPolicy` together with a runtime substrate separate from the boot-time Config string.

### What's new

- `ProofPolicy::from_governance_value(v: f64) -> Option<Self>` — parses a `ChangeParameter` proposal's `new_value`; rounds to nearest non-negative integer; rejects out-of-range and non-finite floats.
- `GovernanceState::execute_proof_policy_proposal(id, current)` — takes a Passed `ChangeParameter { name: \"PROOF_POLICY\", ... }`, applies `try_ratchet_proof_policy` (Constitutional no-downgrade), marks the proposal `Executed`, returns the new policy. New error variants: `ProposalNotPassed`, `UnsupportedExecution`, `InvalidProofPolicyValue`, `ProofPolicyDowngradeVetoed`.
- `AppState.current_proof_policy: Arc<RwLock<ProofPolicy>>` — runtime state, initialised from Config at boot, then ratcheted by the governance dispatcher. Distinct from `config.proof_policy` which stays the boot-time default.
- `POST /v1/tirami/governance/execute/:id` — applies a Passed PROOF_POLICY proposal. `200 OK` / `404` not-found / `409 Conflict` (downgrade or not-Passed) / `400 Bad Request` (unsupported parameter).
- `GET /v1/tirami/governance/proof-policy` — read current enforced policy.

### NOT in this PR

The trade-accept gate still reads the immutable `Config` string, not `AppState.current_proof_policy`. That hookup is Wave 4.5 — bounded follow-up, plumbing only.

## Tests +22

- `tirami-ledger::zk` +4: `from_governance_value` round-trip + rounding tolerance + out-of-range + non-finite rejection
- `tirami-ledger::governance` +12: full ratchet matrix (upgrade, idempotent, skip-steps, vetoed downgrade) + error variants (not-passed, wrong-name, wrong-kind, NaN, invalid value, unknown id, execute-twice)
- `tirami-node::handlers::governance` +6: HTTP happy/sad paths for `/execute/:id` and `/proof-policy`

Workspace **1,441 passing** (Wave 3 1,419 → +22).

## Test plan

- [x] `cargo check --workspace` — warnings only
- [x] `cargo test --workspace` — 1,441 pass, 0 fail
- [x] `cargo test -p tirami-ledger --lib governance::tests::execute` — 12 pass
- [x] `cargo test -p tirami-node --lib handlers::governance::` — 15 pass (was 9 → +6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)