### PR TITLE
feat(phase-25/b): risc0 guest crate skeleton (closes #130)

### DIFF
--- a/crates/tirami-zkml-bench-guest/Cargo.toml
+++ b/crates/tirami-zkml-bench-guest/Cargo.toml
@@ -1,0 +1,41 @@
+# Phase 25 B / Wave 5.2.1 — risc0 guest program skeleton.
+#
+# This crate is INTENTIONALLY NOT in the workspace `members =` list:
+# it targets `riscv32im-risc0-zkvm-elf` and is built by
+# `cargo-risczero` separately from the host workspace. Adding it to
+# the host workspace would break `cargo build` on dev machines
+# without the Risc-V toolchain.
+#
+# Build (operator-side):
+#
+#   1. `cargo install cargo-risczero`
+#   2. `rzup install`
+#   3. `cd crates/tirami-zkml-bench-guest && cargo risczero build`
+#
+# The produced ELF + image ID drop into
+# `target/riscv-guest/riscv32im-risc0-zkvm-elf/release/bench-commit`.
+# Host-side wiring (Wave 5.2.2+) will `include_bytes!` that path.
+
+[package]
+name = "tirami-zkml-bench-guest"
+version = "0.1.0"
+edition = "2024"
+
+# Skeleton: when cargo-risczero is installed and the toolchain is
+# bootstrapped, uncomment the dependency below. Until then the
+# `[[bin]]` target compiles as a host-side stub that prints what
+# the guest WOULD do — handy for protocol-level tests that don't
+# need a real receipt.
+#
+# [dependencies]
+# risc0-zkvm = { version = "1.2", default-features = false, features = ["std"] }
+
+[[bin]]
+name = "bench-commit"
+path = "src/main.rs"
+
+[profile.release]
+opt-level = 3
+codegen-units = 1
+lto = true
+debug = false

--- a/crates/tirami-zkml-bench-guest/README.md
+++ b/crates/tirami-zkml-bench-guest/README.md
@@ -1,0 +1,84 @@
+# tirami-zkml-bench-guest
+
+Phase 25 B / Wave 5.2.1 — risc0 guest program for the `Risc0HostBackend`
+verifier wired in Phase 24 Wave 5.2 (PR #115).
+
+## Status
+
+This crate ships as a **skeleton**. Until the operator runs
+`cargo-risczero build`, this code compiles as a host-side stub that
+prints "real ELF not built" rather than emitting a real Risc-V binary.
+
+The skeleton is intentionally separate from the host workspace
+(`crates/tirami-zkml-bench-guest` is NOT in the root `members =`) so
+contributors without the Risc-V toolchain can still build the
+host workspace.
+
+## What it commits to (when built as a guest)
+
+The guest reads five public inputs from the host's `ExecutorEnv`:
+
+- `model_hash: [u8; 32]`
+- `prompt_hash: [u8; 32]`
+- `output_hash: [u8; 32]`
+- `token_count: u64`
+- `flops: u64`
+
+It writes a single 32-byte commitment to the public journal:
+
+```
+commit = SHA-256( "tirami-risc0-commit-v1"
+                 || model_hash
+                 || prompt_hash
+                 || output_hash
+                 || token_count.to_le_bytes()
+                 || flops.to_le_bytes() )
+```
+
+The host verifier (`tirami_zkml_bench::risc0_host::Risc0HostBackend::verify`)
+re-derives the same commitment via `expected_journal_commit(&BenchSpec)`
+and rejects any receipt whose journal disagrees. The cryptographic
+STARK verification is performed by the host-side `risc0-zkvm` crate
+(v1.2.x — wired in PR #115).
+
+## Build (operator-side)
+
+```bash
+cargo install cargo-risczero
+rzup install
+cd crates/tirami-zkml-bench-guest
+cargo risczero build
+# → target/riscv-guest/riscv32im-risc0-zkvm-elf/release/bench-commit
+```
+
+## What this PR does NOT do
+
+- **Embed the ELF into the host crate.** Wave 5.2.2 (next bounded
+  PR) `include_bytes!` the operator-built ELF + image ID into
+  `tirami-zkml-bench` under a new `risc0-host-prove` feature. Until
+  that lands, `Risc0HostBackend::prove` still returns
+  `BackendUnavailable("guest ELF required")`.
+- **Add the guest crate to CI.** The Risc-V toolchain prebuild is
+  multi-GB and would dominate CI time; operators who care about
+  proving locally bootstrap the toolchain themselves following the
+  steps above.
+
+## Why the guest source is commented-out today
+
+`risc0_zkvm::guest::env` and `risc0_zkvm::entry!` macros are only
+defined when the `risc0-zkvm` crate is compiled for the
+`riscv32im-risc0-zkvm-elf` target. Importing them under the host
+target would fail at link time. Keeping the guest body as comments
++ a host-stub `main()` lets:
+
+1. `cargo build` in this crate succeed on developer machines.
+2. The full guest source still live next to the host code, so
+   readers learn the protocol contract by reading the file.
+3. Wave 5.2.2 swap-in is a literal "uncomment + delete stub" diff.
+
+## Issue references
+
+- Wave 5.2 (host-side verifier): PR #115
+- Wave 5 design doc: `docs/phase-24-wave-5-zk-backends.md`
+- This skeleton: closes #130 (the guest binary path is unblocked;
+  the actual ELF build is the operator's problem until 5.2.2).

--- a/crates/tirami-zkml-bench-guest/src/main.rs
+++ b/crates/tirami-zkml-bench-guest/src/main.rs
@@ -1,0 +1,50 @@
+//! Phase 25 B / Wave 5.2.1 — guest program skeleton.
+//!
+//! When built with `cargo risczero build`, this becomes the
+//! `bench-commit` ELF that `Risc0HostBackend::prove` (host side)
+//! drives via `risc0_zkvm::default_prover`. The skeleton commits
+//! to the canonical `BenchSpec` SHA-256 so the host can
+//! cross-check the receipt's journal against
+//! `tirami_zkml_bench::risc0_host::expected_journal_commit`.
+//!
+//! See `docs/phase-24-wave-5-zk-backends.md` for the full plan.
+
+// When `risc0-zkvm` is uncommented in Cargo.toml, this `#![no_main]`
+// attribute together with `risc0_zkvm::entry!(main)` makes the
+// crate a guest ELF instead of a host binary. We keep the
+// host-stub form here (a plain `fn main()`) so contributors who
+// haven't installed cargo-risczero can still `cargo build` the
+// crate locally and reason about the surface area.
+
+fn main() {
+    // ---- Guest version (build under cargo-risczero) ----
+    //
+    // #![no_main]
+    // risc0_zkvm::entry!(main);
+    // use risc0_zkvm::guest::env;
+    // use sha2::{Digest, Sha256};
+    //
+    // let model_hash: [u8; 32] = env::read();
+    // let prompt_hash: [u8; 32] = env::read();
+    // let output_hash: [u8; 32] = env::read();
+    // let token_count: u64 = env::read();
+    // let flops: u64 = env::read();
+    //
+    // let mut h = Sha256::new();
+    // h.update(b"tirami-risc0-commit-v1");
+    // h.update(model_hash);
+    // h.update(prompt_hash);
+    // h.update(output_hash);
+    // h.update(token_count.to_le_bytes());
+    // h.update(flops.to_le_bytes());
+    // let commit: [u8; 32] = h.finalize().into();
+    //
+    // env::commit(&commit);
+    //
+    // ---- Host-stub form (this file as currently shipped) ----
+    eprintln!(
+        "tirami-zkml-bench-guest: host-stub build. Run \
+         `cargo risczero build` to produce the real guest ELF; \
+         see docs/phase-24-wave-5-zk-backends.md."
+    );
+}


### PR DESCRIPTION
Guest crate skeleton (separate from workspace) shipping the source + commented-out guest body + operator README. The actual ELF build is operator-side; ELF embedding into the host crate is Wave 5.2.2. Closes #130.