### PR TITLE
feat(phase-24/wave-5.0): scaffold backends behind feature flags + Wave 5.1+ plan

### DIFF
--- a/crates/tirami-zkml-bench/Cargo.toml
+++ b/crates/tirami-zkml-bench/Cargo.toml
@@ -32,8 +32,16 @@ rand = { workspace = true }
 #
 # The MockBackend is always available so the harness compiles
 # (and has tests) without any real zk dep.
+#
+# Phase 24 Wave 5.0 — the `risc0` / `ezkl` / `halo2` features now
+# wire up a *scaffold* implementation that is structurally honest:
+# it produces a deterministic commitment with a backend-specific
+# version prefix so receivers know which proof family to expect,
+# but the commitment is NOT zero-knowledge yet. Real risc0-zkvm /
+# ezkl crates land in Wave 5.1+ (see
+# `docs/phase-24-wave-5-zk-backends.md`).
 [features]
 default = []
-risc0 = []  # scaffolded; actual crate import lands in 18.3-part-2
-halo2 = []  # scaffolded; actual crate import lands in 18.3-part-2
-ezkl = []   # scaffolded; ezkl is git-vendored, landing in 18.3-part-2
+risc0 = []  # Wave 5.0: scaffold commitment; Wave 5.1+ wires risc0-zkvm
+halo2 = []  # same shape; real halo2 lands separately
+ezkl = []   # same shape; ezkl is git-vendored, landing separately

--- a/crates/tirami-zkml-bench/src/lib.rs
+++ b/crates/tirami-zkml-bench/src/lib.rs
@@ -179,9 +179,41 @@ impl BenchBackend for MockBackend {
 }
 
 // ---------------------------------------------------------------------------
-// Ezkl / Risc0 / Halo2 stubs (feature-gated; return BackendUnavailable
-// until Phase 18.3-part-2 wires real integrations)
+// Ezkl / Risc0 / Halo2 — feature-gated.
+//
+// Default build (no features): return `BackendUnavailable` so the
+// harness compiles + tests stay lean.
+//
+// Phase 24 Wave 5.0 — when the corresponding feature is enabled,
+// the backend produces a *scaffold* commitment that:
+//   - is deterministic (same spec → same proof bytes)
+//   - has a backend-specific version prefix in the canonical pre-image
+//   - verifies via recomputation (NOT zero-knowledge; not yet zk-SNARK)
+//
+// The scaffold establishes the wire format and lets downstream code
+// (`SignedTradeRecord.attestation`, gossip verifier) exercise the
+// non-ed-attest path. Real risc0-zkvm / ezkl / halo2 crate imports
+// land in Wave 5.1+ (see `docs/phase-24-wave-5-zk-backends.md`).
 // ---------------------------------------------------------------------------
+
+/// Phase 24 Wave 5.0 — compute the scaffold commitment for a given
+/// backend label + spec. The label is part of the canonical pre-image
+/// so collisions across backends are structurally impossible. Format
+/// (versioned, see `SCAFFOLD_VERSION`): 32-byte SHA-256 over
+/// `b"tirami-{label}-scaffold-v0" || canonical_spec`.
+fn scaffold_commitment(label: &str, spec: &BenchSpec) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(b"tirami-");
+    h.update(label.as_bytes());
+    h.update(b"-scaffold-v0");
+    h.update(spec.model_hash);
+    h.update(spec.prompt_hash);
+    h.update(spec.output_hash);
+    h.update(spec.token_count.to_le_bytes());
+    h.update(spec.flops.to_le_bytes());
+    h.finalize().into()
+}
 
 macro_rules! stub_backend {
     ($name:ident, $label:expr) => {
@@ -208,9 +240,72 @@ macro_rules! stub_backend {
     };
 }
 
+#[cfg(not(feature = "ezkl"))]
 stub_backend!(EzklBackend, "ezkl");
+
+#[cfg(not(feature = "risc0"))]
 stub_backend!(Risc0Backend, "risc0");
+
+#[cfg(not(feature = "halo2"))]
 stub_backend!(Halo2Backend, "halo2");
+
+macro_rules! scaffold_backend {
+    ($name:ident, $label:expr) => {
+        /// Phase 24 Wave 5.0 — scaffold backend. Produces a
+        /// deterministic 32-byte SHA-256 commitment keyed by the
+        /// backend label and the full canonical `BenchSpec`. NOT
+        /// zero-knowledge; receivers verify by recomputing.
+        /// Real zk implementation lands in Wave 5.1+.
+        #[derive(Debug, Clone, Copy, Default)]
+        pub struct $name;
+
+        impl BenchBackend for $name {
+            fn name(&self) -> &'static str {
+                $label
+            }
+
+            fn prove(&self, spec: &BenchSpec) -> Result<BenchProof, BenchError> {
+                if spec.token_count == 0 {
+                    return Err(BenchError::InvalidSpec("token_count must be > 0".into()));
+                }
+                let bytes = scaffold_commitment($label, spec).to_vec();
+                Ok(BenchProof { backend: $label.to_string(), bytes })
+            }
+
+            fn verify(
+                &self,
+                spec: &BenchSpec,
+                proof: &BenchProof,
+            ) -> Result<(), BenchError> {
+                if proof.backend != $label {
+                    return Err(BenchError::VerifyFailed(format!(
+                        "backend mismatch: expected {} got {}",
+                        $label, proof.backend
+                    )));
+                }
+                if proof.bytes.len() != 32 {
+                    return Err(BenchError::VerifyFailed(
+                        "proof bytes must be 32 bytes (SHA-256)".into(),
+                    ));
+                }
+                let expected = scaffold_commitment($label, spec);
+                if proof.bytes.as_slice() != expected.as_slice() {
+                    return Err(BenchError::VerifyFailed("scaffold commitment mismatch".into()));
+                }
+                Ok(())
+            }
+        }
+    };
+}
+
+#[cfg(feature = "ezkl")]
+scaffold_backend!(EzklBackend, "ezkl");
+
+#[cfg(feature = "risc0")]
+scaffold_backend!(Risc0Backend, "risc0");
+
+#[cfg(feature = "halo2")]
+scaffold_backend!(Halo2Backend, "halo2");
 
 // ---------------------------------------------------------------------------
 // Phase 24 Wave 1 — Ed25519 attestation backend
@@ -628,6 +723,8 @@ mod tests {
         assert!(matches!(err, BenchError::InvalidSpec(_)));
     }
 
+    // Default feature build: ezkl/risc0/halo2 are unavailable stubs.
+    #[cfg(not(any(feature = "ezkl", feature = "risc0", feature = "halo2")))]
     #[test]
     fn stub_backends_return_unavailable() {
         for b_result in [
@@ -640,6 +737,104 @@ mod tests {
                 Err(BenchError::BackendUnavailable(_))
             ));
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 24 Wave 5.0 — scaffold-backend property tests (feature-gated)
+    // -----------------------------------------------------------------
+
+    #[cfg(feature = "risc0")]
+    #[test]
+    fn risc0_scaffold_round_trip_succeeds() {
+        let b = Risc0Backend;
+        let s = spec();
+        let proof = b.prove(&s).expect("prove");
+        assert_eq!(proof.backend, "risc0");
+        assert_eq!(proof.bytes.len(), 32);
+        b.verify(&s, &proof).expect("verify");
+    }
+
+    #[cfg(feature = "risc0")]
+    #[test]
+    fn risc0_scaffold_is_deterministic() {
+        let b = Risc0Backend;
+        let s = spec();
+        let p1 = b.prove(&s).expect("prove");
+        let p2 = b.prove(&s).expect("prove");
+        assert_eq!(p1.bytes, p2.bytes);
+    }
+
+    #[cfg(feature = "risc0")]
+    #[test]
+    fn risc0_scaffold_rejects_tampered_spec() {
+        let b = Risc0Backend;
+        let s = spec();
+        let proof = b.prove(&s).expect("prove");
+        let mut tampered = s.clone();
+        tampered.prompt_hash[0] ^= 0xFF;
+        let err = b.verify(&tampered, &proof).unwrap_err();
+        assert!(matches!(err, BenchError::VerifyFailed(_)));
+    }
+
+    #[cfg(feature = "risc0")]
+    #[test]
+    fn risc0_scaffold_rejects_wrong_backend_label_on_proof() {
+        let b = Risc0Backend;
+        let s = spec();
+        let mut proof = b.prove(&s).expect("prove");
+        proof.backend = "ezkl".to_string();
+        let err = b.verify(&s, &proof).unwrap_err();
+        assert!(matches!(err, BenchError::VerifyFailed(_)));
+    }
+
+    #[cfg(feature = "risc0")]
+    #[test]
+    fn risc0_scaffold_rejects_zero_token_count() {
+        let mut s = spec();
+        s.token_count = 0;
+        let err = Risc0Backend.prove(&s).unwrap_err();
+        assert!(matches!(err, BenchError::InvalidSpec(_)));
+    }
+
+    #[cfg(feature = "risc0")]
+    #[test]
+    fn risc0_scaffold_label_is_part_of_canonical_preimage() {
+        // Each scaffold backend produces a label-keyed commitment, so
+        // even identical specs yield different bytes across backends.
+        // Without that, an attacker could replay an `ezkl` proof under
+        // the `risc0` label and pass receiver-side dispatch.
+        #[cfg(feature = "ezkl")]
+        {
+            let s = spec();
+            let r0 = Risc0Backend.prove(&s).unwrap();
+            let ez = EzklBackend.prove(&s).unwrap();
+            assert_ne!(r0.bytes, ez.bytes);
+        }
+    }
+
+    #[cfg(feature = "risc0")]
+    #[test]
+    fn risc0_scaffold_runs_through_run_bench_harness() {
+        let r = run_bench(&Risc0Backend, &spec(), 5).expect("bench");
+        assert_eq!(r.backend, "risc0");
+        assert_eq!(r.proof_bytes, 32);
+        assert_eq!(r.trials, 5);
+    }
+
+    #[cfg(feature = "risc0")]
+    #[test]
+    fn risc0_scaffold_runs_through_run_bench_trade_attestation() {
+        // Wave-2 verifier helper dispatches by backend name — confirm
+        // the scaffold backend is rejected (it's not on the dispatch
+        // matrix; only `mock` and `ed-attest` are). This is the
+        // intended behaviour: scaffold proofs are NOT meant to pass
+        // through `verify_trade_attestation` until Wave 5.1+ makes
+        // them real zk.
+        let s = spec();
+        let proof = Risc0Backend.prove(&s).expect("prove");
+        let att = TradeAttestation::new(proof.backend.clone(), proof.bytes.clone());
+        let err = verify_trade_attestation(&s, &att, &[0u8; 32]);
+        assert!(err.is_err());
     }
 
     #[test]

--- a/docs/phase-24-wave-5-zk-backends.md
+++ b/docs/phase-24-wave-5-zk-backends.md
@@ -1,0 +1,245 @@
+# Phase 24 Wave 5 — Real zk backends
+
+> Phase 24 Waves 1–4.5 built the full attestation pipeline using
+> Ed25519 attestations: producers sign, receivers verify, gossip
+> carries proofs end-to-end, governance can ratchet the policy
+> upward and the trade-accept gate honours it. The remaining gap
+> is the **strength of the claim** — ed-attest only proves "I
+> signed this" not "I actually computed Y on X correctly".
+>
+> Wave 5 closes that gap with real zk-SNARK / zk-STARK proofs.
+
+Status: **Wave 5.0 shipped** (scaffold backends behind feature
+flags). **Wave 5.1+ pending** (real risc0/ezkl crate integration
+— week-scale).
+
+## What ed-attest proves vs. what zk would prove
+
+| | ed-attest (Waves 1–4.5) | zk (Wave 5.1+) |
+|---|---|---|
+| Unforgeable claim about identity | ✅ | ✅ |
+| Unforgeable claim about *computation* | ❌ — provider could lie about output | ✅ — circuit constrains output to be correct |
+| Hides model weights from verifier | N/A | ✅ |
+| Hides prompt from verifier | N/A | ✅ (depending on scheme) |
+| Proof size | 96 bytes | 200 B – few KB (Groth16) / 50–500 KB (STARK) |
+| Prove time | sub-ms | seconds to minutes |
+| Verify time | sub-ms | ms–10 ms (Groth16) / 10–100 ms (STARK) |
+
+## Wave 5.0 (✅ shipped) — Scaffold backends
+
+The `risc0` / `ezkl` / `halo2` Cargo features now wire up a
+**deterministic SHA-256 commitment scaffold** rather than returning
+`BackendUnavailable`. The commitment is keyed by:
+
+```
+sha256(b"tirami-{label}-scaffold-v0" || canonical_bench_spec)
+```
+
+This is **not** zero-knowledge — receivers verify by recomputing —
+but it lets:
+
+1. Downstream code (trade attestation wire format, gossip verifier
+   dispatch, `BenchBackendKind` selector) exercise non-ed-attest
+   paths.
+2. Property tests confirm the wire format is label-keyed (an
+   `ezkl` proof can't be replayed under the `risc0` label).
+3. CI benchmark the harness against a non-mock backend without
+   pulling in the multi-GB risc0-zkvm dep chain.
+
+Scaffold proofs are **explicitly rejected** by
+`verify_trade_attestation` — see the
+`risc0_scaffold_runs_through_run_bench_trade_attestation` test.
+This is intentional: scaffolds are dev-only.
+
+## Wave 5.1 — risc0-zkvm integration
+
+### Goal
+
+Replace `Risc0Backend`'s scaffold with a real risc0 STARK proof.
+Guest computes `BenchSpec` validation: model_hash + prompt_hash
++ output_hash were correctly committed for the claimed
+token_count + flops.
+
+### Dependencies to add
+
+```toml
+# crates/tirami-zkml-bench/Cargo.toml
+[dependencies.risc0-zkvm]
+version = "1.0"
+optional = true
+default-features = false
+features = ["std"]
+
+[features]
+risc0 = ["dep:risc0-zkvm"]
+```
+
+Note: `risc0-zkvm` ≈ 100 MB of compile artifacts + Risc-V
+toolchain prebuild. Add a feature-flagged CI job; do **not**
+enable on default workspace builds.
+
+### Guest program (skeleton)
+
+```rust
+// guests/bench_commit/src/main.rs
+use risc0_zkvm::guest::env;
+use sha2::{Digest, Sha256};
+
+fn main() {
+    // Read public inputs: model_hash, prompt_hash, output_hash,
+    // token_count, flops.
+    let model_hash: [u8; 32] = env::read();
+    let prompt_hash: [u8; 32] = env::read();
+    let output_hash: [u8; 32] = env::read();
+    let token_count: u64 = env::read();
+    let flops: u64 = env::read();
+
+    // Commit to all inputs publicly so the verifier can recompute
+    // the journal hash and bind the receipt to this exact spec.
+    let mut h = Sha256::new();
+    h.update(b"tirami-risc0-commit-v1");
+    h.update(model_hash);
+    h.update(prompt_hash);
+    h.update(output_hash);
+    h.update(token_count.to_le_bytes());
+    h.update(flops.to_le_bytes());
+    let commit: [u8; 32] = h.finalize().into();
+
+    env::commit(&commit);
+}
+```
+
+This is still a "commit-only" circuit — it doesn't *verify*
+inference correctness. That requires a circuit that runs a
+quantised model forward pass, which is Wave 5.3.
+
+### Host-side wiring
+
+```rust
+// crates/tirami-zkml-bench/src/risc0_backend.rs
+#[cfg(feature = "risc0")]
+impl BenchBackend for Risc0Backend {
+    fn prove(&self, spec: &BenchSpec) -> Result<BenchProof, BenchError> {
+        let env = risc0_zkvm::ExecutorEnv::builder()
+            .write(&spec.model_hash)?
+            .write(&spec.prompt_hash)?
+            .write(&spec.output_hash)?
+            .write(&spec.token_count)?
+            .write(&spec.flops)?
+            .build()?;
+
+        let prover = risc0_zkvm::default_prover();
+        let receipt = prover.prove(env, BENCH_COMMIT_ELF)?;
+
+        let bytes = bincode::serialize(&receipt)
+            .map_err(|e| BenchError::ProveFailed(e.to_string()))?;
+
+        Ok(BenchProof { backend: "risc0".to_string(), bytes })
+    }
+
+    fn verify(&self, spec: &BenchSpec, proof: &BenchProof) -> Result<(), BenchError> {
+        let receipt: risc0_zkvm::Receipt = bincode::deserialize(&proof.bytes)?;
+        receipt.verify(BENCH_COMMIT_ID)?;
+        // Cross-check the journal commitment matches the spec.
+        let journal_commit: [u8; 32] = receipt.journal.decode()?;
+        let expected = expected_commitment(spec);
+        if journal_commit != expected {
+            return Err(BenchError::VerifyFailed("journal mismatch".into()));
+        }
+        Ok(())
+    }
+}
+```
+
+### Tests
+
+- `risc0_real_prove_then_verify_round_trip` — guarded by
+  `#[cfg(feature = "risc0")]` and slow (multi-second prove).
+- `risc0_real_verify_rejects_tampered_spec` — receipt verifies
+  cryptographically but journal commitment binds to spec.
+- `risc0_real_verify_rejects_tampered_journal` — receipt
+  itself fails if the journal is rewritten.
+
+### Wire-up
+
+When `Config.zkml_backend == "risc0"` AND `feature = "risc0"`,
+`pipeline.rs::produce_ed_attest_attestation` (now misnamed; will
+be renamed `produce_attestation` in Wave 5.1) dispatches to
+`Risc0Backend` instead of `EdAttestBackend`.
+
+`verify_trade_attestation` gets a third dispatch arm for
+`"risc0"` proofs.
+
+## Wave 5.2 — ezkl integration
+
+Same shape as 5.1 but using `ezkl` (Halo2-based, SNARK). Trade-off:
+
+- ezkl can take an ONNX model as input and synthesise a circuit
+  per layer — naturally aligned with the "prove this specific
+  model's output" goal.
+- Compile-per-model is expensive (one-time per model variant);
+  per-inference prove is fast(er than risc0).
+- Requires SRS file management — operators ship a 100 MB SRS
+  the first time they run ezkl-attested inference.
+
+## Wave 5.3 — model-forward circuit (research scope)
+
+True zkML proof of inference: the circuit runs the model
+forward pass and commits to the output. This is the property
+the protocol promises but no backend currently delivers.
+
+Open questions:
+
+- Quantisation: int8 models prove tractably; bf16/f16 don't.
+- Memory: full forward-pass circuits for 7B-parameter models
+  blow up SRS sizes. Layer-wise sub-circuits + recursion are
+  one promising direction.
+- Batching: per-inference proofs are bandwidth-prohibitive for
+  high-throughput nodes. Folding schemes (Nova, ProtoStar) let
+  one proof commit to many inferences.
+
+This is genuinely cutting-edge work; the protocol provides the
+substrate (attestation wire format, governance ratchet) and
+benefits from any backend that ships.
+
+## Wave 5.4 — backend strength taxonomy
+
+Once multiple real backends exist, the protocol needs a
+machine-readable strength taxonomy so agents can route on it.
+
+Sketch:
+
+```rust
+pub enum BackendStrength {
+    /// Recomputable by anyone (mock, scaffold). Dev only.
+    None,
+    /// Unforgeable but not zk (ed-attest). Bound to a key.
+    Cryptographic,
+    /// zk-SNARK / zk-STARK over input/output commitment but
+    /// not the computation (risc0-commit-only).
+    InputOutputBound,
+    /// zk over the computation itself (ezkl + ONNX model
+    /// circuit, or risc0 guest that runs the model).
+    ComputeBound,
+}
+
+impl BenchBackend {
+    fn strength(&self) -> BackendStrength;
+}
+```
+
+Agents reading the discovery manifest can prefer
+`ComputeBound > InputOutputBound > Cryptographic > None`.
+
+## What Wave 5 explicitly does NOT do
+
+- **Mandate any specific backend.** The constitution doesn't
+  pick winners; governance does, via the
+  `ProofPolicy` + `BenchBackendKind` selectors.
+- **Optimise prove time.** Real zk is slow today. Wave 5 ships
+  *correct* proofs first; performance is a tracking concern.
+- **Reach Wave 5.3 in one PR.** Model-forward circuits are
+  weeks-to-months of cryptography + engineering work. Waves
+  5.1 and 5.2 ship "commit-only" proofs which already provide
+  meaningful protocol-level value (binding the trade to a
+  specific input/output without revealing the prompt).

--- a/docs/phase-24-zkml-real-backends.md
+++ b/docs/phase-24-zkml-real-backends.md
@@ -8,7 +8,9 @@
 > forgeable" to "production-grade proof of inference" without a
 > single multi-week commit.
 
-Status: Wave 1 + Wave 2 + Wave 2.5 + Wave 3 + Wave 4 + Wave 4.5 shipped.
+Status: Wave 1 + Wave 2 + Wave 2.5 + Wave 3 + Wave 4 + Wave 4.5 + Wave 5.0 shipped.
+Wave 5.1+ (real risc0/ezkl crate integration) is week-scale work
+tracked in `docs/phase-24-wave-5-zk-backends.md`.
 
 ## The trajectory
 
@@ -344,14 +346,60 @@ When `policy = Required` and an unattested trade arrives:
 
 Workspace passes **1,450** tests (Wave 4 1,441 → +9).
 
-### Wave 5 (next, week-scale) — real zk backend
+### Wave 5.0 ✅ shipped — scaffold backends behind feature flags
 
-The protocol now has the full pipeline:
-- Wave 1: ed-attest backend produces unforgeable signature-based attestations
-- Waves 2–3: attestations flow end-to-end over wire and are cryptographically verifiable by receivers
-- Waves 4–4.5: governance can ratchet the policy upward and the trade-accept gate enforces it
+Pre-Wave-5.0 state: `Risc0Backend` / `EzklBackend` / `Halo2Backend`
+were stubs returning `BackendUnavailable` even with their Cargo
+feature enabled. Real risc0-zkvm / ezkl crate integration is
+genuinely week-scale work (Risc-V toolchain, ~100 MB SRS files,
+guest program builds), so it doesn't ship in one PR.
 
-Remaining work: replace ed-attest's "I signed this with my key" claim with a real zk proof — "I correctly computed Y on X without revealing the model weights or intermediate activations." This means wiring `risc0` or `ezkl` as a real `BenchBackend` and shipping `risc0`-flavoured `BenchProof` bytes. The on-trade `TradeAttestation` format already accommodates any backend name + bytes; the wire path doesn't change.
+Wave 5.0 closes a narrower gap: when the `risc0` / `ezkl` /
+`halo2` features are enabled, the backends produce a
+**deterministic SHA-256 commitment scaffold** keyed by the
+backend label and the full canonical `BenchSpec`. This is
+explicitly **not zero-knowledge** — receivers verify by
+recomputing — but it lets the downstream wiring be exercised:
+
+- The `BenchBackendKind` selector dispatches to a non-mock backend.
+- The wire format (`TradeAttestation { backend, bytes }`) carries
+  a non-ed-attest proof through the gossip pipeline.
+- An attacker can't replay an `ezkl` scaffold proof under the
+  `risc0` label (the label is part of the canonical pre-image).
+- The verifier dispatch in `verify_trade_attestation` correctly
+  rejects scaffold proofs — they're dev-only and must not pass
+  through the protocol's authoritative verifier.
+
+#### Tests added
+
+`tirami-zkml-bench` +8 (all `#[cfg(feature = "risc0")]`):
+- `risc0_scaffold_round_trip_succeeds`
+- `risc0_scaffold_is_deterministic`
+- `risc0_scaffold_rejects_tampered_spec`
+- `risc0_scaffold_rejects_wrong_backend_label_on_proof`
+- `risc0_scaffold_rejects_zero_token_count`
+- `risc0_scaffold_label_is_part_of_canonical_preimage`
+- `risc0_scaffold_runs_through_run_bench_harness`
+- `risc0_scaffold_runs_through_run_bench_trade_attestation` (asserts the scaffold proof is rejected by the protocol verifier — intended)
+
+Default-feature workspace still passes **1,450** tests; with
+`--features risc0` enabled, `tirami-zkml-bench` runs 44 tests
+(was 37 → +7 active, plus the 8th replaces the no-longer-firing
+`stub_backends_return_unavailable` which is now feature-gated
+to the no-features build).
+
+### Wave 5.1 (next, week-scale) — real risc0 zkVM integration
+
+`docs/phase-24-wave-5-zk-backends.md` carries the full plan:
+- guest program (`bench_commit`) — commits to all spec fields
+- host-side `Risc0Backend` impl using `risc0_zkvm::default_prover`
+- receipt serialised as `BenchProof.bytes`
+- verifier dispatches `"risc0"` proofs to receipt verify + journal
+  commitment cross-check
+- `Config.zkml_backend = "risc0"` routes producers to it
+
+Wave 5.2 mirrors the same shape for `ezkl`. Wave 5.3 is research
+scope (model-forward circuits proving inference correctness).
 
 ## Wave 3 — risc0 or ezkl integration
 


### PR DESCRIPTION
## Summary

Wave 5 was scoped as **week-scale** (real risc0-zkvm / ezkl crate integration with Risc-V toolchain prebuild + SRS file management). This PR is the bounded **Wave 5.0 foundation** that ships in one commit; Wave 5.1+ tracks the multi-week zk integration in [`docs/phase-24-wave-5-zk-backends.md`](docs/phase-24-wave-5-zk-backends.md).

## What Wave 5.0 ships

**Before:** `Risc0Backend` / `EzklBackend` / `Halo2Backend` returned `BackendUnavailable` even with their Cargo feature enabled.

**After:** when the `risc0` / `ezkl` / `halo2` feature is enabled, the backend produces a **deterministic SHA-256 commitment scaffold** keyed by the backend label and the canonical `BenchSpec`. This is **not zero-knowledge** — receivers verify by recomputing — but it exercises:

- `BenchBackendKind` selector dispatching to non-mock backends
- `TradeAttestation { backend, bytes }` wire format carrying non-ed-attest proofs
- Label-keyed canonical pre-image (`ezkl` proof can't be replayed under the `risc0` label)
- Protocol verifier dispatch correctly **rejecting** scaffold proofs (dev-only, must not pass authoritative verify)

## Honest scope statement

This PR **does not** ship a real zk proof. It ships the wiring necessary so that Wave 5.1 can drop in a `risc0_zkvm::Receipt` and the rest of the pipeline (gossip wire, governance ratchet, trade-accept gate) keeps working unchanged. See the design doc for the Wave 5.1 plan.

## Tests +8 (feature-gated)

All `#[cfg(feature = \"risc0\")]`:
- `risc0_scaffold_round_trip_succeeds`
- `risc0_scaffold_is_deterministic`
- `risc0_scaffold_rejects_tampered_spec`
- `risc0_scaffold_rejects_wrong_backend_label_on_proof`
- `risc0_scaffold_rejects_zero_token_count`
- `risc0_scaffold_label_is_part_of_canonical_preimage`
- `risc0_scaffold_runs_through_run_bench_harness`
- `risc0_scaffold_runs_through_run_bench_trade_attestation` (asserts scaffold proof rejected by protocol verifier — intended)

Default-feature workspace still passes **1,450** tests. With `--features risc0`, `tirami-zkml-bench` runs **44** tests (was 37 → +7 active + 8th-as-conditional-stub-replacement).

## Test plan

- [x] `cargo check -p tirami-zkml-bench` — no features, OK
- [x] `cargo check -p tirami-zkml-bench --features risc0` — OK
- [x] `cargo check -p tirami-zkml-bench --features ezkl,risc0,halo2` — OK
- [x] `cargo test --workspace` — 1,450 pass
- [x] `cargo test -p tirami-zkml-bench --features risc0` — 44 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)