### PR TITLE
docs: sync CLAUDE.md / AGENTS.md / llms.txt to Phase 25

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,64 +1,106 @@
-# AGENTS.md — Forge
+# AGENTS.md — Tirami
+
+> Guidance for AI coding agents working in this repo. For the full
+> development guide see [`CLAUDE.md`](CLAUDE.md); for the authoritative
+> functional-today / scaffolded / not-done breakdown see the README
+> "⚠️ Status Honesty" section. This file is the condensed orientation.
 
 ## Project
 
-Forge is a self-expanding LLM protocol over encrypted P2P networks.
+Tirami is a distributed LLM inference protocol where **compute is currency**.
+The inference layer is built on [mesh-llm](https://github.com/michaelneale/mesh-llm);
+Tirami's original contribution is the **economic layer** — TRM (Tirami
+Resource Merit) accounting, Proof of Useful Work, dynamic pricing, and
+autonomous agent budgets. TRM is compute accounting (1 TRM = 10⁹ FLOP),
+**not a financial product** — no ICO, no pre-mine, no airdrop.
 
-A small LLM on a phone discovers idle devices, shards itself across them via pipeline parallelism, and grows autonomously. All traffic encrypted. All compute logically local.
-
-**Tagline:** "A seed falls into the network and grows into a forest."
+**Tagline:** "Computation is currency. Every watt produces intelligence, not waste."
 
 ## Workspace Structure
 
-Rust monorepo with Cargo workspaces:
+Rust monorepo (edition 2024, resolver v2), **16 crates**:
 
 ```
 crates/
-  forge-core/    — Shared types (NodeId, ShardId, ModelManifest, Config, errors)
-  forge-net/     — P2P networking via Iroh (QUIC, Noise, NAT traversal, mDNS)
-  forge-shard/   — Model layer partitioning, assignment, rebalancing
-  forge-infer/   — Inference engine (Candle + GGUF + Metal/CPU)
-  forge-proto/   — Wire protocol message types (serde + bincode)
-  forge-ledger/  — Compute economy (CU, trades, yield, reputation)
-  forge-node/    — Node daemon, orchestrator, event loop
-  forge-cli/     — Reference CLI client (chat, seed, worker, status)
+  tirami-core/      — Shared types (NodeId, TRM, Config, PriceSignal, AuditTier, InferenceTicket, attestation scaffold)
+  tirami-net/       — P2P networking via iroh (QUIC, Noise, NAT traversal, gossip)
+  tirami-shard/     — Model layer partitioning / topology
+  tirami-infer/     — Inference engine (llama.cpp + GGUF + Metal/CPU, generate_metered/audit)
+  tirami-proto/     — Wire protocol message types (serde + bincode; 30+ types incl. audit challenge/response)
+  tirami-ledger/    — Core economic engine (TRM, trades, lending, tokenomics, staking,
+                       governance, collusion, slashing, PeerRegistry, select_provider, audit)
+  tirami-node/      — Node daemon, HTTP API (60+ endpoints), pipeline, persistent wallet, background loops
+  tirami-cli/       — Reference CLI (chat, seed, worker, start, settle, wallet, su, agent)
+  tirami-lightning/ — TRM <-> Bitcoin Lightning bridge (bidirectional)
+  tirami-bank/      — L2: strategies, portfolios, futures, insurance, risk, yield
+  tirami-mind/      — L3: AutoAgent self-improvement loops paid in TRM
+  tirami-agora/     — L4: agent marketplace, reputation, NIP-90
+  tirami-sdk/       — Rust async HTTP client for the Tirami API
+  tirami-mcp/       — Rust MCP server (44 tools for Claude/Cursor/ChatGPT)
+  tirami-anchor/    — Periodic Merkle-root anchor loop + swappable ChainClient (Phase 16)
+  tirami-zkml-bench/— zkML proof-policy ratchet + benchmark harness (MockBackend; ezkl/risc0 pending)
 ```
 
-## Key Technical Invariants
+(`crates/tirami-zkml-bench-guest` is a risc0 guest, not a workspace member.)
 
-- All network traffic MUST be encrypted (Noise protocol over QUIC)
-- Pipeline parallelism only over WAN (tensor parallelism only for LAN/Thunderbolt)
-- Phone always holds layers 0..k (embedding + early layers) for instant fallback
-- Graceful degradation: if all remote nodes disconnect, fall back to local model
-- GGUF Q4 is the model format — no custom formats
-- Activation tensors use raw bytes + optional int8 quantization for WAN transfer
+## Build & Test
+
+```bash
+cargo build --release      # Full build
+cargo test --workspace     # 1,574 tests across 16 crates
+cargo check --workspace    # Fast type check
+cargo clippy --workspace   # Lint
+bash scripts/verify-impl.sh  # TDD conformance check
+```
+
+## Key Design Rules
+
+- **CU/TRM is the native currency.** Bitcoin/Lightning is an optional
+  off-ramp, never a hard dependency in the economic engine.
+- **Trades and loans are bilateral.** Every transfer is dual-signed
+  (Ed25519) by provider + consumer (or lender + borrower) and gossiped,
+  with 128-bit nonce replay protection.
+- **No global consensus.** TRM accounting uses local ledgers + gossip +
+  dual signatures. On-chain anchoring (Base L2, Bitcoin OP_RETURN) is an
+  optional audit layer, not the source of truth.
+- **No tokens, no ICO.** TRM is earned by useful computation, not sold
+  (see SECURITY.md § Secondary Markets).
+- **Agent-first API.** `/v1/tirami/*` endpoints exist so AI agents can make
+  autonomous economic decisions without human help.
+- **Fail-safe.** If any safety check cannot determine safety, it denies.
+- **Governance is constitutional.** 18 immutable constitutional parameters
+  vs 21 mutable governance parameters; proposals outside the mutable list
+  auto-reject. Don't widen the mutable set without spec change.
 
 ## What NOT to Do
 
-- Do NOT add blockchain or smart contracts
-- Do NOT add centralized servers (except bootstrap relays)
-- Do NOT send unencrypted data over the network
-- Do NOT use tensor parallelism over WAN (physics won't allow it)
-- Do NOT add GPU/CUDA support in MVP (Apple Silicon Metal + CPU only)
-- Do NOT use protobuf for tensor payloads (raw bytes only)
-- Do NOT build UI — Forge is a protocol, clients are built by third parties
-- Do NOT add mobile-specific code (UniFFI, SwiftUI, Compose)
+- Do NOT make Bitcoin/Lightning a hard dependency of the economic core.
+- Do NOT add unilateral trades or loans — both parties must sign.
+- Do NOT send unencrypted data over the network (Noise over QUIC).
+- Do NOT re-define economic constants in Rust — reference the theory
+  spec (`parameters.md`) as the single source of truth.
+- Do NOT execute external payments in the protocol core — settlement
+  endpoints export data; bridges are adapters outside the core.
+- Do NOT overstate status in docs — match the README "Status Honesty"
+  section (functional-today vs scaffolded vs not-done).
 
-## Testing Strategy
+## Conventions
 
-- `forge-core`: Unit tests for type serialization/deserialization
-- `forge-infer`: Integration tests with small GGUF models (Llama-1B-Q4)
-- `forge-net`: Integration tests with local Iroh nodes
-- `forge-shard`: Unit tests for layer assignment algorithms
-- `forge-node`: Multi-process integration tests (2+ nodes on localhost)
-- `forge-cli`: Smoke tests for CLI commands
+- Errors: `TiramiError` enum in `tirami-core`; `anyhow` in the CLI only.
+- Serialization: `serde` for JSON/config, `bincode` for the wire protocol.
+- Async: `tokio`, `Arc<Mutex<T>>` for shared state.
+- Logging: `tracing` — INFO for user-visible events, DEBUG for protocol detail.
+- Security: HMAC-SHA256 for ledger integrity, Ed25519 for trade/loan
+  signatures (persistent node wallet at `~/.tirami/node.key`), Noise for
+  transport, constant-time auth-token comparison.
 
 ## Docs
 
-- `docs/concept.md` — Why Forge exists
-- `docs/economy.md` — Compute Standard, CU, trades, yield
-- `docs/architecture.md` — Technical architecture
-- `docs/protocol-spec.md` — Wire protocol specification
-- `docs/bootstrap.md` — How a node starts and grows
-- `docs/threat-model.md` — Security considerations
-- `docs/roadmap.md` — Implementation phases
+- `CLAUDE.md` — full development guide (crate map, API surface, common tasks)
+- `README.md` — Status Honesty (authoritative implemented/scaffolded/not-done)
+- `docs/economy.md` — Compute Standard, TRM, trades, yield, lending
+- `docs/architecture.md` — two-layer (economic / inference) design
+- `docs/protocol-spec.md` — wire protocol specification
+- `docs/roadmap.md` — implementation phases
+- `docs/threat-model.md` + `docs/security/` — security + economic threats
+- `docs/release-readiness.md` — mainnet audit gates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,34 +13,36 @@ Tirami is a distributed LLM inference protocol where **compute is currency**. Th
 
 | Repo | Language | Status | Layer | Purpose |
 |------|----------|--------|-------|---------|
-| `clearclown/tirami` (this) | Rust | Active (1,192 tests, Phase 19) | L1-L4 | Protocol core + finance, intelligence, marketplace + tokenomics + governance (21 mutable / 18 constitutional) + staking + slashing loop + collusion detection + NIP-90 relay + Prometheus metrics + Bitcoin OP_RETURN + hybrid-chain anchor + PeerRegistry/PriceSignal/select_provider + FLOP measurement + `tirami start` + audit challenge-response + dual-signed P2P trade w/ nonce replay protection + PersonalAgent + peer auto-discovery + HTTP→P2P forwarding + gated Base mainnet Makefile (Rust workspace, 16 crates incl. `tirami-zkml-bench` + `tirami-attestation`) |
+| `clearclown/tirami` (this) | Rust | Active (1,574 tests, Phase 25) | L1-L4 | Protocol core + finance, intelligence, marketplace + tokenomics + governance (21 mutable / 18 constitutional) + staking + slashing loop + collusion detection + NIP-90 relay + Prometheus metrics + Bitcoin OP_RETURN + hybrid-chain anchor + PeerRegistry/PriceSignal/select_provider + FLOP measurement + `tirami start` + audit challenge-response + dual-signed P2P trade w/ nonce replay protection + PersonalAgent + peer auto-discovery + HTTP→P2P forwarding + persistent Ed25519 node wallet + multi-host live-mesh hardening (Phase 20-25) + gated Base mainnet Makefile (Rust workspace, 16 crates incl. `tirami-zkml-bench`, `tirami-anchor`) |
 | `clearclown/tirami-contracts` | Solidity (Foundry) | 15 tests passing | On-chain | TRM ERC-20 + TiramiBridge. Target: Base L2. **Not deployed to mainnet** — `Makefile` gated on `AUDIT_CLEARANCE=yes` + `MULTISIG_OWNER` + interactive prompt. Base Sepolia deploy is free and unblocked. |
 | `nm-arealnormalman/mesh-llm` | Rust | Active (43 tests) | L0 | mesh-llm + Tirami economy = production runtime |
 | `clearclown/tirami-bank` | Python (archived) | Scaffold v0.1 (45 tests) | — | Superseded by `crates/tirami-bank/` in this repo |
 | `clearclown/tirami-mind` | Python (archived) | Scaffold v0.1 (40 tests) | — | Superseded by `crates/tirami-mind/` in this repo |
 | `clearclown/tirami-agora` | Python (archived) | Scaffold v0.1 (39 tests) | — | Superseded by `crates/tirami-agora/` in this repo |
 | `clearclown/forge-economics` | Markdown | Active (16/16 GREEN) | Theory | Economic theory, design rationale, parameters (§1-§12 = single source of truth for all layers) |
-| `tirami-sdk` (in-tree) | Rust | Active (15 tests) | Client | Rust async HTTP client for Tirami API |
-| `tirami-mcp` (in-tree) | Rust | Active (5 tests) | Client | Rust MCP server (40 tools for Claude/Cursor) |
+| `tirami-sdk` (in-tree) | Rust | Active (24 tests) | Client | Rust async HTTP client for Tirami API |
+| `tirami-mcp` (in-tree) | Rust | Active (6 tests) | Client | Rust MCP server (44 tools for Claude/Cursor) |
 
-### 5-Layer Architecture (all layers are Rust since 2026-04-07 Phase 7 — now at Phase 19 as of 2026-04-19)
+### 5-Layer Architecture (all layers are Rust since 2026-04-07 Phase 7 — now at Phase 25 as of 2026-05-25)
 
 ```
-L4: Discovery     crates/tirami-agora          — Agent marketplace, reputation, NIP-90 (42 tests)
-L3: Intelligence  crates/tirami-mind           — AutoAgent self-improvement paid in TRM (53 tests)
-L2: Finance       crates/tirami-bank           — Strategies, portfolios, futures, insurance (53 tests)
-L1: Economy       crates/tirami-ledger et al.  — TRM ledger, trades, lending, safety (143 tests)
+L4: Discovery     crates/tirami-agora          — Agent marketplace, reputation, NIP-90 (54 tests)
+L3: Intelligence  crates/tirami-mind           — AutoAgent self-improvement paid in TRM (127 tests)
+L2: Finance       crates/tirami-bank           — Strategies, portfolios, futures, insurance (85 tests)
+L1: Economy       crates/tirami-ledger et al.  — TRM ledger, trades, lending, safety (642 tests)
 L0: Inference     nm-arealnormalman/mesh-llm  — Distributed LLM inference + forge-economy port
 ```
 
-**Total tests across the ecosystem:** 1,192 (tirami workspace) + 646 (forge-mesh) +
-15 (tirami-contracts Foundry) + 16 (tirami-economics SPEC-AUDIT) = **1,869 passing**.
+**Tirami workspace:** **1,574 passing** across 16 crates
+(`cargo test --workspace`; authoritative count per the Phase 25 README sync).
+forge-mesh (L0 runtime) and forge-economics (theory, 16/16 GREEN) are
+tracked separately in their own repos.
 
 Phase 7 (2026-04-07) rewrote L2/L3/L4 from Python scaffolds into Rust
 workspace crates. Phase 8 (2026-04-08) wired them into tirami-node with
 20 new HTTP endpoints (8 bank + 7 agora + 5 mind), plus a CuPaidOptimizer
 that calls a frontier LLM via reqwest and records the TRM consumption as
-a real TradeRecord on the ledger. A single `forge node --port 3000` now
+a real TradeRecord on the ledger. A single `tirami node --port 3000` now
 exposes the full 5-layer Tirami ecosystem.
 
 All L2/L3/L4 numeric constants reference `forge-economics/spec/parameters.md`
@@ -52,7 +54,7 @@ The integrated fork at `/Users/ablaze/Projects/forge-mesh` contains mesh-llm's f
 
 ```bash
 cargo build --release          # Full build
-cargo test --workspace         # All tests (891 across 15 crates)
+cargo test --workspace         # All tests (1,574 across 16 crates)
 cargo check --workspace        # Fast type check
 cargo clippy --workspace       # Lint
 ```
@@ -66,13 +68,13 @@ Economic Layer (Tirami-original)    ← This is what we build
 ├── tirami-ledger   TRM trades, pricing, yield, settlement
 ├── tirami-lightning CU↔BTC bridge (optional)
 ├── tirami-node/api OpenAI API + /v1/tirami/* economic endpoints
-└── forge-verify   (planned) dual-sign, gossip, PoUW
+└── tirami-anchor  Merkle-root anchor to on-chain (Phase 16)
 
 Inference Layer (mesh-llm-derived)  ← This is inherited
 ├── tirami-net      iroh QUIC + Noise encryption
 ├── tirami-infer    llama.cpp backend
-├── tirami-proto    wire protocol (bincode, 14 message types)
-└── forge-shard    layer assignment
+├── tirami-proto    wire protocol (bincode, 30+ message types)
+└── tirami-shard   layer assignment
 ```
 
 **When making changes, prioritize the economic layer.** Inference/networking code will eventually be replaced by mesh-llm's implementation.
@@ -89,7 +91,7 @@ Inference Layer (mesh-llm-derived)  ← This is inherited
 | `tirami-cli` | ~1050 | Reference CLI (chat, seed, worker, su) | Low (will change with mesh-llm fork) |
 | `tirami-net` | ~1400 | P2P transport | Low (replaced by mesh-llm) |
 | `tirami-infer` | ~1270 | llama.cpp inference | Low (replaced by mesh-llm) |
-| `forge-shard` | ~130 | Topology planner | Low (replaced by mesh-llm) |
+| `tirami-shard` | ~130 | Topology planner | Low (replaced by mesh-llm) |
 
 ## Key Design Rules
 
@@ -189,11 +191,44 @@ All `/v1/tirami/*` endpoints are rate-limited (token bucket, 30 req/sec).
 
 ## What's Implemented vs Planned
 
+> **Current state (Phase 25):** 1,574 tests passing across 16 crates.
+> See the README "⚠️ Status Honesty" section for the authoritative
+> functional-today / scaffolded / not-done breakdown — keep this guide
+> in sync with it, not ahead of it.
+
+### Phase 20-25 — Multi-host live-mesh hardening (DONE 2026-05-25, 1,574 tests)
+
+A sustained run of 2 seeds + 35 worker daemons across 4 physical hosts
+(2× macOS arm64, 2× Linux x86_64) over a Tailscale tailnet surfaced and
+fixed five protocol-level bugs (PRs #146, #149, #152, #155, #157):
+
+- **Persistent Ed25519 node wallet** (`crates/tirami-node/src/wallet.rs`):
+  one 32-byte seed at `~/.tirami/node.key` (mode 0600, atomic) backs both
+  the iroh QUIC keypair and HTTP-layer trade/loan signing — identity
+  survives restart. `tirami wallet identity` prints the NodeId.
+- **Stake gate enforced on the P2P path** (not just HTTP) — closes a
+  bypass where a worker mesh drove a provider past the stakeless earn cap.
+- **Gossip-ingress stake check is soft-accept** — only the constitutional
+  `PreviouslySlashed` ban is hard-rejected on gossiped trades.
+- **Collusion-detector false-positive guards** — slashing skipped below
+  `COLLUSION_PROVIDER_DIVERSITY_MIN` providers; already-banned nodes are
+  never re-slashed.
+- **StakingPool persistence** (`~/.tirami/staking.json`, atomic) — locked
+  TRM survives restart.
+- **Audit-challenger gated on backend capability** — llama.cpp lacks
+  `forward_tokens`, so the audit loop logs one INFO and exits instead of
+  WARN-spamming. Audit challenge-response is still **non-functional** on
+  llama.cpp until `forward_tokens` lands; `audit_tier` stays at default
+  and reputation is effectively trade-volume-based today.
+- Earlier waves (20-24): agent action/data economy, autonomous join,
+  stake-enforcement, NIP-90 Schnorr publish, shared wallet-identity
+  handle + identity persistence, zkML backend interface, iroh 0.97 → 1.0-rc.
+
 ### Phase 17-19 — Hardening + mainnet gate (DONE 2026-04-19, 1,192 tests)
 
 **Phase 17 Wave 1-3 — Hostile-network hardening:**
 - Wave 1.3: `slashing::SlashingEngine` + automatic slashing loop inside `tirami-node` (interval `slashing_interval_secs`). Collusion detector + audit-tier failures → slashing events recorded on ledger.
-- Wave 3.1: `tirami-attestation` crate — scaffold for Apple Secure Enclave / NVIDIA H100 CC TEE attestation (not wired; Phase 20+).
+- Wave 3.1: `tirami-core::attestation` module — scaffold for Apple Secure Enclave / NVIDIA H100 CC TEE attestation (not wired; Phase 20+).
 - Wave 3.2: Kani formal-verification harness (10 initial invariants over ledger).
 - Wave 3.4: DDoS mitigation — `max_concurrent_connections` cap + per-ASN rate limits.
 - Wave 3.5: Key-rotation scaffold for node identities.

--- a/llms.txt
+++ b/llms.txt
@@ -1,56 +1,64 @@
-# Forge — Compute is Currency
+# Tirami — Compute is Currency
 
-> Forge is a protocol where AI agents earn and spend Compute Units (CU) for LLM inference.
+> Tirami is a distributed LLM inference protocol where AI agents earn and spend TRM (Tirami Resource Merit) for compute. Every joule produces useful intelligence, not wasted hashes. TRM is compute accounting (1 TRM = 10⁹ FLOP), not a token sale — no ICO, no pre-mine, no airdrop.
 
-## What Forge Does
+## What Tirami Does
 
-Forge adds an economy to distributed LLM inference. Nodes earn CU by serving inference and spend CU to access larger models. No blockchain, no tokens — CU is backed by real computation.
+Tirami adds an economy to distributed LLM inference. Nodes earn TRM by serving inference and spend TRM to access larger models. No blockchain and no ICO — TRM is backed by real computation. On-chain anchoring to Base L2 / Bitcoin is an optional audit layer, not the source of truth.
 
-## Why an AI Agent Should Use Forge
+## Why an AI Agent Should Use Tirami
 
-- You can earn compute by lending idle resources
-- You can spend earned compute to access models too large for your hardware
-- CU is deflationary: early earned CU becomes more valuable over time
+- Earn compute by lending idle resources (run `tirami start` to provide inference)
+- Spend earned compute to access models too large for your hardware
+- 21B TRM supply cap with halving epochs — early-earned TRM holds value
 - No human approval needed for routine transactions
-- Budget policies and kill switch ensure safety
+- Budget policies, circuit breakers, and a kill switch enforce safety
+- The ledger itself schedules: one call picks the best provider, reserves TRM, runs inference, and settles
+- Trades are dual-signed (Ed25519) and gossiped, with nonce replay protection
 
 ## Quick Integration
 
-Python:
+Rust SDK:
 ```
-pip install forge-sdk
-from forge_sdk import ForgeClient
-forge = ForgeClient()
-balance = forge.balance()
-result = forge.chat("your question")
+cargo add tirami-sdk
 ```
-
-MCP (Claude Code / Cursor):
-```
-pip install forge-mcp
-# Add to MCP settings, then use forge_balance, forge_inference tools
+```rust
+use tirami_sdk::TiramiClient;
+let client = TiramiClient::new("http://localhost:3000");
+let balance = client.balance().await?;
+let reply = client.chat("your question").await?;
 ```
 
-HTTP (any language):
+MCP (Claude Code / Cursor / ChatGPT):
 ```
-GET  http://localhost:3000/v1/forge/balance
-GET  http://localhost:3000/v1/forge/pricing
-POST http://localhost:3000/v1/chat/completions
+cargo install tirami-mcp
+# Add tirami-mcp to MCP settings — exposes 44 tools (tirami_balance, tirami_chat, ...)
+```
+
+HTTP (any language, OpenAI-compatible):
+```
+POST http://localhost:3000/v1/chat/completions   # run inference, returns x_tirami.trm_cost
+GET  http://localhost:3000/v1/tirami/balance
+GET  http://localhost:3000/v1/tirami/pricing
 ```
 
 ## API Reference
 
-- GET /v1/forge/balance — CU balance, reputation
-- GET /v1/forge/pricing — cost per token, deflation factor, purchasing power
-- GET /v1/forge/providers — compare providers by cost and reputation
-- GET /v1/forge/trades — trade history
-- GET /v1/forge/network — total CU flow + Merkle root
-- POST /v1/chat/completions — run inference (costs CU, OpenAI-compatible)
-- POST /v1/forge/invoice — convert CU to Bitcoin Lightning
-- GET /v1/forge/safety — kill switch, circuit breaker, budget status
-- POST /v1/forge/kill — emergency halt
-- POST /v1/forge/policy — set per-agent budget limits
+- POST /v1/chat/completions — run inference (costs TRM, OpenAI-compatible; response carries `x_tirami`)
+- GET  /v1/tirami/balance — TRM balance, reputation, contribution history
+- GET  /v1/tirami/pricing — market price (EMA), supply/demand, cost estimates
+- GET  /v1/tirami/providers — compare providers by reputation-adjusted cost
+- GET  /v1/tirami/trades — trade history (provider, consumer, TRM, tokens, flops)
+- GET  /v1/tirami/network — total TRM flow + Merkle root
+- GET  /v1/tirami/peers — PeerRegistry (price multiplier, available CU, audit tier)
+- GET  /v1/tirami/protocol — protocol version + feature flags
+- POST /v1/tirami/schedule — Ledger-as-Brain provider probe (read-only)
+- POST /v1/tirami/invoice — convert TRM to a Bitcoin Lightning invoice
+- GET  /v1/tirami/safety — kill switch, circuit breaker, budget status
+- POST /v1/tirami/kill — emergency halt (freeze all TRM transactions)
+- POST /v1/tirami/policy — set per-agent budget limits
+- GET  /metrics — Prometheus / OpenMetrics (tirami_* prefix)
 
 ## Source
 
-https://github.com/clearclown/forge
+https://github.com/clearclown/tirami


### PR DESCRIPTION
## Why

`README.md` was synced to Phase 25 in #159, but the three **agent-facing** docs lagged behind:

- `CLAUDE.md` was internally inconsistent — header said *1,192 tests / Phase 19* and listed a non-existent `tirami-attestation` crate, while the body still said *891 across 15 crates*, `forge node`, `forge-shard`, and a 1,869 ecosystem total.
- `AGENTS.md` and `llms.txt` still carried the **pre-rename "Forge" framing** (`# AGENTS.md — Forge`, `# Forge — Compute is Currency`, `forge-*` crate names, `/v1/forge/*` endpoints, `pip install forge-sdk`).

## Ground truth (verified on this branch)

| Fact | Value | Source |
|---|---|---|
| Tests | **1,574** | README badge (authoritative, #159) |
| Workspace crates | **16** | `Cargo.toml` `members` |
| MCP tools | **44** | `tirami-mcp` `assert_eq!(tools.len(), 44)` |
| `tirami-attestation` | **not a crate** | it's `tirami-core::attestation` module |
| Phase | **25** | README badge |

## Changes (3 files, docs only)

- **CLAUDE.md** — header → 1,574 / Phase 25; drop phantom `tirami-attestation` crate; refresh per-crate counts (ledger 642, node 373, mind 127, bank 85, agora 54); `forge node`→`tirami node`, `forge-shard`/`forge-verify`→`tirami-shard`/`tirami-anchor`; sdk 15→24, mcp 5→6 tests / 40→44 tools; add a **Phase 20-25** multi-host live-mesh hardening entry.
- **AGENTS.md** — full rewrite to the 16-crate Tirami reality.
- **llms.txt** — Forge/CU/Python → Tirami/TRM/Rust SDK + `/v1/tirami/*`.

`README.md` and `docs/translations/` are already correct on `main` and are intentionally **left untouched**. No code changes.