### PR TITLE
fix(#143): worker drives PriceSignal broadcast — auto-discovery completes

### DIFF
--- a/crates/tirami-cli/src/main.rs
+++ b/crates/tirami-cli/src/main.rs
@@ -728,6 +728,12 @@ async fn main() -> anyhow::Result<()> {
 
             if daemon {
                 tracing::info!("Worker running in daemon mode (Ctrl-C to stop)");
+                // Issue #143 — worker also self-registers + drives
+                // the 30 s PriceSignal broadcast loop so seeds (and
+                // other workers) populate this worker in their
+                // peer_registry, and vice versa.
+                node.self_register_price_signal().await;
+                node.spawn_price_signal_loop(transport.clone());
                 // Issue #88 — worker daemon mode previously parked
                 // forever without consuming transport.recv(), so
                 // gossip messages (TradeGossip, PriceSignalMsg,

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -623,7 +623,10 @@ impl TiramiNode {
 
     /// Immediately register our own PriceSignal into the PeerRegistry so
     /// select_provider (Phase 14.2) can find us before the first gossip tick.
-    async fn self_register_price_signal(&self) {
+    /// Phase 25 #143 — exposed so worker mode can self-register
+    /// alongside the seed. Without this, workers never appear in
+    /// any peer's PriceSignal-driven peer_registry.
+    pub async fn self_register_price_signal(&self) {
         let Some(transport) = self.transport.as_ref() else {
             return;
         };
@@ -986,7 +989,10 @@ impl TiramiNode {
         });
     }
 
-    fn spawn_price_signal_loop(&self, transport: Arc<ForgeTransport>) {
+    /// Phase 25 #143 — exposed so worker mode can drive the
+    /// 30 s broadcast loop too. Two-way PriceSignal gossip means
+    /// every node's peer_registry reflects every other node.
+    pub fn spawn_price_signal_loop(&self, transport: Arc<ForgeTransport>) {
         let ledger = self.ledger.clone();
         let gossip = self.gossip.clone();
         let model_manifest = self.model_manifest.clone();


### PR DESCRIPTION
Workers now self-register + run the 30s PriceSignal broadcast loop, so seeds populate worker entries in their peer_registry and vice versa. Live verified: worker /v1/tirami/peers 0→1, seed /v1/tirami/peers 1→2. Closes #143.