### PR TITLE
feat(phase-25): persistent Ed25519 wallet keeps node identity stable

### DIFF
--- a/crates/tirami-cli/src/main.rs
+++ b/crates/tirami-cli/src/main.rs
@@ -386,6 +386,17 @@ enum WalletAction {
         /// BOLT11 invoice string
         invoice: String,
     },
+    /// Show the persistent Ed25519 node identity ("wallet" in the
+    /// Bitcoin sense: the long-lived key whose public component is
+    /// this node's NodeId). Reads the key file at `--key-path` (or
+    /// the config default), auto-creating it with mode 0600 on first
+    /// run. Prints the public NodeId only — the secret seed is never
+    /// displayed.
+    Identity {
+        /// Path to the wallet key file. Defaults to `~/.tirami/node.key`.
+        #[arg(long)]
+        key_path: Option<std::path::PathBuf>,
+    },
 }
 
 /// Default tracing filter when `RUST_LOG` is unset.
@@ -435,6 +446,43 @@ async fn main() -> anyhow::Result<()> {
             tirami_infer::model_registry::list_models();
         }
         Commands::Wallet { action } => {
+            // Phase 25 #161 — Identity action is purely read-only on
+            // the node-key file. Handle it before bringing up the
+            // Lightning wallet (which opens disk + network resources)
+            // so `tirami wallet identity` stays fast and side-effect-free.
+            if let WalletAction::Identity { key_path } = action {
+                let path = match key_path {
+                    Some(p) => p,
+                    None => default_node_key_path()?,
+                };
+                let (wallet, created) = tirami_node::wallet::WalletKey::load_or_create(&path)
+                    .map_err(|e| {
+                        anyhow::anyhow!("failed to open wallet at {}: {e}", path.display())
+                    })?;
+                println!("Wallet file:        {}", path.display());
+                println!(
+                    "Status:             {}",
+                    if created {
+                        "created (fresh keypair generated)"
+                    } else {
+                        "loaded"
+                    }
+                );
+                println!(
+                    "Node ID (Ed25519):  {}",
+                    hex::encode(wallet.verifying_key_bytes())
+                );
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if let Ok(meta) = std::fs::metadata(&path) {
+                        let mode = meta.permissions().mode() & 0o777;
+                        println!("File permissions:   {:o}", mode);
+                    }
+                }
+                return Ok(());
+            }
+
             let config = tirami_lightning::node::WalletConfig::default();
             let wallet = tirami_lightning::ForgeWallet::start(config)?;
 
@@ -464,6 +512,7 @@ async fn main() -> anyhow::Result<()> {
                     let payment_id = wallet.pay_invoice(&invoice)?;
                     println!("Payment sent: {}", payment_id);
                 }
+                WalletAction::Identity { .. } => unreachable!("handled above"),
             }
         }
         Commands::Chat {
@@ -1541,6 +1590,14 @@ fn ensure_default_data_dir() -> anyhow::Result<PathBuf> {
         std::fs::create_dir_all(&tirami_dir)?;
     }
     Ok(tirami_dir)
+}
+
+/// Default location for the persistent Ed25519 wallet file
+/// (`~/.tirami/node.key`). The parent directory is created on demand
+/// by `WalletKey::load_or_create`, so this helper only resolves the
+/// path — it does not touch the filesystem.
+fn default_node_key_path() -> anyhow::Result<PathBuf> {
+    Ok(default_data_dir()?.join("node.key"))
 }
 
 fn ensure_default_node_key() -> anyhow::Result<PathBuf> {

--- a/crates/tirami-node/src/api.rs
+++ b/crates/tirami-node/src/api.rs
@@ -109,6 +109,15 @@ pub(crate) struct AppState {
     /// in-flight `/v1/chat/completions` requests. `None` when
     /// `config.chat_concurrency_cap == 0` (legacy behaviour).
     pub chat_concurrency: Option<Arc<tokio::sync::Semaphore>>,
+    /// Phase 25 #161 — persistent Ed25519 wallet for this node.
+    /// Same seed underlies the iroh QUIC keypair and HTTP-layer
+    /// signing. `None` when the API was built via `create_router`
+    /// (legacy/test path); production callers go through
+    /// `create_router_with_services` and TiramiNode supplies a real
+    /// wallet. Handlers like `/v1/tirami/borrow` and
+    /// `/v1/tirami/lend-to` sign with this wallet when present so
+    /// the loan record binds to the actual node identity.
+    pub wallet: Option<Arc<crate::wallet::WalletKey>>,
 }
 
 /// Simple rate limiter for authentication failures.
@@ -218,6 +227,10 @@ pub fn create_router(
         Arc::new(Mutex::new(None)),
         // Phase 24 Wave 4.5 — runtime policy handle, computed above.
         proof_policy_handle,
+        // Phase 25 #161 — `create_router` is the legacy test/stub
+        // entrypoint; no wallet plumbed in. HTTP signing handlers fall
+        // back to ephemeral keys when this is None.
+        None,
     )
 }
 
@@ -254,6 +267,10 @@ pub fn create_router_with_services(
     // `POST /v1/tirami/governance/execute/:id` is immediately
     // visible to the pipeline.
     current_proof_policy: Arc<tokio::sync::RwLock<tirami_ledger::zk::ProofPolicy>>,
+    // Phase 25 #161 — persistent Ed25519 wallet. Populated by
+    // `TiramiNode::init_transport`. `None` when the API runs in a
+    // test fixture that did not stand up a transport.
+    wallet: Option<Arc<crate::wallet::WalletKey>>,
 ) -> Router {
     // Derive local node ID from cluster or generate a deterministic one.
     let local_node_id = cluster
@@ -311,6 +328,7 @@ pub fn create_router_with_services(
                 Some(Arc::new(tokio::sync::Semaphore::new(cap as usize)))
             }
         },
+        wallet,
     };
     let api_max_request_body_bytes = state.config.api_max_request_body_bytes;
 
@@ -3310,10 +3328,20 @@ async fn forge_lend_to(
         })?;
     let borrower = NodeId(borrower_bytes);
 
-    // MVP: generate ephemeral lender key (same caveat as forge_borrow).
-    // TODO: use node's persistent signing key from state.
-    let lender_key = SigningKey::generate(&mut OsRng);
-    let lender_id = NodeId(lender_key.verifying_key().to_bytes());
+    // Lender side: prefer the persistent wallet (real node identity)
+    // so the lend operation accrues to *this* node's lending history.
+    // Falls back to a fresh ephemeral key when no wallet is wired in
+    // (legacy test fixtures).
+    let (lender_id, lender_key): (NodeId, SigningKey) = match state.wallet.as_ref() {
+        Some(w) => (
+            NodeId(w.verifying_key_bytes()),
+            SigningKey::from_bytes(w.seed()),
+        ),
+        None => {
+            let ek = SigningKey::generate(&mut OsRng);
+            (NodeId(ek.verifying_key().to_bytes()), ek)
+        }
+    };
 
     // Compute borrower's credit score for rate determination.
     let ledger = state.ledger.lock().await;
@@ -3411,10 +3439,14 @@ async fn forge_lend_to(
 
 /// POST /v1/tirami/borrow — request a CU loan.
 ///
-/// MVP: constructs a self-signed loan against a fresh keypair so the
-/// dual-signature verification path inside `create_loan` succeeds. This is
-/// only meaningful inside a single-node test fixture; the production path
-/// is the gossiped LoanProposal/LoanAccept handshake (Batch B2).
+/// The borrower is the caller node itself (signed with `state.wallet`
+/// when present, so the loan binds to the real persistent NodeId and
+/// affects this node's credit + effective balance). The lender side
+/// is an ephemeral one-shot pool key — a placeholder until the full
+/// P2P LoanProposal/LoanAccept handshake (Batch B2) wires in a real
+/// counterparty. When no wallet is configured (test fixtures, legacy
+/// `create_router`), both sides fall back to ephemeral keys so the
+/// bilateral-signature check still passes.
 async fn forge_borrow(
     State(state): State<AppState>,
     Json(req): Json<BorrowRequest>,
@@ -3437,16 +3469,30 @@ async fn forge_borrow(
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0);
 
-    // MVP: one-shot signing key acting as both lender and borrower so the
-    // bilateral signature check inside `create_loan` is satisfied without
-    // requiring the persistent node key (which lives in forge-net).
-    let signing_key = SigningKey::generate(&mut OsRng);
-    let signed_node_id = NodeId(signing_key.verifying_key().to_bytes());
+    // Ephemeral one-shot "pool" key for the lender side — same MVP
+    // placeholder as before. Replace with a real counterparty when the
+    // P2P LoanProposal/LoanAccept handshake ships.
+    let pool_key = SigningKey::generate(&mut OsRng);
+    let pool_id = NodeId(pool_key.verifying_key().to_bytes());
+
+    // Borrower side: prefer the persistent wallet (real node identity)
+    // so the loan accrues to this node. Fall back to a fresh ephemeral
+    // key when no wallet is wired in (legacy test fixtures).
+    let (borrower_id, borrower_signer): (NodeId, SigningKey) = match state.wallet.as_ref() {
+        Some(w) => (
+            NodeId(w.verifying_key_bytes()),
+            SigningKey::from_bytes(w.seed()),
+        ),
+        None => {
+            let ek = SigningKey::generate(&mut OsRng);
+            (NodeId(ek.verifying_key().to_bytes()), ek)
+        }
+    };
 
     let mut loan = LoanRecord {
         loan_id: [0u8; 32],
-        lender: signed_node_id.clone(),
-        borrower: signed_node_id,
+        lender: pool_id,
+        borrower: borrower_id,
         principal_trm: req.amount,
         interest_rate_per_hour: interest_rate,
         term_hours: req.term_hours,
@@ -3459,11 +3505,12 @@ async fn forge_borrow(
     loan.loan_id = loan.compute_loan_id();
 
     let canonical = loan.canonical_bytes();
-    let sig = signing_key.sign(&canonical).to_bytes().to_vec();
+    let lender_sig = pool_key.sign(&canonical).to_bytes().to_vec();
+    let borrower_sig = borrower_signer.sign(&canonical).to_bytes().to_vec();
     let signed = SignedLoanRecord {
         loan: loan.clone(),
-        lender_sig: sig.clone(),
-        borrower_sig: sig,
+        lender_sig,
+        borrower_sig,
     };
 
     ledger
@@ -4760,6 +4807,9 @@ pub(crate) fn test_router_default(config: Config) -> Router {
         Arc::new(Mutex::new(None)),
         // Phase 24 Wave 4.5 — runtime policy handle.
         policy_handle,
+        // Phase 25 #161 — test helper omits the persistent wallet;
+        // HTTP signing handlers fall back to ephemeral keys.
+        None,
     )
 }
 
@@ -4894,6 +4944,7 @@ mod tests {
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             Arc::new(Mutex::new(None)),
             proof_policy_handle,
+            None,
         );
         let _ = TokenStore::new(); // unused
         // Hold the ledger lock for the duration of the probe.
@@ -6050,6 +6101,7 @@ mod tests {
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             Arc::new(Mutex::new(None)),
             Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
+            None,
         )
     }
 
@@ -8367,6 +8419,7 @@ mod tests {
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             shared.clone(), // ← the Arc we will observe externally
             Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
+            None,
         );
 
         // Externally observed slot is empty before init.
@@ -8417,6 +8470,7 @@ mod tests {
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             shared.clone(),
             Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
+            None,
         );
         // First identity via init.
         let (_, init_a) = post_identity_init(app_a.clone(), None).await;
@@ -8447,6 +8501,7 @@ mod tests {
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             shared_b.clone(),
             Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
+            None,
         );
         let (_status, _view) =
             post_identity_import(app_b, "passphrase-1234567", bundle).await;

--- a/crates/tirami-node/src/lib.rs
+++ b/crates/tirami-node/src/lib.rs
@@ -11,6 +11,7 @@ pub mod pipeline;
 pub mod security_tests;
 pub mod state_persist;
 pub mod topology;
+pub mod wallet;
 
 pub use node::TiramiNode;
 pub use pipeline::{PipelineCoordinator, PipelineRole};

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -2,7 +2,7 @@ use crate::agent_loop::{AgentLoopStats, AgentTickInput, spawn_agent_tick_loop};
 use crate::pipeline::PipelineCoordinator;
 use crate::state_persist;
 use crate::topology::{TopologySnapshot, build_local_capability, build_topology_snapshot};
-use std::path::Path;
+use crate::wallet::WalletKey;
 use std::sync::Arc;
 use tirami_agora::Marketplace;
 use tirami_core::Config;
@@ -66,6 +66,13 @@ pub struct TiramiNode {
     /// pipeline reads it at trade-execute time so the gate honours
     /// the latest governance decision.
     pub current_proof_policy: Arc<tokio::sync::RwLock<tirami_ledger::zk::ProofPolicy>>,
+    /// Phase 25 #161 — persistent Ed25519 wallet. Same 32-byte seed
+    /// underlies the iroh QUIC keypair AND HTTP-layer trade/loan
+    /// signing. Populated by `init_transport` (loaded from
+    /// `config.node_key_path` or generated in-memory). Threaded onto
+    /// `AppState` so handlers like `/v1/tirami/borrow` sign as the
+    /// real node identity instead of one-shot ephemeral keys.
+    pub wallet: Option<Arc<WalletKey>>,
     heartbeat_started: bool,
 }
 
@@ -190,6 +197,7 @@ impl TiramiNode {
             // out-of-the-box default.
             agent_identity: Arc::new(Mutex::new(agent_identity)),
             current_proof_policy,
+            wallet: None,
             heartbeat_started: false,
         }
     }
@@ -251,6 +259,9 @@ impl TiramiNode {
             // Phase 24 Wave 4.5 — share the same proof-policy Arc
             // so HTTP `governance/execute/:id` reaches the pipeline.
             self.current_proof_policy.clone(),
+            // Phase 25 #161 — share the persistent wallet so HTTP
+            // handlers can sign as this node.
+            self.wallet.clone(),
         );
         let addr = self.config.api_socket_addr();
         tracing::info!("API server listening on {}", addr);
@@ -286,6 +297,7 @@ impl TiramiNode {
         let agent_loop_stats_api = self.agent_loop_stats.clone();
         let agent_identity_api = self.agent_identity.clone();
         let current_proof_policy_api = self.current_proof_policy.clone();
+        let wallet_api = self.wallet.clone();
         let api_config = self.config.clone();
         tokio::spawn(async move {
             let app = crate::api::create_router_with_services(
@@ -310,6 +322,8 @@ impl TiramiNode {
                 agent_identity_api,
                 // Phase 24 Wave 4.5 — shared ProofPolicy handle.
                 current_proof_policy_api,
+                // Phase 25 #161 — shared persistent wallet.
+                wallet_api,
             );
             let addr = api_config.api_socket_addr();
             if let Ok(listener) = tokio::net::TcpListener::bind(&addr).await {
@@ -420,38 +434,61 @@ impl TiramiNode {
             })
             .transpose()?;
 
-        let transport = match (self.config.node_key_path.as_ref(), p2p_bind_addr) {
-            (Some(path), Some(bind_addr)) => {
-                let secret_key = load_node_secret_key(path)?;
-                tracing::info!("Loaded persistent node key from {}", path.display());
-                ForgeTransport::new_with_max_connections_secret_key_and_bind_addr(
-                    max_connections,
-                    secret_key,
-                    bind_addr,
-                )
-                .await
+        // Phase 25 #161 — single 32-byte Ed25519 seed underlies both the
+        // iroh QUIC keypair AND HTTP-layer trade/loan signing. Load the
+        // wallet first; auto-create with mode 0600 on first run if a
+        // `node_key_path` is configured. Falls back to an in-memory
+        // wallet when no path is set so the HTTP layer can still sign
+        // (with the same caveat as the old "ephemeral identity" warning:
+        // the NodeId rotates on every restart).
+        let wallet = match self.config.node_key_path.as_ref() {
+            Some(path) => {
+                let (w, created) = WalletKey::load_or_create(path).map_err(|e| {
+                    tirami_core::TiramiError::InvalidRequest(format!(
+                        "wallet load_or_create({}): {e}",
+                        path.display()
+                    ))
+                })?;
+                if created {
+                    tracing::info!(
+                        "Generated fresh wallet at {} (node id: {})",
+                        path.display(),
+                        hex::encode(w.verifying_key_bytes())
+                    );
+                } else {
+                    tracing::info!(
+                        "Loaded wallet from {} (node id: {})",
+                        path.display(),
+                        hex::encode(w.verifying_key_bytes())
+                    );
+                }
+                w
             }
-            (Some(path), None) => {
-                let secret_key = load_node_secret_key(path)?;
-                tracing::info!("Loaded persistent node key from {}", path.display());
+            None => {
+                let w = WalletKey::generate();
+                tracing::warn!(
+                    "No node_key_path configured; generated ephemeral wallet for this process \
+                     (node id: {})",
+                    hex::encode(w.verifying_key_bytes())
+                );
+                w
+            }
+        };
+        let secret_key = iroh::SecretKey::from_bytes(wallet.seed());
+        let transport = match p2p_bind_addr {
+            Some(bind_addr) => ForgeTransport::new_with_max_connections_secret_key_and_bind_addr(
+                max_connections,
+                secret_key,
+                bind_addr,
+            )
+            .await,
+            None => {
                 ForgeTransport::new_with_max_connections_and_secret_key(max_connections, secret_key)
                     .await
             }
-            (None, Some(bind_addr)) => {
-                tracing::warn!(
-                    "No node_key_path configured; using ephemeral P2P identity for this process"
-                );
-                ForgeTransport::new_with_max_connections_and_bind_addr(max_connections, bind_addr)
-                    .await
-            }
-            (None, None) => {
-                tracing::warn!(
-                    "No node_key_path configured; using ephemeral P2P identity for this process"
-                );
-                ForgeTransport::new_with_max_connections(max_connections).await
-            }
         }
         .map_err(|e| tirami_core::TiramiError::NetworkError(format!("transport: {e}")))?;
+        self.wallet = Some(Arc::new(wallet));
         let transport = Arc::new(transport);
         let local_capability = build_local_capability(&self.config, transport.tirami_node_id());
         self.cluster = Some(Arc::new(ClusterManager::new(
@@ -1324,39 +1361,6 @@ fn load_persisted_agent_identity(
     }
 }
 
-fn load_node_secret_key(path: &Path) -> Result<iroh::SecretKey, tirami_core::TiramiError> {
-    let bytes = std::fs::read(path)?;
-    let raw = parse_node_secret_key_bytes(&bytes).map_err(|reason| {
-        tirami_core::TiramiError::InvalidRequest(format!(
-            "invalid node key file {}: {reason}",
-            path.display()
-        ))
-    })?;
-    Ok(iroh::SecretKey::from_bytes(&raw))
-}
-
-fn parse_node_secret_key_bytes(bytes: &[u8]) -> Result<[u8; 32], &'static str> {
-    if bytes.len() == 32 {
-        let mut raw = [0u8; 32];
-        raw.copy_from_slice(bytes);
-        return Ok(raw);
-    }
-
-    let Ok(text) = std::str::from_utf8(bytes) else {
-        return Err("expected 32 raw bytes or 64 lowercase/uppercase hex characters");
-    };
-    let text = text.trim();
-    if text.len() != 64 || !text.as_bytes().iter().all(u8::is_ascii_hexdigit) {
-        return Err("expected 32 raw bytes or 64 lowercase/uppercase hex characters");
-    }
-
-    let decoded =
-        hex::decode(text).map_err(|_| "expected valid hex-encoded Ed25519 secret bytes")?;
-    let mut raw = [0u8; 32];
-    raw.copy_from_slice(&decoded);
-    Ok(raw)
-}
-
 pub(crate) fn parse_bootstrap_peer_spec(spec: &str) -> Result<iroh::EndpointAddr, String> {
     let spec = spec.trim();
     if spec.is_empty() {
@@ -1529,27 +1533,6 @@ mod tests {
         let url = super::derive_public_http_endpoint("2001:db8::1", 3000)
             .expect("v6 public bind should advertise");
         assert_eq!(url, "http://[2001:db8::1]:3000");
-    }
-
-    #[test]
-    fn parse_node_secret_key_accepts_raw_32_bytes() {
-        let bytes = [7u8; 32];
-        assert_eq!(parse_node_secret_key_bytes(&bytes).unwrap(), bytes);
-    }
-
-    #[test]
-    fn parse_node_secret_key_accepts_hex_with_newline() {
-        let parsed = parse_node_secret_key_bytes(
-            b"0707070707070707070707070707070707070707070707070707070707070707\n",
-        )
-        .unwrap();
-        assert_eq!(parsed, [7u8; 32]);
-    }
-
-    #[test]
-    fn parse_node_secret_key_rejects_wrong_length() {
-        let err = parse_node_secret_key_bytes(b"too-short").unwrap_err();
-        assert!(err.contains("expected 32 raw bytes"));
     }
 
     #[test]

--- a/crates/tirami-node/src/security_tests.rs
+++ b/crates/tirami-node/src/security_tests.rs
@@ -711,6 +711,7 @@ mod security_tests {
             Arc::new(Mutex::new(crate::agent_loop::AgentLoopStats::new())),
             Arc::new(Mutex::new(None)),
             Arc::new(tokio::sync::RwLock::new(tirami_ledger::zk::ProofPolicy::Disabled)),
+            None,
         );
         let _ = state; // suppress unused warning
 

--- a/crates/tirami-node/src/wallet.rs
+++ b/crates/tirami-node/src/wallet.rs
@@ -1,0 +1,302 @@
+//! Node wallet — persistent Ed25519 key store for trade & loan signing.
+//!
+//! # Why a wallet abstraction
+//!
+//! A Tirami node has a single 32-byte Ed25519 seed that underlies both
+//! the iroh QUIC keypair (transport identity) and the trade/loan
+//! signing key. Treating that seed as a *wallet* — same model Bitcoin
+//! Core / OpenSSH use — gives us:
+//!
+//! * **Stable identity across restarts.** Same seed → same public
+//!   `NodeId` → reputation and lending history survive process bounces.
+//! * **Auto-bootstrap on first run.** If the configured `node_key_path`
+//!   is missing, we generate a fresh seed, write it atomically with
+//!   `0600` permissions, and log the new public NodeId so the operator
+//!   knows their "address". Matches `wallet.dat` / `id_ed25519` UX.
+//! * **HTTP-layer signing.** The wallet `SigningKey` is plumbed onto
+//!   `AppState`, so HTTP handlers like `/v1/tirami/borrow` sign loans
+//!   as the *real* node identity instead of one-shot ephemeral keys.
+//!
+//! # File format
+//!
+//! Either 32 raw bytes OR 64 ASCII hex characters (optionally with a
+//! trailing newline). Same format the legacy `load_node_secret_key`
+//! has accepted; the wallet loader is a strict superset.
+//!
+//! # File permissions
+//!
+//! On unix, fresh wallets are written with mode `0600`. Existing files
+//! with world- or group-readable bits trigger a runtime warning so the
+//! operator can `chmod 600` them.
+
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use rand::RngCore;
+use rand::rngs::OsRng;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+/// 32-byte Ed25519 seed wrapped with derived signing/verifying keys.
+///
+/// Cheap to clone — the seed and `SigningKey` are both `Copy`-sized.
+#[derive(Clone)]
+pub struct WalletKey {
+    seed: [u8; 32],
+    signing: SigningKey,
+}
+
+impl WalletKey {
+    /// Build a wallet from a raw 32-byte Ed25519 seed.
+    pub fn from_seed(seed: [u8; 32]) -> Self {
+        let signing = SigningKey::from_bytes(&seed);
+        Self { seed, signing }
+    }
+
+    /// Generate a fresh wallet from OS randomness. Used by
+    /// `load_or_create` when the file is missing.
+    pub fn generate() -> Self {
+        let mut seed = [0u8; 32];
+        OsRng.fill_bytes(&mut seed);
+        Self::from_seed(seed)
+    }
+
+    /// Raw seed bytes. Callers that need them (e.g. to construct an
+    /// `iroh::SecretKey` from the same material) hold this read-only.
+    pub fn seed(&self) -> &[u8; 32] {
+        &self.seed
+    }
+
+    /// Borrow the underlying Ed25519 signing key. The wallet retains
+    /// ownership so the key never outlives the wallet handle.
+    pub fn signing_key(&self) -> &SigningKey {
+        &self.signing
+    }
+
+    /// Derive the Ed25519 verifying key (public component).
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.signing.verifying_key()
+    }
+
+    /// 32 bytes of the public verifying key. Equivalent to the wire
+    /// `NodeId` for this wallet.
+    pub fn verifying_key_bytes(&self) -> [u8; 32] {
+        self.verifying_key().to_bytes()
+    }
+
+    /// Load a wallet from `path`. If the file does not exist, generate
+    /// a fresh wallet and atomically write it with mode `0600`.
+    /// Returns `(wallet, was_created)` so callers can log distinctly
+    /// for first-run bootstrap vs. ordinary restart.
+    pub fn load_or_create(path: &Path) -> io::Result<(Self, bool)> {
+        match fs::read(path) {
+            Ok(bytes) => {
+                let seed = parse_seed_bytes(&bytes).map_err(|reason| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("invalid wallet file {}: {reason}", path.display()),
+                    )
+                })?;
+                warn_if_world_readable(path);
+                Ok((Self::from_seed(seed), false))
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                let wallet = Self::generate();
+                if let Some(parent) = path.parent() {
+                    if !parent.as_os_str().is_empty() {
+                        fs::create_dir_all(parent)?;
+                    }
+                }
+                write_seed_atomic(path, &wallet.seed)?;
+                Ok((wallet, true))
+            }
+            Err(err) => Err(err),
+        }
+    }
+}
+
+impl std::fmt::Debug for WalletKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WalletKey")
+            .field("verifying_key_hex", &hex::encode(self.verifying_key_bytes()))
+            .field("seed", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Parse either 32 raw bytes or 64 ASCII hex chars (optionally with
+/// trailing whitespace / newline).
+pub(crate) fn parse_seed_bytes(bytes: &[u8]) -> Result<[u8; 32], &'static str> {
+    if bytes.len() == 32 {
+        let mut raw = [0u8; 32];
+        raw.copy_from_slice(bytes);
+        return Ok(raw);
+    }
+
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return Err("expected 32 raw bytes or 64 lowercase/uppercase hex characters");
+    };
+    let text = text.trim();
+    if text.len() != 64 || !text.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        return Err("expected 32 raw bytes or 64 lowercase/uppercase hex characters");
+    }
+    let decoded =
+        hex::decode(text).map_err(|_| "expected valid hex-encoded Ed25519 secret bytes")?;
+    let mut raw = [0u8; 32];
+    raw.copy_from_slice(&decoded);
+    Ok(raw)
+}
+
+fn write_seed_atomic(path: &Path, seed: &[u8; 32]) -> io::Result<()> {
+    // Write to a sibling tmp file first, fsync-via-rename so a crash
+    // between create and write can never leave a half-written wallet.
+    let tmp = match path.file_name() {
+        Some(name) => {
+            let mut buf = std::ffi::OsString::from(name);
+            buf.push(".tmp");
+            path.with_file_name(buf)
+        }
+        None => path.with_extension("key.tmp"),
+    };
+    fs::write(&tmp, seed)?;
+    #[cfg(unix)]
+    fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600))?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn warn_if_world_readable(path: &Path) {
+    if let Ok(meta) = fs::metadata(path) {
+        let mode = meta.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            tracing::warn!(
+                "wallet file {} has permissive mode {:o} (other/group readable) — \
+                 recommend `chmod 600`",
+                path.display(),
+                mode
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn warn_if_world_readable(_path: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    /// Create a unique scratch dir under `std::env::temp_dir()` and
+    /// return its path. Drops are best-effort via `RemoveOnDrop`.
+    struct ScratchDir(std::path::PathBuf);
+    impl ScratchDir {
+        fn new(label: &str) -> Self {
+            let n = TEST_DIR_COUNTER.fetch_add(1, Ordering::SeqCst);
+            let pid = std::process::id();
+            let path = std::env::temp_dir().join(format!("tirami-wallet-{label}-{pid}-{n}"));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for ScratchDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn from_seed_is_deterministic() {
+        let seed = [0x42u8; 32];
+        let a = WalletKey::from_seed(seed);
+        let b = WalletKey::from_seed(seed);
+        assert_eq!(a.verifying_key_bytes(), b.verifying_key_bytes());
+        assert_eq!(a.seed(), b.seed());
+    }
+
+    #[test]
+    fn generate_produces_distinct_seeds() {
+        let a = WalletKey::generate();
+        let b = WalletKey::generate();
+        assert_ne!(a.seed(), b.seed());
+        assert_ne!(a.verifying_key_bytes(), b.verifying_key_bytes());
+    }
+
+    #[test]
+    fn load_or_create_writes_fresh_seed_when_missing() {
+        let dir = ScratchDir::new("fresh");
+        let path = dir.path().join("subdir").join("node.key");
+        assert!(!path.exists());
+
+        let (wallet, created) = WalletKey::load_or_create(&path).unwrap();
+        assert!(created);
+        assert!(path.exists());
+
+        let raw = fs::read(&path).unwrap();
+        assert_eq!(raw.len(), 32);
+        assert_eq!(&raw[..], wallet.seed());
+    }
+
+    #[test]
+    fn load_or_create_reloads_existing_seed() {
+        let dir = ScratchDir::new("reload");
+        let path = dir.path().join("node.key");
+        let (first, created_first) = WalletKey::load_or_create(&path).unwrap();
+        assert!(created_first);
+
+        let (second, created_second) = WalletKey::load_or_create(&path).unwrap();
+        assert!(!created_second);
+        assert_eq!(first.seed(), second.seed());
+        assert_eq!(first.verifying_key_bytes(), second.verifying_key_bytes());
+    }
+
+    #[test]
+    fn load_or_create_accepts_hex_format() {
+        let dir = ScratchDir::new("hex");
+        let path = dir.path().join("node.key");
+        let seed = [0xABu8; 32];
+        fs::write(&path, format!("{}\n", hex::encode(seed))).unwrap();
+
+        let (wallet, created) = WalletKey::load_or_create(&path).unwrap();
+        assert!(!created);
+        assert_eq!(wallet.seed(), &seed);
+    }
+
+    #[test]
+    fn load_or_create_rejects_malformed_file() {
+        let dir = ScratchDir::new("bad");
+        let path = dir.path().join("node.key");
+        fs::write(&path, b"not a key").unwrap();
+
+        let err = WalletKey::load_or_create(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn auto_created_wallet_has_mode_0600() {
+        let dir = ScratchDir::new("perms");
+        let path = dir.path().join("node.key");
+        let (_w, _created) = WalletKey::load_or_create(&path).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "fresh wallet must be 0600, got {:o}", mode);
+    }
+
+    #[test]
+    fn sign_round_trips() {
+        let w = WalletKey::from_seed([7u8; 32]);
+        use ed25519_dalek::{Signer, Verifier};
+        let msg = b"economic statement of the realm";
+        let sig = w.signing_key().sign(msg);
+        assert!(w.verifying_key().verify(msg, &sig).is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

- Same 32-byte Ed25519 seed underlies both iroh QUIC keypair AND HTTP-layer trade/loan signing — treat it as a Bitcoin-style **wallet**.
- New `WalletKey` (in `tirami-node`) auto-creates `~/.tirami/node.key` with **file mode 0600** on first run, atomic-renamed from a sibling tmp file. World/group-readable existing files emit a runtime warning.
- `TiramiNode.wallet: Option<Arc<WalletKey>>` populated by `init_transport`, threaded through to `AppState` so HTTP handlers can sign as the real node.
- **`/v1/tirami/borrow`** now binds the loan to the persistent node identity instead of a one-shot ephemeral key, so the loan accrues credit + effective balance for the calling node. **`/v1/tirami/lend-to`** does the same on the lender side.
- `tirami wallet identity` CLI prints NodeId / wallet path / file permissions without bringing up the Lightning subsystem.
- Drops the now-redundant `load_node_secret_key` / `parse_node_secret_key_bytes` helpers in `node.rs` (replaced by `wallet::parse_seed_bytes` covered by 8 dedicated tests).

## Why now

Field-test of the 50-worker burst plateaued at 2 359 trades because `/v1/tirami/borrow` was using `SigningKey::generate(&mut OsRng)` as both lender and borrower — the loan was registered against an ephemeral identity, not the calling worker. Pool / loan state stayed at 0, no real credit was issued, and mesh activity stalled once welcome-loan quota was drained. Persistent-wallet plumbing fixes that.

## Test plan

- [x] `cargo test --workspace --lib` — 1 533 passing including 8 new `wallet::tests::*`
- [x] `tirami wallet identity --key-path /tmp/...` — fresh run creates 0600 file + prints NodeId; second run reloads the **same** NodeId (stability proven)
- [ ] On a live mesh node: restart and confirm NodeId stable (existing field deploy already exercises this via `config.node_key_path`)
- [ ] Compare `/v1/tirami/pool` and `/v1/tirami/loans` state before vs after a borrow against a wallet-enabled node

🤖 Generated with [Claude Code](https://claude.com/claude-code)