### PR TITLE
feat(phase-25/a8+c6+c9): request trace ids + slashing cap + anchor pace note (issue #116)

### DIFF
--- a/crates/tirami-core/src/config.rs
+++ b/crates/tirami-core/src/config.rs
@@ -239,6 +239,15 @@ pub struct Config {
     /// scrapers without credentials.
     #[serde(default)]
     pub metrics_require_bearer: bool,
+
+    /// Phase 25 C9 — maximum number of `SlashEvent`s the
+    /// slashing engine is permitted to emit in a single tick.
+    /// Defends against a logic bug or false-positive cluster that
+    /// would otherwise drain the staking pool in one pass.
+    /// Default 100 trades plenty of room for honest collusion
+    /// detection while bounding worst-case damage per tick.
+    #[serde(default = "default_max_slashes_per_tick")]
+    pub max_slashes_per_tick: u32,
 }
 
 /// Phase 21 Wave 2 — stake gate is **on by default** so that fresh
@@ -300,6 +309,10 @@ fn default_agent_tick_interval_secs() -> u64 {
 
 fn default_zkml_backend() -> String {
     "mock".to_string()
+}
+
+fn default_max_slashes_per_tick() -> u32 {
+    100
 }
 
 fn default_personal_agent_enabled() -> bool {
@@ -422,6 +435,7 @@ impl Default for Config {
             personal_agent_enabled: true,
             zkml_backend: "mock".to_string(),
             metrics_require_bearer: false,
+            max_slashes_per_tick: 100,
         }
     }
 }

--- a/crates/tirami-ledger/src/ledger.rs
+++ b/crates/tirami-ledger/src/ledger.rs
@@ -1561,10 +1561,27 @@ impl ComputeLedger {
     /// * Nodes that have already been slashed in the last 5 minutes
     ///   are skipped too, so repeated runs don't zero the same stake
     ///   to dust over one bad streak.
+    /// Phase 25 C9 — back-compat wrapper that delegates to
+    /// [`update_trust_penalties_capped`] with `cap = u32::MAX`,
+    /// preserving the pre-Phase-25 unbounded behaviour for tests
+    /// and tooling that hasn't been migrated yet.
     pub fn update_trust_penalties(
         &mut self,
         staking: &mut crate::StakingPool,
         now_ms: u64,
+    ) -> Vec<SlashEvent> {
+        self.update_trust_penalties_capped(staking, now_ms, u32::MAX)
+    }
+
+    /// Phase 25 C9 — rate-limited slashing. Same semantics as
+    /// `update_trust_penalties` except the engine stops once
+    /// `max_slashes_per_tick` events have been emitted in a
+    /// single call. The remainder is left for the next tick.
+    pub fn update_trust_penalties_capped(
+        &mut self,
+        staking: &mut crate::StakingPool,
+        now_ms: u64,
+        max_slashes_per_tick: u32,
     ) -> Vec<SlashEvent> {
         let candidates: Vec<NodeId> = {
             let mut seen: std::collections::HashSet<NodeId> =
@@ -1588,6 +1605,13 @@ impl ComputeLedger {
 
         let mut new_events = Vec::new();
         for node_id in candidates {
+            if (new_events.len() as u32) >= max_slashes_per_tick {
+                // Phase 25 C9 — cap reached; remaining candidates
+                // wait until the next slashing tick. Bounds worst-
+                // case damage from a logic bug / false-positive
+                // cluster to `max_slashes_per_tick` per interval.
+                break;
+            }
             if recently_slashed.contains(&node_id) {
                 continue;
             }
@@ -3442,6 +3466,84 @@ mod tests {
         inject_tight_cluster(&mut ledger, subject, counterparty, 20, now);
         let events = ledger.update_trust_penalties(&mut staking, now);
         assert!(events.is_empty(), "stakeless nodes must not spam audit log");
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 25 C9 — slashing rate-limiter
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn update_trust_penalties_capped_at_zero_yields_no_events() {
+        // Cap = 0 → engine emits nothing even when conditions match.
+        use crate::StakingPool;
+        let subject = NodeId([0xAA; 32]);
+        let counterparty = NodeId([0xBB; 32]);
+        let now = now_millis();
+        let mut staking = StakingPool::new();
+        staking
+            .stake(subject.clone(), 10_000, crate::staking::StakeDuration::Days7, now)
+            .expect("stake fixture");
+        let mut ledger = ComputeLedger::new();
+        inject_tight_cluster(&mut ledger, subject, counterparty, 20, now);
+        let events = ledger.update_trust_penalties_capped(&mut staking, now, 0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn update_trust_penalties_capped_respects_max() {
+        // Build a ledger with many slashable nodes and assert the
+        // engine stops at the requested cap. The "remainder" is
+        // left for the next tick.
+        use crate::StakingPool;
+        let now = now_millis();
+        let mut staking = StakingPool::new();
+        let mut ledger = ComputeLedger::new();
+        // Create 5 slashable subjects with distinct ids.
+        let subjects: Vec<NodeId> = (0..5).map(|i| NodeId([0xC0 + i as u8; 32])).collect();
+        let counterparty = NodeId([0xEE; 32]);
+        for subject in &subjects {
+            staking
+            .stake(subject.clone(), 10_000, crate::staking::StakeDuration::Days7, now)
+            .expect("stake fixture");
+            inject_tight_cluster(&mut ledger, subject.clone(), counterparty.clone(), 20, now);
+        }
+        // Cap = 2 → engine emits at most 2 events.
+        let events = ledger.update_trust_penalties_capped(&mut staking, now, 2);
+        assert!(events.len() <= 2, "got {} events, cap was 2", events.len());
+    }
+
+    #[test]
+    fn update_trust_penalties_back_compat_unbounded() {
+        // The unparameterised method matches the old semantics
+        // (no cap, all eligible nodes processed in one call).
+        use crate::StakingPool;
+        let now = now_millis();
+        let mut staking = StakingPool::new();
+        let mut ledger = ComputeLedger::new();
+        for i in 0..3 {
+            let subject = NodeId([0xD0 + i as u8; 32]);
+            let counterparty = NodeId([0xEF + i as u8; 32]);
+            staking
+            .stake(subject.clone(), 10_000, crate::staking::StakeDuration::Days7, now)
+            .expect("stake fixture");
+            inject_tight_cluster(&mut ledger, subject, counterparty, 20, now);
+        }
+        let bounded = ledger.update_trust_penalties_capped(&mut staking, now, u32::MAX);
+        // Same wrapper at any large cap should match the
+        // unparameterised call on a fresh ledger (separate scope
+        // since the first call already consumed the candidates).
+        let mut staking2 = StakingPool::new();
+        let mut ledger2 = ComputeLedger::new();
+        for i in 0..3 {
+            let subject = NodeId([0xD0 + i as u8; 32]);
+            let counterparty = NodeId([0xEF + i as u8; 32]);
+            staking2
+                .stake(subject.clone(), 10_000, crate::staking::StakeDuration::Days7, now)
+                .expect("stake fixture");
+            inject_tight_cluster(&mut ledger2, subject, counterparty, 20, now);
+        }
+        let unbounded = ledger2.update_trust_penalties(&mut staking2, now);
+        assert_eq!(bounded.len(), unbounded.len());
     }
 
     #[test]

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -608,6 +608,10 @@ pub fn create_router_with_services(
         // envelope. Applied as the outermost layer so it runs AFTER
         // all other middleware and handler responses.
         .layer(middleware::from_fn(json_error_envelope))
+        // Phase 25 A8 — stamp every response with X-Tirami-Request-Id.
+        // Outer-most so the id ends up on the wire even when the
+        // envelope middleware reshapes the body.
+        .layer(middleware::from_fn(request_trace_id_layer))
         .layer(DefaultBodyLimit::max(api_max_request_body_bytes))
         .with_state(state)
 }
@@ -1371,6 +1375,40 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         status: "ok".to_string(),
         model_loaded: engine.is_loaded(),
     })
+}
+
+/// Phase 25 A8 — request-trace id middleware.
+///
+/// Stamps an `X-Tirami-Request-Id` header into every response so
+/// operators can correlate a single client request across log
+/// lines, traces, and gossip events. If the client supplied its
+/// own request id we echo it back so the chain is transitive;
+/// otherwise we generate a fresh `req-` id (separate prefix from
+/// `chatcmpl-` so the two namespaces don't collide).
+async fn request_trace_id_layer(
+    mut request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    use rand::Rng;
+    let header_name = axum::http::HeaderName::from_static("x-tirami-request-id");
+    let incoming = request
+        .headers()
+        .get(&header_name)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let request_id = incoming.unwrap_or_else(|| {
+        let id: u64 = rand::thread_rng().r#gen();
+        format!("req-{:016x}", id)
+    });
+    // Stamp the id onto the request so downstream handlers can
+    // grab it from extensions if they want to include it in their
+    // own structured logging.
+    request.extensions_mut().insert(request_id.clone());
+    let mut response = next.run(request).await;
+    if let Ok(value) = axum::http::HeaderValue::from_str(&request_id) {
+        response.headers_mut().insert(header_name, value);
+    }
+    response
 }
 
 /// Phase 25 A2 — structured 503 envelope for the inference path.
@@ -4869,6 +4907,76 @@ mod tests {
         assert_ne!(h1, h2);
         assert_ne!(h2, h3);
         assert_ne!(h1, h3);
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 25 A8 — request-trace id middleware
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn request_trace_id_is_stamped_on_response_when_not_supplied() {
+        let app = test_router(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let id = resp
+            .headers()
+            .get("x-tirami-request-id")
+            .and_then(|v| v.to_str().ok())
+            .expect("x-tirami-request-id must be present");
+        assert!(id.starts_with("req-"), "generated id should be req- prefix, got {id}");
+        assert!(id.len() >= 8);
+    }
+
+    #[tokio::test]
+    async fn request_trace_id_is_echoed_when_client_supplies_one() {
+        let app = test_router(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/healthz")
+                    .header("x-tirami-request-id", "trace-abc-123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let echoed = resp
+            .headers()
+            .get("x-tirami-request-id")
+            .and_then(|v| v.to_str().ok())
+            .expect("must echo");
+        assert_eq!(echoed, "trace-abc-123");
+    }
+
+    #[tokio::test]
+    async fn request_trace_id_persists_through_error_envelope() {
+        // 404 still gets a request id stamped (middleware runs
+        // after json_error_envelope so the id survives the rewrap).
+        let app = test_router(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/tirami/nonexistent-route")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(resp
+            .headers()
+            .get("x-tirami-request-id")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| !v.is_empty()));
     }
 
     #[tokio::test]

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -778,6 +778,9 @@ impl TiramiNode {
         let staking = self.staking_pool.clone();
         let ledger_path = self.config.ledger_path.clone();
         let interval_secs = self.config.slashing_interval_secs.max(60);
+        // Phase 25 C9 — per-tick cap so a logic bug or false-positive
+        // cluster can't drain the staking pool in one sweep.
+        let max_slashes_per_tick = self.config.max_slashes_per_tick;
 
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
@@ -795,7 +798,7 @@ impl TiramiNode {
                 let events = {
                     let mut l = ledger.lock().await;
                     let mut s = staking.lock().await;
-                    l.update_trust_penalties(&mut s, now_ms)
+                    l.update_trust_penalties_capped(&mut s, now_ms, max_slashes_per_tick)
                 };
 
                 if !events.is_empty() {
@@ -958,6 +961,10 @@ impl TiramiNode {
                 tirami_core::NodeId([0u8; 32])
             }
         };
+        // Phase 25 C6 — operators can dial this down to 10 sec for
+        // global-scale fresh anchoring; the hard floor stays at 10 s
+        // so a misconfigured `0` doesn't spin the loop into a tight
+        // CPU burn.
         let interval_secs = self.config.anchor_interval_secs.max(10);
 
         tokio::spawn(async move {


### PR DESCRIPTION
Three bounded items merged into one PR for tempo: A8 X-Tirami-Request-Id, C9 max_slashes_per_tick (default 100), C6 anchor pace docstring. Tests +6, workspace 1,499 passing.