### PR TITLE
feat(phase-24/wave-4.5): trade-accept gate honours runtime ProofPolicy

### DIFF
--- a/crates/tirami-ledger/src/ledger.rs
+++ b/crates/tirami-ledger/src/ledger.rs
@@ -624,6 +624,14 @@ pub enum SignatureError {
     /// attestation bytes are malformed (wrong backend / wrong length).
     #[error("attestation signer does not match trade provider")]
     AttestationSignerMismatch,
+    /// Phase 24 Wave 4.5 — the runtime `ProofPolicy` rejected the
+    /// trade. Today that means policy=Required AND the trade has no
+    /// attestation attached.
+    #[error("trade rejected by proof policy {policy}: {reason}")]
+    TradeRejectedByProofPolicy {
+        policy: &'static str,
+        reason: &'static str,
+    },
 }
 
 /// Errors raised when creating a new loan via [`ComputeLedger::create_loan`].
@@ -1337,6 +1345,32 @@ impl ComputeLedger {
     ///   when the provider has already spent this exact nonce.
     /// * Accepted v2 nonces are inserted into [`Self::seen_nonces`],
     ///   which is ephemeral but rebuilt from `trade_log` on load.
+    /// Phase 24 Wave 4.5 — execute_signed_trade with an explicit
+    /// runtime `ProofPolicy` gate. When `policy` requires a proof
+    /// and the trade carries none, the trade is rejected with
+    /// `SignatureError::TradeRejectedByProofPolicy`. All other
+    /// policies fall through to the standard `execute_signed_trade`
+    /// path. Use this from runtime callers that hold the
+    /// governance-ratcheted policy (e.g. `AppState.current_proof_policy`);
+    /// the unparameterised `execute_signed_trade` remains for tests
+    /// and back-compat callers that haven't been updated yet —
+    /// behaviour there is equivalent to passing `ProofPolicy::Disabled`.
+    pub fn execute_signed_trade_gated(
+        &mut self,
+        signed: &SignedTradeRecord,
+        policy: crate::zk::ProofPolicy,
+    ) -> Result<(), SignatureError> {
+        let (allowed, reason) =
+            crate::zk::policy_allows_trade(policy, signed.attestation.is_some());
+        if !allowed {
+            return Err(SignatureError::TradeRejectedByProofPolicy {
+                policy: policy.as_str(),
+                reason,
+            });
+        }
+        self.execute_signed_trade(signed)
+    }
+
     pub fn execute_signed_trade(
         &mut self,
         signed: &SignedTradeRecord,
@@ -3116,6 +3150,148 @@ mod tests {
             ledger.get_balance(&signed.trade.provider).unwrap().contributed,
             signed.trade.trm_amount
         );
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 24 Wave 4.5 — execute_signed_trade_gated
+    // -----------------------------------------------------------------
+
+    use crate::zk::ProofPolicy;
+
+    fn build_attested_trade_with_self_signed_attestation()
+        -> (SignedTradeRecord, ed25519_dalek::SigningKey)
+    {
+        let (mut signed, provider_key) = build_attested_trade(None);
+        let mut bytes = vec![0u8; 96];
+        bytes[..32].copy_from_slice(&provider_key.verifying_key().to_bytes());
+        signed.attestation = Some(TradeAttestation::new("ed-attest".into(), bytes));
+        (signed, provider_key)
+    }
+
+    #[test]
+    fn gated_disabled_accepts_unattested_trade() {
+        let (signed, _) = build_attested_trade(None);
+        let mut ledger = ComputeLedger::new();
+        assert!(ledger
+            .execute_signed_trade_gated(&signed, ProofPolicy::Disabled)
+            .is_ok());
+    }
+
+    #[test]
+    fn gated_optional_accepts_unattested_trade() {
+        let (signed, _) = build_attested_trade(None);
+        let mut ledger = ComputeLedger::new();
+        assert!(ledger
+            .execute_signed_trade_gated(&signed, ProofPolicy::Optional)
+            .is_ok());
+    }
+
+    #[test]
+    fn gated_recommended_accepts_unattested_trade() {
+        // Recommended is informational; the gate still accepts.
+        let (signed, _) = build_attested_trade(None);
+        let mut ledger = ComputeLedger::new();
+        assert!(ledger
+            .execute_signed_trade_gated(&signed, ProofPolicy::Recommended)
+            .is_ok());
+    }
+
+    #[test]
+    fn gated_required_rejects_unattested_trade() {
+        let (signed, _) = build_attested_trade(None);
+        let mut ledger = ComputeLedger::new();
+        let err = ledger
+            .execute_signed_trade_gated(&signed, ProofPolicy::Required)
+            .unwrap_err();
+        assert!(matches!(err, SignatureError::TradeRejectedByProofPolicy { policy, .. } if policy == "required"));
+        // Trade must NOT have landed on the ledger.
+        assert!(ledger.get_balance(&signed.trade.provider).is_none());
+    }
+
+    #[test]
+    fn gated_required_accepts_well_attested_trade() {
+        let (signed, _) = build_attested_trade_with_self_signed_attestation();
+        let mut ledger = ComputeLedger::new();
+        assert!(ledger
+            .execute_signed_trade_gated(&signed, ProofPolicy::Required)
+            .is_ok());
+        // Trade landed.
+        assert_eq!(
+            ledger.get_balance(&signed.trade.provider).unwrap().contributed,
+            signed.trade.trm_amount
+        );
+    }
+
+    #[test]
+    fn gated_still_enforces_attestation_signer_match() {
+        // policy=Disabled doesn't bypass attestation-signer check —
+        // signer mismatch is a structural defect, not a policy gate.
+        let (mut signed, _) = build_attested_trade(None);
+        let mut bytes = vec![0u8; 96];
+        bytes[0] = 0xCD; // wrong pubkey
+        signed.attestation = Some(TradeAttestation::new("ed-attest".into(), bytes));
+        let mut ledger = ComputeLedger::new();
+        let err = ledger
+            .execute_signed_trade_gated(&signed, ProofPolicy::Disabled)
+            .unwrap_err();
+        assert!(matches!(err, SignatureError::AttestationSignerMismatch));
+    }
+
+    #[test]
+    fn gated_still_enforces_nonce_dedup() {
+        let (signed, _) = build_attested_trade_with_self_signed_attestation();
+        let mut ledger = ComputeLedger::new();
+        ledger
+            .execute_signed_trade_gated(&signed, ProofPolicy::Required)
+            .unwrap();
+        let err = ledger
+            .execute_signed_trade_gated(&signed, ProofPolicy::Required)
+            .unwrap_err();
+        assert!(matches!(err, SignatureError::ReplayedNonce { .. }));
+    }
+
+    #[test]
+    fn gated_required_with_optional_attestation_present_still_accepts() {
+        // Just because Required *requires* an attestation doesn't mean
+        // a non-Required policy MUST have one absent.
+        let (signed, _) = build_attested_trade_with_self_signed_attestation();
+        let mut ledger = ComputeLedger::new();
+        assert!(ledger
+            .execute_signed_trade_gated(&signed, ProofPolicy::Optional)
+            .is_ok());
+    }
+
+    #[test]
+    fn gated_rejection_does_not_consume_nonce_slot() {
+        // If Required rejects an unattested trade, the nonce should
+        // remain unconsumed so the consumer can retry with a freshly-
+        // produced attestation under the same nonce.
+        let (signed, _) = build_attested_trade(None);
+        let mut ledger = ComputeLedger::new();
+        let _ = ledger.execute_signed_trade_gated(&signed, ProofPolicy::Required);
+        // Now retry the *same* nonce with an attested record. Build a
+        // fresh attestation onto the same trade (same provider key)
+        // — note we re-use the same SignedTradeRecord with a now
+        // attached attestation.
+        let (mut retry, provider_key) = build_attested_trade(None);
+        retry.trade.nonce = signed.trade.nonce;
+        retry.trade.provider = signed.trade.provider.clone();
+        retry.trade.consumer = signed.trade.consumer.clone();
+        retry.trade.timestamp = signed.trade.timestamp;
+        retry.trade.trm_amount = signed.trade.trm_amount;
+        retry.trade.tokens_processed = signed.trade.tokens_processed;
+        retry.trade.model_id = signed.trade.model_id.clone();
+        // Re-sign with the same keys (provider_key is preserved via
+        // build_attested_trade's returned key) — but build_attested_trade
+        // generated new keys for `retry`; this property test relies
+        // on the policy gate being checked BEFORE nonce dedup. We
+        // verify only that the gated path doesn't burn the slot.
+        // (For a full retry-under-same-nonce semantic test we'd need
+        // a deterministic-key fixture.)
+        let _ = provider_key;
+        assert!(ledger.seen_nonces.get(&signed.trade.provider).is_none() ||
+            ledger.seen_nonces.get(&signed.trade.provider).map(|c| !c.contains(&signed.trade.nonce)).unwrap_or(true),
+            "policy rejection must not consume the nonce slot");
     }
 
     #[test]

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -185,6 +185,10 @@ pub fn create_router(
     cluster: Option<Arc<ClusterManager>>,
     gossip: Arc<Mutex<GossipState>>,
 ) -> Router {
+    // Compute before `config` moves into the call below.
+    let initial_proof_policy = tirami_ledger::zk::ProofPolicy::parse(&config.proof_policy)
+        .unwrap_or(tirami_ledger::zk::ProofPolicy::Disabled);
+    let proof_policy_handle = Arc::new(tokio::sync::RwLock::new(initial_proof_policy));
     create_router_with_services(
         config,
         engine,
@@ -208,6 +212,8 @@ pub fn create_router(
         // calls `create_router_with_services` directly with the
         // node's own shared Arc.
         Arc::new(Mutex::new(None)),
+        // Phase 24 Wave 4.5 — runtime policy handle, computed above.
+        proof_policy_handle,
     )
 }
 
@@ -237,20 +243,19 @@ pub fn create_router_with_services(
     // `run_seed` so an HTTP `agent/identity/init` immediately
     // updates the signer the pipeline reads.
     agent_identity: Arc<Mutex<Option<tirami_mind::AgentIdentity>>>,
+    // Phase 24 Wave 4.5 — shared `current_proof_policy` handle.
+    // Same `Arc<RwLock<ProofPolicy>>` is held by `AppState` (this
+    // function's HTTP layer) and `TiramiNode` (which passes it to
+    // `run_seed`) so a governance ratchet via
+    // `POST /v1/tirami/governance/execute/:id` is immediately
+    // visible to the pipeline.
+    current_proof_policy: Arc<tokio::sync::RwLock<tirami_ledger::zk::ProofPolicy>>,
 ) -> Router {
     // Derive local node ID from cluster or generate a deterministic one.
     let local_node_id = cluster
         .as_ref()
         .map(|c| c.local_capability().node_id.clone())
         .unwrap_or_else(|| NodeId([0u8; 32]));
-
-    // Phase 24 Wave 4 — boot-time proof_policy from Config; governance
-    // ratchets this upward. Unknown / malformed strings fall back to
-    // the conservative `Disabled` so a misconfigured node doesn't
-    // silently start running an unintended policy.
-    let initial_proof_policy = tirami_ledger::zk::ProofPolicy::parse(&config.proof_policy)
-        .unwrap_or(tirami_ledger::zk::ProofPolicy::Disabled);
-    let current_proof_policy = Arc::new(tokio::sync::RwLock::new(initial_proof_policy));
 
     let state = AppState {
         config,
@@ -4441,6 +4446,9 @@ fn now_secs() -> u64 {
 /// Used by handler unit tests in `handlers/bank.rs`, `handlers/agora.rs`, and `handlers/mind.rs`.
 pub(crate) fn test_router_default(config: Config) -> Router {
     use crate::bank_adapter::BankServices;
+    let initial_policy = tirami_ledger::zk::ProofPolicy::parse(&config.proof_policy)
+        .unwrap_or(tirami_ledger::zk::ProofPolicy::Disabled);
+    let policy_handle = Arc::new(tokio::sync::RwLock::new(initial_policy));
     create_router_with_services(
         config,
         Arc::new(Mutex::new(CandleEngine::new())),
@@ -4461,6 +4469,8 @@ pub(crate) fn test_router_default(config: Config) -> Router {
         Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
         // Phase 23 Wave 2.5 — test helper builds an unshared slot.
         Arc::new(Mutex::new(None)),
+        // Phase 24 Wave 4.5 — runtime policy handle.
+        policy_handle,
     )
 }
 
@@ -5235,6 +5245,7 @@ mod tests {
             Arc::new(Mutex::new(agent)),
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             Arc::new(Mutex::new(None)),
+            Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
         )
     }
 
@@ -7547,6 +7558,7 @@ mod tests {
             Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             shared.clone(), // ← the Arc we will observe externally
+            Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
         );
 
         // Externally observed slot is empty before init.
@@ -7596,6 +7608,7 @@ mod tests {
             Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             shared.clone(),
+            Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
         );
         // First identity via init.
         let (_, init_a) = post_identity_init(app_a.clone(), None).await;
@@ -7625,6 +7638,7 @@ mod tests {
             Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             shared_b.clone(),
+            Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
         );
         let (_status, _view) =
             post_identity_import(app_b, "passphrase-1234567", bundle).await;

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -57,6 +57,12 @@ pub struct TiramiNode {
     /// Defaults to `None` on construction so existing behaviour is
     /// preserved when no identity is loaded.
     pub agent_identity: Arc<Mutex<Option<tirami_mind::AgentIdentity>>>,
+    /// Phase 24 Wave 4.5 — runtime `ProofPolicy` shared with
+    /// `AppState.current_proof_policy`. The HTTP API ratchets this
+    /// upward via `POST /v1/tirami/governance/execute/:id`; the
+    /// pipeline reads it at trade-execute time so the gate honours
+    /// the latest governance decision.
+    pub current_proof_policy: Arc<tokio::sync::RwLock<tirami_ledger::zk::ProofPolicy>>,
     heartbeat_started: bool,
 }
 
@@ -143,6 +149,14 @@ impl TiramiNode {
         // passphrase env var is unset.
         let agent_identity = load_persisted_agent_identity(&config);
 
+        // Phase 24 Wave 4.5 — boot the runtime ProofPolicy from the
+        // boot Config string. Unknown / malformed strings fall back
+        // to the conservative `Disabled` so a misconfigured node
+        // doesn't silently start running an unintended policy.
+        let initial_proof_policy = tirami_ledger::zk::ProofPolicy::parse(&config.proof_policy)
+            .unwrap_or(tirami_ledger::zk::ProofPolicy::Disabled);
+        let current_proof_policy = Arc::new(tokio::sync::RwLock::new(initial_proof_policy));
+
         Self {
             config,
             engine: Arc::new(Mutex::new(CandleEngine::new())),
@@ -167,6 +181,7 @@ impl TiramiNode {
             // is missing so the in-memory-only path remains the
             // out-of-the-box default.
             agent_identity: Arc::new(Mutex::new(agent_identity)),
+            current_proof_policy,
             heartbeat_started: false,
         }
     }
@@ -225,6 +240,9 @@ impl TiramiNode {
             // with the pipeline. HTTP `agent/identity/init` now
             // populates the slot the signer reads.
             self.agent_identity.clone(),
+            // Phase 24 Wave 4.5 — share the same proof-policy Arc
+            // so HTTP `governance/execute/:id` reaches the pipeline.
+            self.current_proof_policy.clone(),
         );
         let addr = self.config.api_socket_addr();
         tracing::info!("API server listening on {}", addr);
@@ -259,6 +277,7 @@ impl TiramiNode {
         let personal_agent_api = self.personal_agent.clone();
         let agent_loop_stats_api = self.agent_loop_stats.clone();
         let agent_identity_api = self.agent_identity.clone();
+        let current_proof_policy_api = self.current_proof_policy.clone();
         let api_config = self.config.clone();
         tokio::spawn(async move {
             let app = crate::api::create_router_with_services(
@@ -281,6 +300,8 @@ impl TiramiNode {
                 agent_loop_stats_api,
                 // Phase 23 Wave 2.5 — shared Arc.
                 agent_identity_api,
+                // Phase 24 Wave 4.5 — shared ProofPolicy handle.
+                current_proof_policy_api,
             );
             let addr = api_config.api_socket_addr();
             if let Ok(listener) = tokio::net::TcpListener::bind(&addr).await {
@@ -527,6 +548,9 @@ impl TiramiNode {
                 // Phase 23 Wave 2 — propagate the AgentIdentity slot
                 // so trade signing follows the DID when one is loaded.
                 self.agent_identity.clone(),
+                // Phase 24 Wave 4.5 — share the runtime ProofPolicy
+                // handle so the pipeline respects governance ratchets.
+                self.current_proof_policy.clone(),
             )
             .await
             .map_err(|e| tirami_core::TiramiError::NetworkError(format!("seed: {e}")))?;

--- a/crates/tirami-node/src/pipeline.rs
+++ b/crates/tirami-node/src/pipeline.rs
@@ -71,6 +71,12 @@ impl PipelineCoordinator {
         // node id. Pass `Arc::new(Mutex::new(None))` to keep the
         // pre-Wave-2 behaviour.
         agent_identity: Arc<Mutex<Option<tirami_mind::AgentIdentity>>>,
+        // Phase 24 Wave 4.5 — runtime ProofPolicy gate. Shared with
+        // `AppState.current_proof_policy` so governance ratchet
+        // upgrades take immediate effect on freshly-spawned tasks.
+        // Tasks read this once when they actually need to gate; the
+        // governance ratchet itself ensures monotonic upgrades.
+        current_proof_policy: Arc<tokio::sync::RwLock<tirami_ledger::zk::ProofPolicy>>,
     ) -> anyhow::Result<()> {
         let node_id = self.transport.tirami_node_id();
         tracing::info!("Pipeline seed running, waiting for requests...");
@@ -197,6 +203,12 @@ impl PipelineCoordinator {
                             let guard = agent_identity.lock().await;
                             guard.as_ref().cloned()
                         };
+                        // Phase 24 Wave 4.5 — snapshot the current
+                        // proof policy so the spawned task sees a
+                        // consistent value across its own lifetime,
+                        // even if governance ratchets mid-flight.
+                        let policy_snapshot =
+                            *current_proof_policy.read().await;
 
                         tokio::spawn(async move {
                             let _permit = permit;
@@ -213,6 +225,7 @@ impl PipelineCoordinator {
                                 gossip,
                                 dispatcher,
                                 agent_snapshot,
+                                policy_snapshot,
                             )
                             .await
                             {
@@ -417,6 +430,13 @@ impl PipelineCoordinator {
                         // it records a remote-originated trade.
                         let staking = staking_pool.clone();
                         let stake_gate_enabled = config.stake_gate_enabled;
+                        // Phase 24 Wave 4.5 — clone the proof-policy
+                        // handle so the spawned task can read the
+                        // current value at the moment it tries to
+                        // record. Reading inside the task picks up
+                        // a governance ratchet that completed
+                        // between gossip-receive and ledger-write.
+                        let policy_handle = current_proof_policy.clone();
                         tokio::spawn(async move {
                             if let Some(signed) =
                                 tirami_net::gossip::handle_trade_gossip(&gossip, &trade_gossip).await
@@ -460,7 +480,11 @@ impl PipelineCoordinator {
                                 // trades. The gossip helper already ran a
                                 // first-pass verify, but dedup is stateful
                                 // and must happen at the ledger layer.
-                                match ledger.execute_signed_trade(&signed) {
+                                // Phase 24 Wave 4.5 — read the *current*
+                                // ratcheted policy (not the boot-time
+                                // string) and use the gated execute path.
+                                let policy = *policy_handle.read().await;
+                                match ledger.execute_signed_trade_gated(&signed, policy) {
                                     Ok(()) => {
                                         if let Some(path) = ledger_path.as_ref() {
                                             let _ = ledger.save_to_path(path);
@@ -862,6 +886,10 @@ async fn handle_inference(
     // attribution AND signing key follow this identity rather than
     // the machine-level transport.
     agent_identity: Option<tirami_mind::AgentIdentity>,
+    // Phase 24 Wave 4.5 — current runtime ProofPolicy. Read once at
+    // execute_signed_trade time so a governance ratchet between
+    // dispatch and execute is honoured.
+    current_proof_policy: tirami_ledger::zk::ProofPolicy,
 ) -> anyhow::Result<()> {
     use tirami_infer::InferenceEngine;
 
@@ -1092,7 +1120,9 @@ async fn handle_inference(
             match signed.verify() {
                 Ok(()) => {
                     let mut ledger = ledger.lock().await;
-                    match ledger.execute_signed_trade(&signed) {
+                    // Phase 24 Wave 4.5 — gate on the runtime
+                    // ProofPolicy passed into handle_inference.
+                    match ledger.execute_signed_trade_gated(&signed, current_proof_policy) {
                         Ok(()) => {
                             if let Some(path) = ledger_path.as_ref() {
                                 ledger.save_to_path(path)?;
@@ -1771,6 +1801,7 @@ mod tests {
                         Arc::new(Mutex::new(GossipState::new())),
                         Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
                         Arc::new(Mutex::new(None)),
+                        Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
                     )
                     .await
                     .expect("seed loop");

--- a/crates/tirami-node/src/security_tests.rs
+++ b/crates/tirami-node/src/security_tests.rs
@@ -710,6 +710,7 @@ mod security_tests {
             Arc::new(Mutex::new(None::<tirami_mind::PersonalAgent>)),
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             Arc::new(Mutex::new(None)),
+            Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
         );
         let _ = state; // suppress unused warning
 

--- a/docs/phase-24-zkml-real-backends.md
+++ b/docs/phase-24-zkml-real-backends.md
@@ -8,7 +8,7 @@
 > forgeable" to "production-grade proof of inference" without a
 > single multi-week commit.
 
-Status: Wave 1 + Wave 2 + Wave 2.5 + Wave 3 + Wave 4 shipped.
+Status: Wave 1 + Wave 2 + Wave 2.5 + Wave 3 + Wave 4 + Wave 4.5 shipped.
 
 ## The trajectory
 
@@ -289,18 +289,69 @@ Wave 4.5 (bounded — single function, plus tests).
 
 Workspace passes **1,441** tests (Wave 3 1,419 → +22).
 
-### Wave 5 (next) — runtime gate hookup OR real zk backend
+### Wave 4.5 ✅ shipped — runtime gate hookup
 
-Two bounded follow-ups remain:
+The Wave-4 substrate now actually gates trade execution.
 
-1. **Wave 4.5 — runtime gate** (bounded, ≤ 100 LOC): change
-   `policy_allows_trade` callers to read
-   `AppState.current_proof_policy` instead of the immutable
-   boot-time `config.proof_policy`. Plumbing only — the gate
-   logic itself already exists.
-2. **Wave 5 — real zk backend** (week-scale): pick `risc0` or
-   `ezkl` and ship a real proof-of-inference. Wire format,
-   conversions, attestation typing all unchanged.
+#### What's new
+
+- **`ComputeLedger::execute_signed_trade_gated(signed, policy)`** —
+  evaluates `policy_allows_trade(policy, has_attestation)` BEFORE
+  the existing `execute_signed_trade` path. Failure returns
+  `SignatureError::TradeRejectedByProofPolicy { policy, reason }`.
+  The unparameterised `execute_signed_trade` is retained for tests
+  / back-compat callers (behaviour ≡ `Disabled`).
+- **`SignatureError::TradeRejectedByProofPolicy`** — new variant.
+- **`TiramiNode.current_proof_policy: Arc<RwLock<ProofPolicy>>`** —
+  shared with `AppState.current_proof_policy` (same Arc passed
+  through `create_router_with_services`). A governance ratchet
+  via `POST /v1/tirami/governance/execute/:id` is immediately
+  visible to the pipeline.
+- **`PipelineCoordinator::run_seed` takes the shared
+  `current_proof_policy`** and threads it through
+  `handle_inference` and the gossip-receive task. The producer
+  path uses `current_proof_policy` as a snapshot (the gate value
+  doesn't change mid-inference); the gossip-receive path reads
+  it fresh per trade so late-arriving gossip respects the most
+  recent governance state.
+
+#### Reject path semantics
+
+When `policy = Required` and an unattested trade arrives:
+
+- **Local execution** (producer's own inference): the trade is
+  rejected; the consumer reservation is already released
+  upstream; reputation does *not* get the success boost.
+- **Gossip receive**: rejected locally; the bilateral agreement
+  between remote provider/consumer is unaffected — this only
+  refuses to *record* the trade in this node's ledger.
+- **Nonce slot is NOT consumed** on policy rejection — a
+  follow-up attempt to record the same nonce with a valid
+  attestation isn't auto-blocked as a replay.
+
+#### Tests added
+
+`tirami-ledger::execute_signed_trade_gated` matrix +9:
+- `gated_disabled_accepts_unattested_trade`
+- `gated_optional_accepts_unattested_trade`
+- `gated_recommended_accepts_unattested_trade`
+- `gated_required_rejects_unattested_trade`
+- `gated_required_accepts_well_attested_trade`
+- `gated_still_enforces_attestation_signer_match`
+- `gated_still_enforces_nonce_dedup`
+- `gated_required_with_optional_attestation_present_still_accepts`
+- `gated_rejection_does_not_consume_nonce_slot`
+
+Workspace passes **1,450** tests (Wave 4 1,441 → +9).
+
+### Wave 5 (next, week-scale) — real zk backend
+
+The protocol now has the full pipeline:
+- Wave 1: ed-attest backend produces unforgeable signature-based attestations
+- Waves 2–3: attestations flow end-to-end over wire and are cryptographically verifiable by receivers
+- Waves 4–4.5: governance can ratchet the policy upward and the trade-accept gate enforces it
+
+Remaining work: replace ed-attest's "I signed this with my key" claim with a real zk proof — "I correctly computed Y on X without revealing the model weights or intermediate activations." This means wiring `risc0` or `ezkl` as a real `BenchBackend` and shipping `risc0`-flavoured `BenchProof` bytes. The on-trade `TradeAttestation` format already accommodates any backend name + bytes; the wire path doesn't change.
 
 ## Wave 3 — risc0 or ezkl integration
 


### PR DESCRIPTION
## Summary

Wave 4.5 wires the Wave-4 substrate (`AppState.current_proof_policy`) into the trade-execution gate. A governance ratchet via `POST /v1/tirami/governance/execute/:id` now takes effect immediately at the pipeline.

### Changes

- `ComputeLedger::execute_signed_trade_gated(signed, policy)` — evaluates `policy_allows_trade(policy, has_attestation)` before falling through to `execute_signed_trade`. Failure returns the new `SignatureError::TradeRejectedByProofPolicy { policy, reason }`. The unparameterised `execute_signed_trade` remains for back-compat callers/tests (semantically `Disabled`).
- `TiramiNode.current_proof_policy: Arc<RwLock<ProofPolicy>>` shared with `AppState.current_proof_policy` (same Arc threaded through `create_router_with_services`).
- `PipelineCoordinator::run_seed` takes the handle and threads it through:
  - `handle_inference` (producer path) — snapshot at task spawn
  - gossip-receive task — read fresh per trade
- `create_router_with_services` gains a `current_proof_policy: Arc<RwLock<ProofPolicy>>` parameter; all in-workspace callers updated.

### Reject path semantics

When `policy = Required` and an unattested trade arrives:
- Local execution → rejected; consumer reservation already released upstream; no reputation boost.
- Gossip receive → rejected locally; bilateral agreement between remote provider/consumer unaffected.
- **Nonce slot NOT consumed** on policy rejection — retry under the same nonce with a valid attestation isn't auto-blocked as a replay.

## Tests +9 (gated matrix)

- Disabled / Optional / Recommended → accept unattested
- Required → reject unattested
- Required → accept well-attested
- Attestation-signer check still firing under all policies
- Nonce dedup still firing under gated path
- Required + attested + duplicate nonce → ReplayedNonce
- Optional + present attestation → accept (no requirement)
- Policy rejection doesn't burn nonce slot

Workspace **1,450 passing** (Wave 4 1,441 → +9).

## Test plan

- [x] `cargo check --workspace --tests` — warnings only
- [x] `cargo test --workspace` — 1,450 pass, 0 fail
- [x] `cargo test -p tirami-ledger --lib gated` — 10 pass (Wave 4.5 9 + 1 sibling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)