### PR TITLE
feat(phase-25/a6+c4): /metrics process gauges + configurable gossip cap (issue #116)

### DIFF
--- a/crates/tirami-core/src/config.rs
+++ b/crates/tirami-core/src/config.rs
@@ -248,6 +248,14 @@ pub struct Config {
     /// detection while bounding worst-case damage per tick.
     #[serde(default = "default_max_slashes_per_tick")]
     pub max_slashes_per_tick: u32,
+
+    /// Phase 25 C4 — per-node gossip dedup capacity. Operators
+    /// running global-scale nodes should raise this to keep the
+    /// dedup horizon long enough for sustained TPS; resource-
+    /// constrained edge nodes can lower it. Default 100,000
+    /// matches the historical hardcoded const.
+    #[serde(default = "default_gossip_max_seen")]
+    pub gossip_max_seen: usize,
 }
 
 /// Phase 21 Wave 2 — stake gate is **on by default** so that fresh
@@ -313,6 +321,10 @@ fn default_zkml_backend() -> String {
 
 fn default_max_slashes_per_tick() -> u32 {
     100
+}
+
+fn default_gossip_max_seen() -> usize {
+    100_000
 }
 
 fn default_personal_agent_enabled() -> bool {
@@ -436,6 +448,7 @@ impl Default for Config {
             zkml_backend: "mock".to_string(),
             metrics_require_bearer: false,
             max_slashes_per_tick: 100,
+            gossip_max_seen: 100_000,
         }
     }
 }

--- a/crates/tirami-net/src/gossip.rs
+++ b/crates/tirami-net/src/gossip.rs
@@ -12,9 +12,12 @@ use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-/// Maximum number of trade hashes to remember for deduplication.
-/// Prevents unbounded memory growth under trade flooding (Issue #1).
-const MAX_GOSSIP_SEEN: usize = 100_000;
+/// Default maximum number of trade hashes to remember for
+/// deduplication. Prevents unbounded memory growth under trade
+/// flooding (Issue #1). Phase 25 C4 — the per-`GossipState`
+/// `max_seen` field overrides this when the operator wants a
+/// taller cap for global-scale deployments.
+pub const DEFAULT_MAX_GOSSIP_SEEN: usize = 100_000;
 
 /// Maximum pending gossip trades to process per second (Issue #14).
 const MAX_GOSSIP_TRADES_PER_SEC: u32 = 100;
@@ -38,10 +41,24 @@ pub struct GossipState {
     /// Rate limiting for incoming gossip (Issue #14).
     ingest_count: u32,
     ingest_window: std::time::Instant,
+    /// Phase 25 C4 — per-instance dedup capacity. Operators with
+    /// many gossip-active peers can raise this beyond
+    /// `DEFAULT_MAX_GOSSIP_SEEN` to keep the dedup horizon long
+    /// enough for sustained TPS. Bounded so the field still caps
+    /// worst-case memory.
+    max_seen: usize,
 }
 
 impl GossipState {
     pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_MAX_GOSSIP_SEEN)
+    }
+
+    /// Phase 25 C4 — explicit per-instance dedup capacity. Use this
+    /// from a node startup path when the operator's Config carries
+    /// a higher `gossip_max_seen` (global-scale deployments) or a
+    /// smaller one (resource-constrained edge nodes).
+    pub fn with_capacity(max_seen: usize) -> Self {
         Self {
             seen: HashSet::new(),
             order: VecDeque::new(),
@@ -53,7 +70,13 @@ impl GossipState {
             order_price_signals: VecDeque::new(),
             ingest_count: 0,
             ingest_window: std::time::Instant::now(),
+            max_seen: max_seen.max(1),
         }
+    }
+
+    /// Effective dedup capacity for this `GossipState` instance.
+    pub fn max_seen(&self) -> usize {
+        self.max_seen
     }
 
     /// Phase 14.1 — check if a price signal is new. Returns true if new.
@@ -73,7 +96,7 @@ impl GossipState {
             return false;
         }
         self.order_price_signals.push_back(key);
-        while self.order_price_signals.len() > MAX_GOSSIP_SEEN {
+        while self.order_price_signals.len() > self.max_seen {
             if let Some(evicted) = self.order_price_signals.pop_front() {
                 self.seen_price_signals.remove(&evicted);
             }
@@ -99,7 +122,7 @@ impl GossipState {
         }
         self.order.push_back(hash);
         // Evict oldest when over limit
-        while self.order.len() > MAX_GOSSIP_SEEN {
+        while self.order.len() > self.max_seen {
             if let Some(evicted) = self.order.pop_front() {
                 self.seen.remove(&evicted);
             }
@@ -119,7 +142,7 @@ impl GossipState {
             return false;
         }
         self.order_loans.push_back(hash);
-        while self.order_loans.len() > MAX_GOSSIP_SEEN {
+        while self.order_loans.len() > self.max_seen {
             if let Some(evicted) = self.order_loans.pop_front() {
                 self.seen_loans.remove(&evicted);
             }
@@ -138,7 +161,7 @@ impl GossipState {
             return false;
         }
         self.order_reputation.push_back(*key);
-        while self.order_reputation.len() > MAX_GOSSIP_SEEN {
+        while self.order_reputation.len() > self.max_seen {
             if let Some(evicted) = self.order_reputation.pop_front() {
                 self.seen_reputation.remove(&evicted);
             }
@@ -1136,10 +1159,62 @@ mod tests {
         );
     }
 
+    // ----- Phase 25 C4 — per-instance dedup cap -----
+
+    #[test]
+    fn gossip_state_default_capacity_matches_default_const() {
+        let state = GossipState::new();
+        assert_eq!(state.max_seen(), DEFAULT_MAX_GOSSIP_SEEN);
+    }
+
+    #[test]
+    fn gossip_state_custom_capacity_is_honoured() {
+        let state = GossipState::with_capacity(42);
+        assert_eq!(state.max_seen(), 42);
+    }
+
+    #[test]
+    fn gossip_state_zero_capacity_clamped_to_one() {
+        // Operator misconfiguration must not produce a zero-cap
+        // ring that immediately discards everything.
+        let state = GossipState::with_capacity(0);
+        assert_eq!(state.max_seen(), 1);
+    }
+
+    #[test]
+    fn gossip_state_small_capacity_evicts_aggressively() {
+        let mut state = GossipState::with_capacity(3);
+        let mut rng = rand::thread_rng();
+        for i in 0..10 {
+            let pk = SigningKey::generate(&mut rng);
+            let ck = SigningKey::generate(&mut rng);
+            let trade = tirami_ledger::TradeRecord {
+                provider: NodeId(pk.verifying_key().to_bytes()),
+                consumer: NodeId(ck.verifying_key().to_bytes()),
+                trm_amount: i + 1,
+                tokens_processed: 1,
+                timestamp: now_millis(),
+                model_id: "c4-test".to_string(),
+                flops_estimated: 0,
+                nonce: [0u8; 16],
+            };
+            let canonical = trade.canonical_bytes();
+            let signed = SignedTradeRecord {
+                trade,
+                provider_sig: pk.sign(&canonical).to_bytes().to_vec(),
+                consumer_sig: ck.sign(&canonical).to_bytes().to_vec(),
+                attestation: None,
+            };
+            state.mark_seen(&signed);
+        }
+        // After 10 inserts on a 3-slot ring, seen_count is capped.
+        assert!(state.seen_count() <= 3, "got {}", state.seen_count());
+    }
+
     #[test]
     fn gossip_bounded_eviction() {
         let mut state = GossipState::new();
-        // Fill beyond MAX_GOSSIP_SEEN (use a smaller count for test speed)
+        // Fill beyond DEFAULT_MAX_GOSSIP_SEEN (use a smaller count for test speed)
         for i in 0..200 {
             let mut rng = rand::thread_rng();
             let provider_key = SigningKey::generate(&mut rng);

--- a/crates/tirami-node/src/handlers/metrics.rs
+++ b/crates/tirami-node/src/handlers/metrics.rs
@@ -18,6 +18,20 @@ fn metrics_instance() -> &'static TiramiMetrics {
     INSTANCE.get_or_init(TiramiMetrics::new)
 }
 
+/// Phase 25 A6 — process start timestamp, captured once on the
+/// first /metrics scrape. We compute uptime_secs as
+/// (now - process_started_at_secs) so dashboards can plot
+/// node freshness and detect crash-loops.
+fn process_started_at_secs() -> u64 {
+    static STARTED_AT: OnceLock<u64> = OnceLock::new();
+    *STARTED_AT.get_or_init(|| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    })
+}
+
 /// Phase 25 A3 — check whether the presented bearer satisfies the
 /// metrics-protection policy. Returns `Ok(())` when the caller is
 /// allowed to read /metrics, or `Err` with the status/body to send.
@@ -68,9 +82,31 @@ pub(crate) async fn metrics_handler(
     drop(referrals);
     drop(staking);
     drop(ledger);
-    let body = metrics
+    let mut body = metrics
         .encode()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    // Phase 25 A6 — append process-level gauges so dashboards can
+    // plot node freshness without a sidecar exporter. Operators
+    // tracking node fleet health graph `tirami_process_uptime_secs`
+    // and alert on a regression toward 0 (crash-loop signature).
+    let started_at = process_started_at_secs();
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let uptime_secs = now_secs.saturating_sub(started_at);
+    body.push_str("# HELP tirami_process_started_at_secs Unix epoch when this process began serving /metrics\n");
+    body.push_str("# TYPE tirami_process_started_at_secs gauge\n");
+    body.push_str(&format!("tirami_process_started_at_secs {started_at}\n"));
+    body.push_str("# HELP tirami_process_uptime_secs Seconds since this process began serving /metrics\n");
+    body.push_str("# TYPE tirami_process_uptime_secs gauge\n");
+    body.push_str(&format!("tirami_process_uptime_secs {uptime_secs}\n"));
+    body.push_str("# HELP tirami_protocol_version Wire protocol version this binary advertises\n");
+    body.push_str("# TYPE tirami_protocol_version gauge\n");
+    body.push_str(&format!(
+        "tirami_protocol_version {}\n",
+        tirami_core::TIRAMI_PROTOCOL_VERSION,
+    ));
     Ok((
         [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
         body,
@@ -201,6 +237,39 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn metrics_carries_phase_25_a6_process_gauges() {
+        // Process gauges: uptime + started_at + protocol_version.
+        // Operators graph these to detect crash-loops and version
+        // skew across a fleet.
+        let app = test_router_default(Config::default());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8_lossy(&body);
+        for expected in [
+            "tirami_process_started_at_secs",
+            "tirami_process_uptime_secs",
+            "tirami_protocol_version",
+        ] {
+            assert!(
+                text.contains(expected),
+                "missing {expected} in /metrics output",
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -156,6 +156,9 @@ impl TiramiNode {
         let initial_proof_policy = tirami_ledger::zk::ProofPolicy::parse(&config.proof_policy)
             .unwrap_or(tirami_ledger::zk::ProofPolicy::Disabled);
         let current_proof_policy = Arc::new(tokio::sync::RwLock::new(initial_proof_policy));
+        // Phase 25 C4 — read gossip_max_seen BEFORE moving `config`
+        // into `self`.
+        let gossip_max_seen = config.gossip_max_seen;
 
         Self {
             config,
@@ -165,7 +168,9 @@ impl TiramiNode {
             advertised_topology: Arc::new(Mutex::new(None)),
             transport: None,
             cluster: None,
-            gossip: Arc::new(Mutex::new(GossipState::new())),
+            gossip: Arc::new(Mutex::new(tirami_net::GossipState::with_capacity(
+                gossip_max_seen,
+            ))),
             bank: Arc::new(Mutex::new(bank)),
             marketplace: Arc::new(Mutex::new(marketplace)),
             mind_agent: Arc::new(Mutex::new(mind_agent)),


### PR DESCRIPTION
A6 process gauges (started_at, uptime, protocol_version) + C4 configurable gossip dedup capacity. Tests +5, workspace 1,504.