### PR TITLE
feat(phase-25/a7): NodeId entropy floor at welcome-loan claim (issue #116)

### DIFF
--- a/crates/tirami-ledger/src/sybil.rs
+++ b/crates/tirami-ledger/src/sybil.rs
@@ -195,6 +195,54 @@ impl WelcomeLoanLimiter {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 25 A7 — NodeId entropy floor
+// ---------------------------------------------------------------------------
+//
+// Welcome loans are credited to the first NodeId a request shows up
+// with. An attacker who hand-picks `NodeId([0u8; 32])` or any other
+// low-entropy pattern can sidestep the per-bucket rate limit by
+// "rotating" through a structured family of trivially-crafted ids
+// (`[0; 32]`, `[1; 32]`, ..., `[0xFF; 32]`). Genuine random NodeIds
+// derived from Ed25519 keypair generation have ~7.97 bits of Shannon
+// entropy per byte (32 bytes ≈ 255 bits of input → close to maximum).
+//
+// `MIN_NODEID_ENTROPY_BITS` rejects everything below 3.5 bits, which
+// catches all single-byte-repeating patterns + 4-byte ramps but
+// leaves real keypair-derived ids comfortably above the floor.
+
+/// Minimum Shannon entropy (bits/byte) a NodeId must clear to be
+/// considered a real cryptographic identity for welcome-loan
+/// purposes. 3.5 is well above any structured pattern but well
+/// below the ~7.97 average of random bytes.
+pub const MIN_NODEID_ENTROPY_BITS: f64 = 3.5;
+
+/// Phase 25 A7 — compute Shannon entropy (bits/byte) of a 32-byte
+/// NodeId. Pure function so callers can short-circuit before
+/// invoking the more expensive limiter machinery.
+pub fn nodeid_entropy_bits(bytes: &[u8; 32]) -> f64 {
+    let mut counts = [0u32; 256];
+    for &b in bytes {
+        counts[b as usize] += 1;
+    }
+    let n = bytes.len() as f64;
+    let mut h = 0.0_f64;
+    for &c in &counts {
+        if c > 0 {
+            let p = c as f64 / n;
+            h -= p * p.log2();
+        }
+    }
+    h
+}
+
+/// Phase 25 A7 — true iff the NodeId clears the entropy floor.
+/// Use this at the welcome-loan claim point to refuse trivially
+/// crafted ids before any limiter bucket gets touched.
+pub fn nodeid_has_sufficient_entropy(bytes: &[u8; 32]) -> bool {
+    nodeid_entropy_bits(bytes) >= MIN_NODEID_ENTROPY_BITS
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -368,5 +416,68 @@ mod tests {
         assert_eq!(back.window_ms, c.window_ms);
         assert_eq!(back.max_per_bucket_per_window, c.max_per_bucket_per_window);
         assert_eq!(back.staked_multiplier, c.staked_multiplier);
+    }
+
+    // --- Phase 25 A7 — NodeId entropy floor ---
+
+    #[test]
+    fn all_zero_nodeid_is_rejected_as_low_entropy() {
+        assert!(!nodeid_has_sufficient_entropy(&[0u8; 32]));
+    }
+
+    #[test]
+    fn all_ones_nodeid_is_rejected() {
+        assert!(!nodeid_has_sufficient_entropy(&[0xFFu8; 32]));
+    }
+
+    #[test]
+    fn repeating_byte_nodeid_is_rejected() {
+        for byte in [0x01u8, 0x55, 0xAA, 0xCC] {
+            assert!(
+                !nodeid_has_sufficient_entropy(&[byte; 32]),
+                "[{byte}; 32] should be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn ramp_nodeid_is_above_floor() {
+        // Sequential 0..32 produces high entropy (each byte distinct).
+        let mut ramp = [0u8; 32];
+        for (i, b) in ramp.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        // 32 distinct values, uniform → 5 bits/byte (log2 32).
+        assert!(nodeid_has_sufficient_entropy(&ramp));
+    }
+
+    #[test]
+    fn high_entropy_random_nodeid_passes() {
+        // Deterministic high-entropy fixture (sha256-derived).
+        use sha2::{Digest, Sha256};
+        let h = Sha256::digest(b"phase-25-a7-entropy-test");
+        let mut id = [0u8; 32];
+        id.copy_from_slice(&h);
+        assert!(nodeid_has_sufficient_entropy(&id));
+    }
+
+    #[test]
+    fn low_diversity_2byte_alphabet_is_rejected() {
+        // 16 zeros + 16 ones → 1.0 bits/byte → below floor.
+        let mut id = [0u8; 32];
+        for b in &mut id[16..] {
+            *b = 1;
+        }
+        assert!(!nodeid_has_sufficient_entropy(&id));
+        // Approx: should be 1.0 bits.
+        let h = nodeid_entropy_bits(&id);
+        assert!((h - 1.0).abs() < 1e-9, "entropy was {h}");
+    }
+
+    #[test]
+    fn entropy_floor_constant_is_documented() {
+        // Sentinel: if the floor changes, the test breaks so docs
+        // + welcome-claim assumptions are re-verified.
+        assert_eq!(MIN_NODEID_ENTROPY_BITS, 3.5);
     }
 }

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -7144,7 +7144,10 @@ mod tests {
     #[tokio::test]
     async fn welcome_loan_claim_returns_grant_for_fresh_node() {
         let app = test_router_with_agent(Config::default(), None);
-        let claimant = "aa".repeat(32);
+        // Phase 25 A7 — must be a high-entropy id to clear the
+        // welcome-claim entropy floor.
+        use sha2::Digest;
+        let claimant = hex::encode(sha2::Sha256::digest(b"a7-welcome-fresh-fixture"));
         let (status, body) = post_claim_welcome(app, &claimant, Some("AS-test")).await;
         assert_eq!(status, StatusCode::OK, "claim failed: {body}");
         assert_eq!(body["node_id"], claimant);
@@ -7164,8 +7167,9 @@ mod tests {
     /// to `false`.
     #[tokio::test]
     async fn welcome_loan_claim_is_one_shot_per_node() {
+        use sha2::Digest;
         let app = test_router_with_agent(Config::default(), None);
-        let claimant = "bb".repeat(32);
+        let claimant = hex::encode(sha2::Sha256::digest(b"a7-welcome-oneshot-fixture"));
         let (status, _) = post_claim_welcome(app.clone(), &claimant, None).await;
         assert_eq!(status, StatusCode::OK);
         let (status, body) = post_claim_welcome(app, &claimant, None).await;

--- a/crates/tirami-node/src/handlers/welcome_claim.rs
+++ b/crates/tirami-node/src/handlers/welcome_claim.rs
@@ -85,6 +85,29 @@ pub(crate) async fn claim_welcome_loan(
 ) -> Result<Json<ClaimWelcomeResponse>, (StatusCode, String)> {
     check_forge_rate_limit(&state).await?;
     let node_id = parse_sender(&headers)?;
+    // Phase 25 A7 — NodeId entropy floor. Hand-crafted ids
+    // (all-zero, all-FF, single-byte repeats) bypass the per-bucket
+    // sybil limiter by rotating through structured "families".
+    // Reject them at the claim point so they never reach the
+    // limiter.
+    if !tirami_ledger::sybil::nodeid_has_sufficient_entropy(&node_id.0) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({
+                "error": {
+                    "type": "welcome_loan_denied",
+                    "code": "low_entropy_nodeid",
+                    "message": format!(
+                        "NodeId entropy {:.2} bits/byte is below the {:.1} floor — \
+                         use a real Ed25519 keypair-derived id",
+                        tirami_ledger::sybil::nodeid_entropy_bits(&node_id.0),
+                        tirami_ledger::sybil::MIN_NODEID_ENTROPY_BITS,
+                    ),
+                }
+            })
+            .to_string(),
+        ));
+    }
     let now = now_millis_pub();
     let mut ledger = state.ledger.lock().await;
     let grant = ledger


### PR DESCRIPTION
Shannon entropy ≥ 3.5 bits/byte gate on /v1/tirami/agent/claim-welcome. Rejects hand-crafted low-entropy NodeIds that would bypass the per-bucket Sybil limiter. Tests +7, workspace 1,491 passing.