### PR TITLE
fix(phase-25/#151): close P2P bypass of stake_required gate

### DIFF
--- a/crates/tirami-node/src/pipeline.rs
+++ b/crates/tirami-node/src/pipeline.rs
@@ -194,6 +194,10 @@ impl PipelineCoordinator {
                         let ledger_path = ledger_path.clone();
                         let gossip = gossip.clone();
                         let dispatcher = trade_accept_dispatcher.clone();
+                        // Issue #151 — plumb staking_pool so the P2P
+                        // inference path can enforce the same stake-
+                        // required gate the HTTP path enforces.
+                        let staking_p2p_gate = staking_pool.clone();
                         // Phase 23 Wave 2 — snapshot the current
                         // AgentIdentity (if any) so the trade is
                         // attributed to the agent rather than the
@@ -226,6 +230,7 @@ impl PipelineCoordinator {
                                 dispatcher,
                                 agent_snapshot,
                                 policy_snapshot,
+                                staking_p2p_gate,
                             )
                             .await
                             {
@@ -890,6 +895,12 @@ async fn handle_inference(
     // execute_signed_trade time so a governance ratchet between
     // dispatch and execute is honoured.
     current_proof_policy: tirami_ledger::zk::ProofPolicy,
+    // Issue #151 — staking pool snapshot used to enforce the same
+    // stake-required gate the HTTP path enforces. The P2P path
+    // previously had no provider-side gate, which let worker meshes
+    // route around the HTTP gate and drive the seed past the
+    // stakeless earn cap indefinitely.
+    staking_pool: Arc<Mutex<tirami_ledger::StakingPool>>,
 ) -> anyhow::Result<()> {
     use tirami_infer::InferenceEngine;
 
@@ -910,6 +921,38 @@ async fn handle_inference(
         )
         .await?;
         return Ok(());
+    }
+
+    // Issue #151 — provider-side stake gate. Mirror the HTTP path's
+    // `forge_chat_completions` gate so a worker mesh can't route
+    // around the Constitutional stake-required requirement. The
+    // verdict has two failure modes:
+    //   - PreviouslySlashed → constitutional permanent ban, non-retryable
+    //   - StakeRequired     → past stakeless earn cap without stake,
+    //                         not retryable until operator stakes
+    if config.stake_gate_enabled {
+        let verdict = {
+            let ledger_g = ledger.lock().await;
+            let staking_g = staking_pool.lock().await;
+            ledger_g.inference_eligibility(&node_id, &staking_g, now_millis())
+        };
+        if let Err(ineligible) = verdict {
+            tracing::warn!(
+                "P2P inference denied by stake gate from {}: {}",
+                peer_id, ineligible
+            );
+            send_protocol_error(
+                &transport,
+                peer_id,
+                &node_id,
+                req.request_id,
+                ErrorCode::InvalidRequest,
+                format!("stake_gate_denied: {ineligible}"),
+                false,
+            )
+            .await?;
+            return Ok(());
+        }
     }
 
     // Reserve CU for this inference (prevents double-spending)


### PR DESCRIPTION
## Summary

- HTTP \`/v1/chat/completions\` correctly returns 403 \`stake_gate_denied\` once a provider crosses \`STAKELESS_EARN_CAP_TRM=10\` without locking \`MIN_PROVIDER_STAKE_TRM=100\`.
- P2P \`handle_inference\` did not perform the same check, so worker meshes routed around the gate and drove the seed past the cap indefinitely — confirmed in the running mesh (seed at 8 648 TRM contributed, 0 staked, P2P trades flowing at ~30/min).
- Patch mirrors the HTTP-side gate at the top of \`handle_inference\`, after request validation and before CU reservation. Failure → \`ErrorCode::InvalidRequest\` Error with \`stake_gate_denied: <verdict>\`, non-retryable.
- The receiver-side gossip gate (#148 / PR #149) stays soft-accept — that path lacks canonical stake state. This patch closes the gate at the *provider*, where the stake state is authoritative.

Closes #151.

## Test plan

- [x] \`cargo test --workspace --lib\` — 1 533 passing, no regressions in the existing gossip-gate / stake-eligibility tests (\`pipeline::gossip_gate_tests\`, ledger \`phase18_can_provide_inference_*\`).
- [ ] On the live mesh after redeploy: confirm \`/v1/tirami/network total_trades\` stops growing on the asus seed (currently 8 648 TRM contributed, 0 staked) AND the P2P workers' logs show the new \`stake_gate_denied\` Error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)