### PR TITLE
fix(phase-25): persist StakingPool (#156) + gate audit on backend capability (#147)

### DIFF
--- a/crates/tirami-core/src/config.rs
+++ b/crates/tirami-core/src/config.rs
@@ -23,6 +23,15 @@ pub struct Config {
     /// Optional path to the persisted forge-agora (L4) marketplace state.
     pub marketplace_state_path: Option<PathBuf>,
 
+    /// Issue #156 — optional path to the persisted staking-pool
+    /// snapshot. When `Some(_)`, `TiramiNode::new` loads the pool at
+    /// startup, and every `/v1/tirami/su/stake`, `/su/unstake`, plus
+    /// the slashing loop persist after mutation. `None` keeps the
+    /// pre-#156 behaviour (in-memory only — operator loses locked
+    /// TRM on restart).
+    #[serde(default)]
+    pub staking_state_path: Option<PathBuf>,
+
     /// Optional path to the persisted forge-mind (L3) agent snapshot.
     pub mind_state_path: Option<PathBuf>,
 
@@ -362,6 +371,7 @@ impl Config {
         self.ledger_path = Some(data_dir.join("ledger.json"));
         self.bank_state_path = Some(data_dir.join("bank_state.json"));
         self.marketplace_state_path = Some(data_dir.join("marketplace_state.json"));
+        self.staking_state_path = Some(data_dir.join("staking.json"));
         self.mind_state_path = Some(data_dir.join("mind_state.json"));
         self.personal_agent_state_path = Some(data_dir.join("personal_agent.json"));
         self.archive_path = Some(data_dir.join("trades.jsonl"));
@@ -426,6 +436,7 @@ impl Default for Config {
             ledger_path: None,
             bank_state_path: None,
             marketplace_state_path: None,
+            staking_state_path: None,
             mind_state_path: None,
             personal_agent_state_path: None,
             agent_identity_path: None,

--- a/crates/tirami-infer/src/engine.rs
+++ b/crates/tirami-infer/src/engine.rs
@@ -14,6 +14,21 @@ pub trait InferenceEngine: Send + Sync {
     /// Check if a model is loaded and ready.
     fn is_loaded(&self) -> bool;
 
+    /// Issue #147 — does this backend implement the inputs the
+    /// audit-challenge loop needs (specifically `forward_tokens`)?
+    /// The `generate_audit` default iterates `forward_tokens` to
+    /// derive a deterministic logit hash; a backend that returns
+    /// `InferenceError::*Not yet implemented*` from `forward_tokens`
+    /// must override this to `false` so the audit-challenger loop
+    /// can exit cleanly instead of spamming WARN every interval.
+    ///
+    /// Default is `true` so backends that implement `forward_tokens`
+    /// (Candle today, future Metal / CUDA backends) opt in
+    /// automatically.
+    fn supports_audit_challenge(&self) -> bool {
+        true
+    }
+
     /// Generate tokens from a prompt string.
     /// Returns a vector of generated text fragments.
     fn generate(

--- a/crates/tirami-infer/src/llama_engine.rs
+++ b/crates/tirami-infer/src/llama_engine.rs
@@ -266,6 +266,15 @@ impl InferenceEngine for LlamaCppEngine {
         ))
     }
 
+    /// Issue #147 — llama.cpp backend lacks `forward_tokens`, so the
+    /// `generate_audit` default would fail every call. Declare the
+    /// capability as unavailable so the audit-challenger loop in
+    /// `tirami-node` skips probing this engine entirely. Re-enable
+    /// when `forward_tokens` ships (Wave 2.x).
+    fn supports_audit_challenge(&self) -> bool {
+        false
+    }
+
     fn sample_token(
         &mut self,
         _logits: &[f32],

--- a/crates/tirami-ledger/src/staking.rs
+++ b/crates/tirami-ledger/src/staking.rs
@@ -211,6 +211,78 @@ impl StakingPool {
             .get(node_id)
             .into_iter()
     }
+
+    /// Issue #156 — persist the pool to JSON at `path`. The write is
+    /// atomic: serialise to a sibling `.tmp` file, then rename into
+    /// place. This guarantees that a crash in the middle of the
+    /// write never produces a torn `staking.json` that would lose
+    /// every operator's locked stake on the next load.
+    ///
+    /// `HashMap<NodeId, Stake>` cannot round-trip through `serde_json`
+    /// directly because `NodeId = [u8; 32]` does not serialise as a
+    /// JSON object key. Each `Stake` already carries its own
+    /// `node_id` field, so the on-disk shape is a `Vec<Stake>` —
+    /// load rehydrates the map from `stake.node_id`.
+    pub fn save_to_path(&self, path: &std::path::Path) -> std::io::Result<()> {
+        let snapshot = PersistedStakingPool {
+            stakes: self.stakes.values().cloned().collect(),
+            total_burned: self.total_burned,
+        };
+        let json = serde_json::to_vec_pretty(&snapshot).map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+        })?;
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+        let tmp = match path.file_name() {
+            Some(name) => {
+                let mut buf = std::ffi::OsString::from(name);
+                buf.push(".tmp");
+                path.with_file_name(buf)
+            }
+            None => path.with_extension("json.tmp"),
+        };
+        std::fs::write(&tmp, &json)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Issue #156 — load the pool from JSON at `path`. Missing file
+    /// is mapped to `Ok(StakingPool::default())` so first-run boot is
+    /// not an error condition; every other I/O / parse failure
+    /// propagates so a corrupted snapshot is surfaced loudly instead
+    /// of silently wiping operator stakes.
+    pub fn load_from_path(path: &std::path::Path) -> std::io::Result<Self> {
+        match std::fs::read(path) {
+            Ok(bytes) => {
+                let snap: PersistedStakingPool =
+                    serde_json::from_slice(&bytes).map_err(|e| {
+                        std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+                    })?;
+                let mut stakes = HashMap::new();
+                for stake in snap.stakes {
+                    stakes.insert(stake.node_id.clone(), stake);
+                }
+                Ok(Self {
+                    stakes,
+                    total_burned: snap.total_burned,
+                })
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Issue #156 — on-disk representation for JSON-friendly serialisation.
+/// Internal to the persistence layer; callers always work with
+/// [`StakingPool`].
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedStakingPool {
+    stakes: Vec<Stake>,
+    total_burned: u64,
 }
 
 #[cfg(test)]
@@ -497,5 +569,83 @@ mod tests {
         let after = NOW + StakeDuration::Days7.duration_ms();
         pool.unstake(&node(100), after).unwrap();
         assert_eq!(pool.total_staked(), 2_000);
+    }
+
+    // -----------------------------------------------------------------
+    // Issue #156 — persistence
+    // -----------------------------------------------------------------
+
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static PERSIST_TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn scratch_path(label: &str) -> std::path::PathBuf {
+        let n = PERSIST_TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let pid = std::process::id();
+        std::env::temp_dir().join(format!("tirami-staking-{label}-{pid}-{n}.json"))
+    }
+
+    #[test]
+    fn save_and_load_round_trip_preserves_stakes() {
+        let mut pool = StakingPool::new();
+        pool.stake(node(1), 1_000, StakeDuration::Days7, NOW).unwrap();
+        pool.stake(node(2), 5_000, StakeDuration::Days30, NOW).unwrap();
+        // Mutate burned counter so we know that field round-trips too.
+        pool.apply_slash(&node(1), 0.5);
+
+        let path = scratch_path("roundtrip");
+        pool.save_to_path(&path).unwrap();
+        let loaded = StakingPool::load_from_path(&path).unwrap();
+
+        assert_eq!(loaded.stakes.len(), pool.stakes.len());
+        assert_eq!(loaded.total_burned, pool.total_burned);
+        assert_eq!(loaded.total_staked(), pool.total_staked());
+        assert_eq!(
+            loaded.stakes.get(&node(2)).map(|s| s.amount),
+            pool.stakes.get(&node(2)).map(|s| s.amount)
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_missing_path_returns_empty_pool() {
+        let path = scratch_path("missing");
+        let loaded = StakingPool::load_from_path(&path).unwrap();
+        assert!(loaded.stakes.is_empty());
+        assert_eq!(loaded.total_burned, 0);
+    }
+
+    #[test]
+    fn save_is_atomic_no_partial_file() {
+        let mut pool = StakingPool::new();
+        pool.stake(node(3), 2_000, StakeDuration::Days7, NOW).unwrap();
+        let path = scratch_path("atomic");
+        pool.save_to_path(&path).unwrap();
+        // Final file exists; sibling .tmp must NOT remain.
+        assert!(path.exists());
+        let tmp = {
+            let mut buf = std::ffi::OsString::from(path.file_name().unwrap());
+            buf.push(".tmp");
+            path.with_file_name(buf)
+        };
+        assert!(
+            !tmp.exists(),
+            ".tmp sibling must be renamed in place by save_to_path"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn locked_stake_survives_save_load() {
+        let mut pool = StakingPool::new();
+        pool.stake(node(4), 100, StakeDuration::Days7, NOW).unwrap();
+        let path = scratch_path("locked");
+        pool.save_to_path(&path).unwrap();
+        let loaded = StakingPool::load_from_path(&path).unwrap();
+        // Lock semantics preserved.
+        let s = loaded.stakes.get(&node(4)).unwrap();
+        assert!(s.is_locked(NOW + 60_000));
+        assert_eq!(s.amount, 100);
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/tirami-node/src/handlers/tokenomics.rs
+++ b/crates/tirami-node/src/handlers/tokenomics.rs
@@ -156,14 +156,28 @@ pub(crate) async fn su_stake(
 
     let now_ms = now_millis_pub();
     let mut pool = state.staking_pool.lock().await;
-    let stake = pool
-        .stake(state.local_node_id.clone(), req.amount, duration, now_ms)
-        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+    let (multiplier, unlocks_at_ms) = {
+        let stake = pool
+            .stake(state.local_node_id.clone(), req.amount, duration, now_ms)
+            .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+        (stake.multiplier(), stake.unlocks_at_ms)
+    };
+    // Issue #156 — persist after mutation so a restart does not
+    // silently wipe the operator's locked TRM.
+    if let Some(path) = state.config.staking_state_path.as_ref() {
+        if let Err(e) = pool.save_to_path(path) {
+            tracing::warn!(
+                "Failed to persist staking pool to {} after stake: {}",
+                path.display(),
+                e
+            );
+        }
+    }
 
     Ok(Json(StakeResponse {
         ok: true,
-        multiplier: stake.multiplier(),
-        unlocks_at_ms: stake.unlocks_at_ms,
+        multiplier,
+        unlocks_at_ms,
     }))
 }
 
@@ -205,6 +219,17 @@ pub(crate) async fn su_unstake(
     let returned = pool
         .unstake(&state.local_node_id, now_ms)
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+    // Issue #156 — persist after the unlock so the next restart
+    // does not silently re-insert the removed stake.
+    if let Some(path) = state.config.staking_state_path.as_ref() {
+        if let Err(e) = pool.save_to_path(path) {
+            tracing::warn!(
+                "Failed to persist staking pool to {} after unstake: {}",
+                path.display(),
+                e
+            );
+        }
+    }
 
     Ok(Json(UnstakeResponse { ok: true, returned }))
 }

--- a/crates/tirami-node/src/node.rs
+++ b/crates/tirami-node/src/node.rs
@@ -154,6 +154,36 @@ impl TiramiNode {
         // for a snapshot file and calls agent.restore_from_snapshot()).
         let mind_agent: Option<tirami_mind::TiramiMindAgent> = None;
 
+        // Issue #156 — load the staking pool snapshot if a path is
+        // configured. Missing file → empty pool (first-run). Other
+        // I/O / parse errors are surfaced loudly as WARN; the
+        // operator's locked TRM has more value than silently
+        // overwriting a corrupted snapshot.
+        let staking_pool = match config.staking_state_path.as_ref() {
+            Some(path) => match tirami_ledger::StakingPool::load_from_path(path) {
+                Ok(pool) => {
+                    if !pool.stakes.is_empty() {
+                        tracing::info!(
+                            "Loaded staking pool from {} ({} active stakes, {} TRM burned)",
+                            path.display(),
+                            pool.stakes.len(),
+                            pool.total_burned
+                        );
+                    }
+                    pool
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to load staking pool from {}: {} — starting with empty pool",
+                        path.display(),
+                        err
+                    );
+                    tirami_ledger::StakingPool::new()
+                }
+            },
+            None => tirami_ledger::StakingPool::new(),
+        };
+
         // Phase 23 Wave 3 — compute BEFORE `config` is moved into
         // `self`. Best-effort load; returns `None` if path or
         // passphrase env var is unset.
@@ -184,7 +214,7 @@ impl TiramiNode {
             bank: Arc::new(Mutex::new(bank)),
             marketplace: Arc::new(Mutex::new(marketplace)),
             mind_agent: Arc::new(Mutex::new(mind_agent)),
-            staking_pool: Arc::new(Mutex::new(tirami_ledger::StakingPool::new())),
+            staking_pool: Arc::new(Mutex::new(staking_pool)),
             referral_tracker: Arc::new(Mutex::new(tirami_ledger::ReferralTracker::new())),
             governance: Arc::new(Mutex::new(tirami_ledger::GovernanceState::new(0))),
             chain_client: Arc::new(tirami_anchor::MockChainClient::new()),
@@ -690,6 +720,26 @@ impl TiramiNode {
         let my_id = transport.tirami_node_id();
 
         tokio::spawn(async move {
+            // Issue #147 — probe the loaded engine's audit capability
+            // once at startup. If the backend cannot serve
+            // `forward_tokens` (e.g. the llama.cpp backend) there is
+            // nothing the audit-challenger loop can produce except
+            // WARN spam every interval. Log once at INFO and exit
+            // the task entirely; a future audit-capable backend will
+            // start the loop on its next process bootstrap.
+            {
+                use tirami_infer::InferenceEngine;
+                let eng = engine.lock().await;
+                if !eng.supports_audit_challenge() {
+                    tracing::info!(
+                        "Audit-challenger loop disabled: loaded inference engine \
+                         does not implement forward_tokens (see issue #147 — \
+                         re-enabled when the backend's audit support lands)"
+                    );
+                    return;
+                }
+            }
+
             let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
             // Skip the immediate first tick — let peers register first.
             ticker.tick().await;
@@ -825,6 +875,9 @@ impl TiramiNode {
         let ledger = self.ledger.clone();
         let staking = self.staking_pool.clone();
         let ledger_path = self.config.ledger_path.clone();
+        // Issue #156 — staking-pool snapshot path so each slash
+        // event persists the residual locked stake.
+        let staking_path = self.config.staking_state_path.clone();
         let interval_secs = self.config.slashing_interval_secs.max(60);
         // Phase 25 C9 — per-tick cap so a logic bug or false-positive
         // cluster can't drain the staking pool in one sweep.
@@ -869,6 +922,18 @@ impl TiramiNode {
                         let l = ledger.lock().await;
                         if let Err(e) = l.save_to_path(path) {
                             tracing::error!("Failed to persist slash events: {}", e);
+                        }
+                    }
+                    // Issue #156 — persist the slashed (smaller)
+                    // staking pool so the burn survives a restart.
+                    if let Some(path) = staking_path.as_ref() {
+                        let s = staking.lock().await;
+                        if let Err(e) = s.save_to_path(path) {
+                            tracing::error!(
+                                "Failed to persist staking pool to {}: {}",
+                                path.display(),
+                                e
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Two protocol-level fixes:

### #156 — StakingPool persistence
- Pre-fix: in-memory only. Every restart wiped operator's locked TRM (both seeds in the running mesh lost 100 TRM each across #155 redeploy).
- Fix: \`save_to_path()\` / \`load_from_path()\` with atomic sibling-tmp + rename. On-disk JSON shape sidesteps the \`HashMap<[u8;32], _>\` JSON-key constraint by serialising as \`Vec<Stake>\`.
- Wired into \`Config\` (\`staking_state_path\`, defaults to \`~/.tirami/staking.json\`), \`TiramiNode::new\`, \`/v1/tirami/su/stake\`, \`/su/unstake\`, and \`spawn_slashing_loop\`.

### #147 — audit-challenger backend gate
- Pre-fix: \`generate_audit\` called \`forward_tokens\`, which is unimplemented in llama.cpp backend. WARN every 60s for the entire process lifetime.
- Fix: new \`InferenceEngine::supports_audit_challenge()\` trait method (default true). \`LlamaCppEngine\` overrides to false. \`spawn_audit_challenger_loop\` probes once at startup, logs **one** INFO, and exits the task — no more WARN spam.

Closes #156. Closes #147.

## Test plan

- [x] \`cargo test --workspace --lib\` — 1 539 passing (+4 new in \`staking::tests::*\`).
- [ ] On the live mesh after redeploy: confirm \`~/.tirami/staking.json\` is written after \`/su/stake\`, survives restart with intact \`{staked, multiplier, unlocks_at_ms}\`.
- [ ] Confirm post-restart logs show **one** \"Audit-challenger loop disabled\" INFO and no \"generate_audit (challenger) failed\" WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)